### PR TITLE
[WIP] buildkit integration

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -1,0 +1,25 @@
+name: Buildkit
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  buildkit-integration:
+    runs-on: ubuntu-18.04
+    name: BuildkitIntegration
+    env:
+      BUILDKIT_RESULT_DIR: ${{ github.workspace }}/buildkit/
+      BUILDKIT_RESULT_FILENAME: result.md
+    steps:
+    - uses: actions/checkout@v1
+    - name: Prepare output directory
+      run: mkdir "${BUILDKIT_RESULT_DIR}"
+    - name: Run buildkit
+      run: ./script/make.sh buildkit-integration
+    - name: Post the result as a comment
+      run: |
+        jq -n --arg result "$(cat ${BUILDKIT_RESULT_DIR}/${BUILDKIT_RESULT_FILENAME})" '{"body": $result}' | \
+        curl -X POST -d @- \
+             -H "Content-Type: application/json" \
+             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.comments_url }}

--- a/script/buildkit/Dockerfile
+++ b/script/buildkit/Dockerfile
@@ -1,0 +1,47 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM golang:1.14
+
+# basic packages
+RUN apt-get update -y && \
+    apt-get install -y libbtrfs-dev libseccomp-dev fuse iptables && \
+    update-alternatives --set iptables /usr/sbin/iptables-legacy
+
+# runtime dependencies
+RUN git clone https://github.com/opencontainers/runc \
+              $GOPATH/src/github.com/opencontainers/runc && \
+    cd $GOPATH/src/github.com/opencontainers/runc && \
+    git checkout d736ef14f0288d6993a1845745d6756cfc9ddd5a && \
+    GO111MODULE=off make BUILDTAGS='seccomp apparmor' && \
+    GO111MODULE=off make install && \
+    git clone https://github.com/containerd/containerd \
+              $GOPATH/src/github.com/containerd/containerd && \
+    cd $GOPATH/src/github.com/containerd/containerd && \
+    git checkout d5714702d1f78ad1149e78e204db0b53611ddb3c && \
+    GO111MODULE=off make && GO111MODULE=off make install && \
+    git clone https://github.com/ktock/buildkit \
+              $GOPATH/src/github.com/moby/buildkit && \
+    cd $GOPATH/src/github.com/moby/buildkit && \
+    git checkout f1ecc7824ebcd147a9bd9426d19999a7eb8e9bab && \
+    mkdir -p /etc/buildkit /opt/cni/bin && \
+    cp ./hack/fixtures/cni.json /etc/buildkit/cni.json && \
+    curl -Ls https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar xzv -C /opt/cni/bin && \
+    go build -o /opt/buildkit/master/bin/buildctl ./cmd/buildctl && \
+    go build -ldflags "-w -extldflags -static" -tags "osusergo netgo static_build seccomp" \
+             -o /opt/buildkit/master/bin/buildkitd ./cmd/buildkitd && \
+    git checkout 636d300fd3d07b1458fc93948caf637105620026 && \
+    go build -o /opt/buildkit/stargz/bin/buildctl ./cmd/buildctl && \
+    go build -ldflags "-w -extldflags -static" -tags "osusergo netgo static_build seccomp" \
+             -o /opt/buildkit/stargz/bin/buildkitd ./cmd/buildkitd

--- a/script/buildkit/config.containerd.toml
+++ b/script/buildkit/config.containerd.toml
@@ -1,0 +1,4 @@
+[proxy_plugins]
+  [proxy_plugins.stargz]
+    type = "snapshot"
+    address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"

--- a/script/buildkit/config.stargz.toml
+++ b/script/buildkit/config.stargz.toml
@@ -1,0 +1,1 @@
+insecure = ["127.0.0.1", "localhost"]

--- a/script/buildkit/docker-compose-buildkit.yml.sh
+++ b/script/buildkit/docker-compose-buildkit.yml.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+if [ "${1}" == "" ]; then
+    echo "Repository path must be provided."
+    exit 1
+fi
+
+if [ "${2}" == "" ]; then
+    echo "Container name must be provided."
+    exit 1
+fi
+
+REPO="${1}"
+CONTAINER_NAME="${2}"
+
+cat <<EOF
+version: "3"
+services:
+  buildkit_integration:
+    build:
+      context: "${REPO}/script/buildkit"
+      dockerfile: Dockerfile
+    container_name: ${CONTAINER_NAME}
+    privileged: true
+    stdin_open: true
+    working_dir: /go/src/github.com/ktock/stargz-snapshotter
+    command: tail -f /dev/null
+    environment:
+    - GO111MODULE=off
+    - NO_PROXY=127.0.0.1,localhost
+    - HTTP_PROXY=${HTTP_PROXY:-}
+    - HTTPS_PROXY=${HTTPS_PROXY:-}
+    - http_proxy=${http_proxy:-}
+    - https_proxy=${https_proxy:-}
+    - BUILDKIT_MASTER=/opt/buildkit/master/bin
+    - BUILDKIT_STARGZ=/opt/buildkit/stargz/bin
+    - GOPATH=/go
+    tmpfs:
+    - /var/lib/buildkit
+    - /var/lib/containerd
+    - /var/lib/containerd-stargz-grpc
+    - /run/containerd-stargz-grpc
+    - /tmp:exec,mode=777
+    volumes:
+    - "${REPO}:/go/src/github.com/ktock/stargz-snapshotter:ro"
+    - /dev/fuse:/dev/fuse
+EOF

--- a/script/buildkit/measure.sh
+++ b/script/buildkit/measure.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+RUN_SCRIPT=./script/buildkit/run.sh
+STARGZ_SNAPSHOTTER_ADDRESS=/run/containerd-stargz-grpc/containerd-stargz-grpc.sock
+BENCHMARK_LOG=/dev/null
+if [ "${WITH_LOGFILE:-}" == "true" ] ; then
+    BENCHMARK_LOG=$(mktemp)
+    echo "log file: ${BENCHMARK_LOG}"
+fi
+
+function build_with_original {
+    TARGET_CONTEXT="./script/buildkit/sample_org"
+    echo "Context for buildctl: ${TARGET_CONTEXT}"
+    time "${BUILDKIT_MASTER}/buildctl" build --progress=plain \
+         --frontend=dockerfile.v0 \
+         --local context="${TARGET_CONTEXT}" \
+         --local dockerfile="${TARGET_CONTEXT}" $@ >> "${BENCHMARK_LOG}" 2>&1
+}
+
+function build_with_stargz {
+    TARGET_CONTEXT="./script/buildkit/sample_sgz"
+    echo "Context for buildctl: ${TARGET_CONTEXT}"
+    time "${BUILDKIT_STARGZ}/buildctl" build --progress=plain \
+         --frontend=dockerfile.v0 \
+         --local context="${TARGET_CONTEXT}" \
+         --local dockerfile="${TARGET_CONTEXT}" $@ >> "${BENCHMARK_LOG}" 2>&1
+}
+
+function run_with_original {
+    echo "Arguments for buildkitd: $@"
+    BUILDKIT_BIN_PATH="${BUILDKIT_MASTER}" "${RUN_SCRIPT}" $@ \
+                     >> "${BENCHMARK_LOG}" 2>&1
+}
+
+function run_with_stargz {
+    echo "Arguments for buildkitd: $@"
+    BUILDKIT_BIN_PATH="${BUILDKIT_STARGZ}" "${RUN_SCRIPT}" $@ \
+                     >> "${BENCHMARK_LOG}" 2>&1
+}
+
+TMPOCI_ORG=$(mktemp)
+TMPOCI_SGZ=$(mktemp)
+TMPCTD_ORG=$(mktemp)
+TMPCTD_SGZ=$(mktemp)
+RMLIST=( "${TMPOCI_ORG}" "${TMPOCI_SGZ}" "${TMPCTD_ORG}" "${TMPCTD_SGZ}" )
+
+# measuring
+
+run_with_original --oci-worker-snapshotter=overlayfs > "${TMPOCI_ORG}" 2>&1
+build_with_original $@ >> "${TMPOCI_ORG}" 2>&1
+
+run_with_stargz --oci-worker-snapshotter=stargz \
+                --oci-worker-proxy-snapshotter-address="${STARGZ_SNAPSHOTTER_ADDRESS}" \
+                > "${TMPOCI_SGZ}" 2>&1
+build_with_stargz $@ >> "${TMPOCI_SGZ}" 2>&1
+
+run_with_original --oci-worker=false --containerd-worker=true > "${TMPCTD_ORG}" 2>&1
+build_with_original $@ >> "${TMPCTD_ORG}" 2>&1
+
+run_with_stargz --oci-worker=false --containerd-worker=true \
+                --containerd-worker-snapshotter=stargz \
+                > "${TMPCTD_SGZ}" 2>&1
+build_with_stargz $@ >> "${TMPCTD_SGZ}" 2>&1
+
+# output
+
+echo "## OCI Worker"
+
+echo "### With original baseimage" | tee -a "${BENCHMARK_LOG}"
+echo '```'
+cat "${TMPOCI_ORG}"
+echo '```'
+
+echo "### With stargz baseimage" | tee -a "${BENCHMARK_LOG}"
+echo '```'
+cat "${TMPOCI_SGZ}"
+echo '```'
+
+echo "## containerd Worker"
+
+echo "### With original baseimage" | tee -a "${BENCHMARK_LOG}"
+echo '```'
+cat "${TMPCTD_ORG}"
+echo '```'
+
+echo "### With stargz baseimage" | tee -a "${BENCHMARK_LOG}"
+echo '```'
+cat "${TMPCTD_SGZ}"
+echo '```'
+
+for RMFILE in "${RMLIST[@]}" ; do
+    rm ${RMFILE}
+done

--- a/script/buildkit/run.sh
+++ b/script/buildkit/run.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+REPO=$GOPATH/src/github.com/ktock/stargz-snapshotter
+CONTAINERD_CONFIG_DIR=/etc/containerd/
+CONTAINERD_ROOT=/var/lib/containerd/
+REMOTE_SNAPSHOTTER_CONFIG_DIR=/etc/containerd-stargz-grpc/
+REMOTE_SNAPSHOTTER_ROOT=/var/lib/containerd-stargz-grpc/
+REMOTE_SNAPSHOTTER_SOCKET=/run/containerd-stargz-grpc/containerd-stargz-grpc.sock
+BUILDKITD_ROOT=/var/lib/buildkit/
+BUILDKITD_SOCKET=/run/buildkit/buildkitd.sock
+BUILDKIT_PATH=${BUILDKIT_BIN_PATH:-}
+
+RETRYNUM=30
+RETRYINTERVAL=1
+TIMEOUTSEC=180
+function retry {
+    SUCCESS=false
+    for i in $(seq ${RETRYNUM}) ; do
+        if eval "timeout ${TIMEOUTSEC} ${@}" ; then
+            SUCCESS=true
+            break
+        fi
+        echo "Fail(${i}). Retrying..."
+        sleep ${RETRYINTERVAL}
+    done
+    if [ "${SUCCESS}" == "true" ] ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function kill_all {
+    if [ "${1}" != "" ] ; then
+        ps aux | grep "${1}" | grep -v grep | grep -v "${0}" | sed -E 's/ +/ /g' | cut -f 2 -d ' ' | xargs -I{} kill -9 {} || true
+    fi
+}
+
+function cleanup {
+    rm -rf "${CONTAINERD_ROOT}"*
+    if [ -f "${REMOTE_SNAPSHOTTER_SOCKET}" ] ; then
+        rm "${REMOTE_SNAPSHOTTER_SOCKET}"
+    fi
+    if [ -d "${REMOTE_SNAPSHOTTER_ROOT}snapshotter/snapshots/" ] ; then 
+        find "${REMOTE_SNAPSHOTTER_ROOT}snapshotter/snapshots/" \
+             -maxdepth 1 -mindepth 1 -type d -exec umount "{}/fs" \;
+    fi
+    rm -rf "${REMOTE_SNAPSHOTTER_ROOT}"*
+    rm -rf "${BUILDKITD_ROOT}"*
+    rm -rf "${BUILDKITD_SOCKET}"
+}
+
+if [ "${BUILDKIT_PATH}" == "" ] ; then
+    echo "specify BUILDKIT_PATH for path of buildkitd binary"
+    exit 1
+fi
+
+echo "copying config from repo..."
+mkdir -p /etc/containerd /etc/containerd-stargz-grpc && \
+    cp "${REPO}/script/demo/config.containerd.toml" "${CONTAINERD_CONFIG_DIR}" && \
+    cp "${REPO}/script/demo/config.stargz.toml" "${REMOTE_SNAPSHOTTER_CONFIG_DIR}"
+
+echo "cleaning up the environment..."
+kill_all "containerd"
+kill_all "containerd-stargz-grpc"
+kill_all "buildkitd"
+cleanup
+
+echo "preparing commands..."
+( cd "${REPO}" && PREFIX=/tmp/out/ make clean && \
+      PREFIX=/tmp/out/ make -j2 && \
+      PREFIX=/tmp/out/ make install )
+
+echo "running remote snaphsotter..."
+containerd-stargz-grpc --log-level=debug \
+                       --address="${REMOTE_SNAPSHOTTER_SOCKET}" \
+                       --config="${REMOTE_SNAPSHOTTER_CONFIG_DIR}config.stargz.toml" &
+retry ls "${REMOTE_SNAPSHOTTER_SOCKET}"
+
+echo "running containerd..."
+containerd --config="${CONTAINERD_CONFIG_DIR}config.containerd.toml" &
+retry ctr version
+
+echo "running buildkitd..."
+"${BUILDKIT_PATH}/buildkitd" $@ &
+retry ls "${BUILDKITD_SOCKET}"

--- a/script/buildkit/sample_org/Dockerfile
+++ b/script/buildkit/sample_org/Dockerfile
@@ -1,0 +1,16 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM ktokunaga/python:3.7-org
+RUN python -c 'print("hello")' | tee /hello.txt

--- a/script/buildkit/sample_sgz/Dockerfile
+++ b/script/buildkit/sample_sgz/Dockerfile
@@ -1,0 +1,16 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM ktokunaga/python:3.7-esgz
+RUN python -c 'print("hello")' | tee /hello.txt

--- a/script/buildkit/testing.md
+++ b/script/buildkit/testing.md
@@ -1,0 +1,73 @@
+# Testing the integration with buildkit(WIP)
+
+Stargz snapshotter's integration with buildkit is WIP but we can test the limited functionalities with our patched version of buildkit.
+
+## Preparing the testing environment
+
+```bash
+$ cd ./script/buildkit
+$ DOCKER_COMPOSE_TMP=$(mktemp)
+$ ./docker-compose-buildkit.yml.sh "$(realpath ../../)" "buildkit-integration" > "${DOCKER_COMPOSE_TMP}"
+$ docker-compose -f "${DOCKER_COMPOSE_TMP}" build \
+                 --build-arg HTTP_PROXY=$HTTP_PROXY \
+                 --build-arg HTTPS_PROXY=$HTTP_PROXY \
+                 --build-arg http_proxy=$HTTP_PROXY \
+                 --build-arg https_proxy=$HTTP_PROXY \
+                 buildkit_integration
+$ docker-compose -f "${DOCKER_COMPOSE_TMP}" up -d
+$ docker exec -it buildkit-integration /bin/bash
+```
+
+## Running buildkitd(inside the testing container)
+
+### With OCI worker
+
+```bash
+# BUILDKIT_BIN_PATH="${BUILDKIT_STARGZ}" ./script/buildkit/run.sh \
+      --oci-worker-snapshotter=stargz \
+      --oci-worker-proxy-snapshotter-address=/run/containerd-stargz-grpc/containerd-stargz-grpc.sock
+```
+
+### With containerd worker
+
+```bash
+# BUILDKIT_BIN_PATH="${BUILDKIT_STARGZ}" ./script/buildkit/run.sh \
+       --oci-worker=false --containerd-worker=true \
+       --containerd-worker-snapshotter=stargz
+```
+
+## Building a sample image
+
+### Without exporting
+```bash
+# "${BUILDKIT_STARGZ}/buildctl" build --progress=plain \
+       --frontend=dockerfile.v0 \
+       --local context=./script/buildkit/sample_sgz \
+       --local dockerfile=./script/buildkit/sample_sgz
+```
+
+### With exporting
+
+Currently, we have two problems for exporting.
+
+1. Archiving layers takes a long time. It is because of the low READ performance including fetching contents from the registry.
+2. We only support exporting type `tar`. It is because when we use remote snapshotters, containerd doesn't store the image contents in the content store but buildkit needs to use these contents for exporting images.
+
+We can export `tar` with the following command.
+
+```bash
+# "${BUILDKIT_STARGZ}/buildctl" build --progress=plain \
+       --frontend=dockerfile.v0 \
+       --local context=./script/buildkit/sample_sgz \
+       --local dockerfile=./script/buildkit/sample_sgz \
+       --output type=tar,dest=/tmp/buildkit-sample.tar
+# cat /tmp/buildkit-sample.tar | tar -xf - 'hello.txt' -O
+hello
+```
+
+## Cleaning up(on the host)
+
+```
+$ docker-compose -f "${DOCKER_COMPOSE_TMP}" down -v
+$ rm "${DOCKER_COMPOSE_TMP}"
+```


### PR DESCRIPTION
This is an experimental integration with buildkit for speeding up fetching base image.

Our patched version of buildkit is [here](https://github.com/ktock/buildkit/tree/remote-snapshotter).

This commit includes benchmark scripts to measure the time for buliding sample images.
See [this doc](https://github.com/ktock/stargz-snapshotter/blob/21a8e3c832e86b9ba137e6aa9ef7a6d02aef1eef/script/buildkit/testing.md) for manual testing.

Though it seems good for the lazy distribution of the base images, we currently have two problems for exporting output image.

1. Archiving layers takes a long time. It is because of the low READ performance including fetching contents from the registry.
2. We only support exporting type `tar`. It is because when we use remote snapshotters, containerd doesn't store the image contents in the content store but buildkit needs to use these contents for exporting images.