### PR TITLE
[WIP] Buildkit integration

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -1,0 +1,23 @@
+name: Buildkit
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  buildkit-integration:
+    runs-on: ubuntu-18.04
+    name: BuildkitIntegration
+    env:
+      BUILDKIT_RESULT_DIR: ${{ github.workspace }}/buildkit/
+    steps:
+    - name: Install gnuplot
+      run: sudo apt-get --no-install-recommends install -y gnuplot
+    - uses: actions/checkout@v1
+    - name: Prepare output directory
+      run: mkdir "${BUILDKIT_RESULT_DIR}"
+    - name: Run buildkit
+      run: ./script/make.sh buildkit-integration
+    - uses: actions/upload-artifact@v1
+      with:
+        name: buildkit-integration-result
+        path: ${{ env.BUILDKIT_RESULT_DIR }}

--- a/docs/pre-converted-images.md
+++ b/docs/pre-converted-images.md
@@ -30,6 +30,7 @@ In the following table, `Image Name` column contains placeholders `{{ suffix }}`
 |`docker.io/ktokunaga/php:7.3.8-{{ suffix }}`|Printing `hello`|
 |`docker.io/ktokunaga/pypy:3.5-{{ suffix }}`|Printing `hello`|
 |`docker.io/ktokunaga/python:3.7-{{ suffix }}`|Printing `hello`|
+|`docker.io/ktokunaga/python:3.7-slim-{{ suffix }}`|Executing `pip --version`|
 |`docker.io/ktokunaga/r-base:3.6.1-{{ suffix }}`|Printing `hello`|
 |`docker.io/ktokunaga/redis:5.0.5-{{ suffix }}`|Code execution until up and ready message (`Ready to accept connections`) is printed|
 |`docker.io/ktokunaga/rethinkdb:2.3.6-{{ suffix }}`|Code execution until up and ready message (`Server ready`) is printed|

--- a/script/benchmark/hello-bench/src/hello.py
+++ b/script/benchmark/hello-bench/src/hello.py
@@ -107,6 +107,7 @@ class BenchRunner:
     CMD_ARG = {'perl:5.30': RunArgs(arg='perl -e \'print("hello\\n")\''),
                'python:3.7': RunArgs(arg='python -c \'print("hello")\''),
                'pypy:3.5': RunArgs(arg='pypy3 -c \'print("hello")\''),
+               'python:3.7-slim': RunArgs(arg='pip --version'),
     }
 
     # complete listing
@@ -116,6 +117,7 @@ class BenchRunner:
                  Bench('rethinkdb:2.3.6', 'database'),
                  Bench('redis:5.0.5', 'database'),
                  Bench('python:3.7', 'language'),
+                 Bench('python:3.7-slim', 'language'),
                  Bench('golang:1.12.9', 'language'),
                  Bench('gcc:9.2.0', 'language'),
                  Bench('jruby:9.2.8.0', 'language'),

--- a/script/buildkit/Dockerfile
+++ b/script/buildkit/Dockerfile
@@ -1,0 +1,47 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM golang:1.14
+
+# basic packages
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y libbtrfs-dev libseccomp-dev fuse iptables time jq && \
+    update-alternatives --set iptables /usr/sbin/iptables-legacy
+
+# runtime dependencies
+RUN git clone https://github.com/opencontainers/runc \
+              $GOPATH/src/github.com/opencontainers/runc && \
+    cd $GOPATH/src/github.com/opencontainers/runc && \
+    git checkout d736ef14f0288d6993a1845745d6756cfc9ddd5a && \
+    GO111MODULE=off make BUILDTAGS='seccomp apparmor' && \
+    GO111MODULE=off make install && \
+    git clone https://github.com/containerd/containerd \
+              $GOPATH/src/github.com/containerd/containerd && \
+    cd $GOPATH/src/github.com/containerd/containerd && \
+    git checkout d5714702d1f78ad1149e78e204db0b53611ddb3c && \
+    GO111MODULE=off make && GO111MODULE=off make install && \
+    git clone https://github.com/ktock/buildkit \
+              $GOPATH/src/github.com/moby/buildkit && \
+    cd $GOPATH/src/github.com/moby/buildkit && \
+    git checkout f1ecc7824ebcd147a9bd9426d19999a7eb8e9bab && \
+    mkdir -p /etc/buildkit /opt/cni/bin && \
+    cp ./hack/fixtures/cni.json /etc/buildkit/cni.json && \
+    curl -Ls https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar xzv -C /opt/cni/bin && \
+    go build -o /opt/buildkit/master/bin/buildctl ./cmd/buildctl && \
+    go build -ldflags "-w -extldflags -static" -tags "osusergo netgo static_build seccomp" \
+             -o /opt/buildkit/master/bin/buildkitd ./cmd/buildkitd && \
+    git checkout 425c1c76bdbfc003542c21aa4b7f081cc2546696 && \
+    go build -o /opt/buildkit/stargz/bin/buildctl ./cmd/buildctl && \
+    go build -ldflags "-w -extldflags -static" -tags "osusergo netgo static_build seccomp" \
+             -o /opt/buildkit/stargz/bin/buildkitd ./cmd/buildkitd

--- a/script/buildkit/config.containerd.toml
+++ b/script/buildkit/config.containerd.toml
@@ -1,0 +1,4 @@
+[proxy_plugins]
+  [proxy_plugins.stargz]
+    type = "snapshot"
+    address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"

--- a/script/buildkit/config.stargz.toml
+++ b/script/buildkit/config.stargz.toml
@@ -1,0 +1,1 @@
+insecure = ["127.0.0.1", "localhost"]

--- a/script/buildkit/docker-compose-buildkit.yml.sh
+++ b/script/buildkit/docker-compose-buildkit.yml.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+if [ "${1}" == "" ]; then
+    echo "Repository path must be provided."
+    exit 1
+fi
+
+if [ "${2}" == "" ]; then
+    echo "Container name must be provided."
+    exit 1
+fi
+
+REPO="${1}"
+CONTAINER_NAME="${2}"
+
+cat <<EOF
+version: "3"
+services:
+  buildkit_integration:
+    build:
+      context: "${REPO}/script/buildkit"
+      dockerfile: Dockerfile
+    container_name: ${CONTAINER_NAME}
+    privileged: true
+    stdin_open: true
+    working_dir: /go/src/github.com/containerd/stargz-snapshotter
+    command: tail -f /dev/null
+    environment:
+    - GO111MODULE=off
+    - NO_PROXY=127.0.0.1,localhost
+    - HTTP_PROXY=${HTTP_PROXY:-}
+    - HTTPS_PROXY=${HTTPS_PROXY:-}
+    - http_proxy=${http_proxy:-}
+    - https_proxy=${https_proxy:-}
+    - BUILDKIT_MASTER=/opt/buildkit/master/bin
+    - BUILDKIT_STARGZ=/opt/buildkit/stargz/bin
+    - GOPATH=/go
+    tmpfs:
+    - /var/lib/buildkit
+    - /var/lib/containerd
+    - /var/lib/containerd-stargz-grpc
+    - /run/containerd-stargz-grpc
+    - /tmp:exec,mode=777
+    volumes:
+    - "${REPO}:/go/src/github.com/containerd/stargz-snapshotter:ro"
+    - /dev/fuse:/dev/fuse
+EOF

--- a/script/buildkit/measure.sh
+++ b/script/buildkit/measure.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+RUN_SCRIPT="./script/buildkit/run.sh"
+SAMPLE_DIR="./script/buildkit/sample/"
+
+STARGZ_SNAPSHOTTER_ADDRESS=/run/containerd-stargz-grpc/containerd-stargz-grpc.sock
+DOCKERFILE_SUFFIX_PH='{{ IMAGE_MODE_SUFFIX }}'
+IMAGE_DEST_DIR=/benchmark/image/
+ORG_DEST_FILE="${IMAGE_DEST_DIR}/org.tar"
+SGZ_DEST_FILE="${IMAGE_DEST_DIR}/sgz.tar"
+ESGZ_DEST_FILE="${IMAGE_DEST_DIR}/esgz.tar"
+
+TEST_ENABLE=true
+if [ "${WITHOUT_TEST:-}" == "true" ] ; then
+    TEST_ENABLE=false
+fi
+
+BENCHMARK_LOG="${WITH_LOGFILE:-}"
+if [ "${BENCHMARK_LOG}" == "" ] ; then
+    BENCHMARK_LOG=/dev/null
+fi
+
+BUILDKIT_WORKER="${WITH_WORKER:-}"
+if [ "${BUILDKIT_WORKER}" == "" ] ; then
+    BUILDKIT_WORKER="oci"
+fi
+
+MODES=( ${TARGET_MODES:-} )
+if [ ${#MODES[@]} -eq 0 ] || [ "${TEST_ENABLE}" == "true"] ; then
+    MODES=("legacy" "stargz" "estargz")
+fi
+
+IMAGES=( ${TARGET_IMAGES:-} )
+if [ ${#IMAGES[@]} -eq 0 ] ; then
+    IMAGES=( $(ls -1 "${SAMPLE_DIR}" | xargs echo) )
+fi
+
+function build {
+    local BUILDCTL_BIN="${1}"
+    local TARGET_CONTEXT="${2}"
+    local TARGET_DOCKERFILE="${3}"
+    local DEST_FILE="${4}"
+    local RESULT=$(mktemp)
+    /usr/bin/time --output="${RESULT}" -f '%e' "${BUILDCTL_BIN}/buildctl" build --progress=plain \
+         --frontend=dockerfile.v0 \
+         --local context="${TARGET_CONTEXT}" \
+         --local dockerfile="${TARGET_DOCKERFILE}" \
+         --output type=docker,name=sample,dest="${DEST_FILE}" \
+         >> "${BENCHMARK_LOG}" 2>&1
+    local ELAPSED=$(cat "${RESULT}")
+    rm "${RESULT}"
+    echo -n "${ELAPSED}"
+}
+
+function run {
+    local BUILDKITD_BIN="${1}"
+    BUILDKIT_BIN_PATH="${BUILDKITD_BIN}" "${RUN_SCRIPT}" ${@:2} \
+                     >> "${BENCHMARK_LOG}" 2>&1
+}
+
+# is_same_image checks the contents of two images are the same
+#
+# It compares the following contents of each image are the same:
+# - Config file
+# - Layer blobs
+#   - but the timestamp differences are ignored
+#   - FIXME: Also compare the timestamp differences.
+#            But in some cases, images created in the different timings
+#            possibly contains files which have same paths but have
+#            different time stamps
+function is_same_image {
+    local IMG1="${1}"
+    local IMG2="${2}"
+    echo "Comparing image ${IMG1} and ${IMG2}" >> "${BENCHMARK_LOG}"
+    
+    # compares config files
+    local IMG1_CONFIG=$(tar xf "${IMG1}" manifest.json -O | jq -r '.[0].Config')
+    local IMG2_CONFIG=$(tar xf "${IMG2}" manifest.json -O | jq -r '.[0].Config')
+    local SUM_CFG1=$(tar xf "${IMG1}" "${IMG1_CONFIG}" -O \
+          | jq '.rootfs = {} | .created = "" | .history = []' \
+          | sha256sum | cut -d ' ' -f 1)
+    local SUM_CFG2=$(tar xf "${IMG2}" "${IMG2_CONFIG}" -O \
+          | jq '.rootfs = {} | .created = "" | .history = []' \
+          | sha256sum | cut -d ' ' -f 1)
+    echo "Sums of configs are ${SUM_CFG1} and ${SUM_CFG2}" >> "${BENCHMARK_LOG}"
+    if ! [ "${SUM_CFG1}" == "${SUM_CFG2}" ] ; then
+        return 1
+    fi
+
+    # compares layer blobs
+    local IMG1_LAYERS=( $(tar xf "${IMG1}" manifest.json -O | jq -r '.[0].Layers[]') )
+    local IMG2_LAYERS=( $(tar xf "${IMG2}" manifest.json -O | jq -r '.[0].Layers[]') )
+    if ! [ ${#IMG1_LAYERS[@]} -eq ${#IMG2_LAYERS[@]} ] ; then
+        return 1
+    fi
+    local I=
+    for I in "${!IMG1_LAYERS[@]}" ; do
+        echo "Diffing ${IMG1_LAYERS[$I]} and ${IMG2_LAYERS[$I]}" >> "${BENCHMARK_LOG}"
+        local TARGET1=$(mktemp -d)
+        local TARGET2=$(mktemp -d)
+        tar xf "${IMG1}" "${IMG1_LAYERS[$I]}" -O | tar zx -C "${TARGET1}"
+        tar xf "${IMG2}" "${IMG2_LAYERS[$I]}" -O | tar zx -C "${TARGET2}"
+        echo "Snapshot of 1st image(${TARGET1}): " >> "${BENCHMARK_LOG}"
+        ls -al "${TARGET1}" >> "${BENCHMARK_LOG}" 2>&1
+        echo "Snapshot of 2nd image(${TARGET2}): " >> "${BENCHMARK_LOG}"
+        ls -al "${TARGET2}" >> "${BENCHMARK_LOG}" 2>&1
+
+        # compares two snapshots without comparing timestamps
+        local SUM1=$(tar -C "${TARGET1}" --mtime='1970-01-01' -c . -O | sha256sum | cut -d ' ' -f 1)
+        local SUM2=$(tar -C "${TARGET2}" --mtime='1970-01-01' -c . -O | sha256sum | cut -d ' ' -f 1)
+        rm -rf "${TARGET1}" "${TARGET2}"
+        echo "Sums are ${SUM1} and ${SUM2}" >> "${BENCHMARK_LOG}"
+        if ! [ "${SUM1}" == "${SUM2}" ] ; then
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+if ! [ -d "${IMAGE_DEST_DIR}" ] ; then
+    mkdir -p "${IMAGE_DEST_DIR}"
+fi
+
+echo '[{'
+for I in "${!IMAGES[@]}" ; do
+    IMAGE="${IMAGES[$I]}"
+    CONTEXT="${SAMPLE_DIR}/${IMAGE}/"
+    rm -f "${ORG_DEST_FILE}" "${SGZ_DEST_FILE}" "${ESGZ_DEST_FILE}" >/dev/null 2>&1
+    echo '"'"${IMAGE}"'": ['
+    for J in "${!MODES[@]}"; do
+        MODE="${MODES[$J]}"
+
+        # configures some parameters according to the mode
+        IMAGE_SUFFIX=
+        DEST_FILE=
+        BUILDKIT_PATH=
+        BUILDKITD_OPTS=
+        if [ "${MODE}" == "legacy" ] ; then
+            BUILDKIT_PATH="${BUILDKIT_MASTER}"
+            if [ "${BUILDKIT_WORKER}" == "oci" ] ; then
+                # uses oci worker
+                BUILDKITD_OPTS="--oci-worker-snapshotter=overlayfs"
+            else
+                # uses containerd worker
+                BUILDKITD_OPTS="--oci-worker=false --containerd-worker=true"
+            fi
+            IMAGE_SUFFIX="org"
+            DEST_FILE="${ORG_DEST_FILE}"
+        else
+            BUILDKIT_PATH="${BUILDKIT_STARGZ}"
+            if [ "${BUILDKIT_WORKER}" == "oci" ] ; then
+                # uses oci worker
+                BUILDKITD_OPTS="--oci-worker-snapshotter=stargz --oci-worker-proxy-snapshotter-address=${STARGZ_SNAPSHOTTER_ADDRESS}"
+            else
+                # uses containerd worker
+                BUILDKITD_OPTS="--oci-worker=false --containerd-worker=true --containerd-worker-snapshotter=stargz"
+            fi
+            if [ "${MODE}" == "stargz" ] ; then
+                IMAGE_SUFFIX="sgz"
+                DEST_FILE="${SGZ_DEST_FILE}"
+            else
+                IMAGE_SUFFIX="esgz"
+                DEST_FILE="${ESGZ_DEST_FILE}"
+            fi
+        fi
+        echo "suffix: ${IMAGE_SUFFIX}, destination: ${DEST_FILE}, buildkit path: ${BUILDKIT_PATH}, options for buildkitd: ${BUILDKITD_OPTS}" >> "${BENCHMARK_LOG}"
+        if [ "${IMAGE_SUFFIX}" == "" ] \
+               || [ "${DEST_FILE}" == "" ] \
+               || [ "${BUILDKIT_PATH}" == "" ] \
+               || [ "${BUILDKITD_OPTS}" == "" ]; then
+            echo "fatal(internal): ${IMAGE}: ${MODE}: necessary information doesn't exist for image mode" | tee -a "${BENCHMARK_LOG}"
+            exit 1
+        fi
+
+        # builds specified image and measure the time to take for building
+        DOCKERFILE_DIR=$(mktemp -d)
+        cat "${CONTEXT}Dockerfile" \
+            | sed 's/'"${DOCKERFILE_SUFFIX_PH}"'/'"${IMAGE_SUFFIX}"'/g' > "${DOCKERFILE_DIR}/Dockerfile"
+        run "${BUILDKIT_PATH}" ${BUILDKITD_OPTS}
+        ELAPSED=$(build "${BUILDKIT_PATH}" "${CONTEXT}" "${DOCKERFILE_DIR}" "${DEST_FILE}")
+
+        echo -n '{ "mode" : "'"${MODE}"'", "elapsed": '"${ELAPSED}"' }'
+        if ! [ ${J} -eq $(expr ${#MODES[@]} - 1) ] ; then
+            echo ","
+        else
+            echo ""
+        fi
+
+        if [ "${TEST_ENABLE}" == "true" ] ; then
+            # checks the image contents are the same as the original image
+            if ! is_same_image "${DEST_FILE}" "${ORG_DEST_FILE}" ; then
+                echo "error: ${IMAGE}: ${MODE}: ${DEST_FILE} and ${ORG_DEST_FILE} are different" \
+                    | tee -a "${BENCHMARK_LOG}"
+                exit 1
+            fi
+        fi
+    done
+    if [ ${I} -eq $(expr ${#IMAGES[@]} - 1) ] ; then
+        echo "]"
+    else
+        echo "],"
+    fi
+done
+echo '}]'

--- a/script/buildkit/run.sh
+++ b/script/buildkit/run.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+REPO=$GOPATH/src/github.com/containerd/stargz-snapshotter
+CONTAINERD_CONFIG_DIR=/etc/containerd/
+CONTAINERD_ROOT=/var/lib/containerd/
+REMOTE_SNAPSHOTTER_CONFIG_DIR=/etc/containerd-stargz-grpc/
+REMOTE_SNAPSHOTTER_ROOT=/var/lib/containerd-stargz-grpc/
+REMOTE_SNAPSHOTTER_SOCKET=/run/containerd-stargz-grpc/containerd-stargz-grpc.sock
+BUILDKITD_ROOT=/var/lib/buildkit/
+BUILDKITD_SOCKET=/run/buildkit/buildkitd.sock
+BUILDKIT_PATH=${BUILDKIT_BIN_PATH:-}
+
+RETRYNUM=30
+RETRYINTERVAL=1
+TIMEOUTSEC=180
+function retry {
+    SUCCESS=false
+    for i in $(seq ${RETRYNUM}) ; do
+        if eval "timeout ${TIMEOUTSEC} ${@}" ; then
+            SUCCESS=true
+            break
+        fi
+        echo "Fail(${i}). Retrying..."
+        sleep ${RETRYINTERVAL}
+    done
+    if [ "${SUCCESS}" == "true" ] ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function kill_all {
+    if [ "${1}" != "" ] ; then
+        ps aux | grep "${1}" | grep -v grep | grep -v "${0}" | sed -E 's/ +/ /g' | cut -f 2 -d ' ' | xargs -I{} kill -9 {} || true
+    fi
+}
+
+function cleanup {
+    rm -rf "${CONTAINERD_ROOT}"*
+    if [ -f "${REMOTE_SNAPSHOTTER_SOCKET}" ] ; then
+        rm "${REMOTE_SNAPSHOTTER_SOCKET}"
+    fi
+    if [ -d "${REMOTE_SNAPSHOTTER_ROOT}snapshotter/snapshots/" ] ; then 
+        find "${REMOTE_SNAPSHOTTER_ROOT}snapshotter/snapshots/" \
+             -maxdepth 1 -mindepth 1 -type d -exec umount "{}/fs" \;
+    fi
+    rm -rf "${REMOTE_SNAPSHOTTER_ROOT}"*
+    rm -rf "${BUILDKITD_ROOT}"*
+    rm -rf "${BUILDKITD_SOCKET}"
+}
+
+if [ "${BUILDKIT_PATH}" == "" ] ; then
+    echo "specify BUILDKIT_PATH for path of buildkitd binary"
+    exit 1
+fi
+
+echo "copying config from repo..."
+mkdir -p /etc/containerd /etc/containerd-stargz-grpc && \
+    cp "${REPO}/script/demo/config.containerd.toml" "${CONTAINERD_CONFIG_DIR}" && \
+    cp "${REPO}/script/demo/config.stargz.toml" "${REMOTE_SNAPSHOTTER_CONFIG_DIR}"
+
+echo "cleaning up the environment..."
+kill_all "containerd"
+kill_all "containerd-stargz-grpc"
+kill_all "buildkitd"
+cleanup
+
+echo "preparing commands..."
+( cd "${REPO}" && PREFIX=/tmp/out/ make clean && \
+      PREFIX=/tmp/out/ make -j2 && \
+      PREFIX=/tmp/out/ make install )
+
+echo "running remote snaphsotter..."
+containerd-stargz-grpc --log-level=debug \
+                       --address="${REMOTE_SNAPSHOTTER_SOCKET}" \
+                       --config="${REMOTE_SNAPSHOTTER_CONFIG_DIR}config.stargz.toml" &
+retry ls "${REMOTE_SNAPSHOTTER_SOCKET}"
+
+echo "running containerd..."
+containerd --config="${CONTAINERD_CONFIG_DIR}config.containerd.toml" &
+retry ctr version
+
+echo "running buildkitd..."
+"${BUILDKIT_PATH}/buildkitd" $@ &
+retry ls "${BUILDKITD_SOCKET}"

--- a/script/buildkit/sample/gcc-9.2.0/Dockerfile
+++ b/script/buildkit/sample/gcc-9.2.0/Dockerfile
@@ -1,0 +1,21 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM ktokunaga/gcc:9.2.0-{{ IMAGE_MODE_SUFFIX }} AS dev
+COPY ./main.c /root/
+RUN cd /root && gcc -o hello ./main.c
+
+FROM alpine:3.10.2
+COPY --from=dev /root/hello /hello
+ENTRYPOINT [ "/hello" ]

--- a/script/buildkit/sample/gcc-9.2.0/main.c
+++ b/script/buildkit/sample/gcc-9.2.0/main.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+  printf("hello\n");
+}

--- a/script/buildkit/sample/golang-1.12.9/Dockerfile
+++ b/script/buildkit/sample/golang-1.12.9/Dockerfile
@@ -1,0 +1,21 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM ktokunaga/golang:1.12.9-{{ IMAGE_MODE_SUFFIX }} AS dev
+COPY ./main.go /go/src/
+RUN cd /go/src && go build -o hello ./main.go
+
+FROM alpine:3.10.2
+COPY --from=dev /go/src/hello /hello
+ENTRYPOINT [ "/hello" ]

--- a/script/buildkit/sample/golang-1.12.9/main.go
+++ b/script/buildkit/sample/golang-1.12.9/main.go
@@ -1,0 +1,23 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}

--- a/script/buildkit/sample/python-3.7-slim/Dockerfile
+++ b/script/buildkit/sample/python-3.7-slim/Dockerfile
@@ -1,0 +1,23 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM ktokunaga/python:3.7-slim-{{ IMAGE_MODE_SUFFIX }} AS dev
+COPY ./app /app
+RUN cd /app && pip install --user --install-option="--no-compile" .
+
+FROM ktokunaga/python:3.7-slim-org
+COPY --from=dev /root/.local /root/.local
+
+ENTRYPOINT [ "python" ]
+CMD [ "/root/.local/bin/hello.py" ]

--- a/script/buildkit/sample/python-3.7-slim/app/hello/hello.py
+++ b/script/buildkit/sample/python-3.7-slim/app/hello/hello.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+print('hello')

--- a/script/buildkit/sample/python-3.7-slim/app/setup.py
+++ b/script/buildkit/sample/python-3.7-slim/app/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    name="hello",
+    scripts=['hello/hello.py'],
+)

--- a/script/buildkit/testing.md
+++ b/script/buildkit/testing.md
@@ -1,0 +1,64 @@
+# Testing the integration with buildkit(WIP)
+
+Stargz snapshotter's integration with buildkit is WIP but we can test the limited functionalities with our patched version of buildkit.
+
+## Preparing the testing environment
+
+```bash
+$ cd ./script/buildkit
+$ DOCKER_COMPOSE_TMP=$(mktemp)
+$ ./docker-compose-buildkit.yml.sh "$(realpath ../../)" "buildkit-integration" > "${DOCKER_COMPOSE_TMP}"
+$ docker-compose -f "${DOCKER_COMPOSE_TMP}" build \
+                 --build-arg HTTP_PROXY=$HTTP_PROXY \
+                 --build-arg HTTPS_PROXY=$HTTP_PROXY \
+                 --build-arg http_proxy=$HTTP_PROXY \
+                 --build-arg https_proxy=$HTTP_PROXY \
+                 buildkit_integration
+$ docker-compose -f "${DOCKER_COMPOSE_TMP}" up -d
+$ docker exec -it buildkit-integration /bin/bash
+```
+
+## Running buildkitd(inside the testing container)
+
+### With OCI worker
+
+```bash
+# BUILDKIT_BIN_PATH="${BUILDKIT_STARGZ}" ./script/buildkit/run.sh \
+      --oci-worker-snapshotter=stargz \
+      --oci-worker-proxy-snapshotter-address=/run/containerd-stargz-grpc/containerd-stargz-grpc.sock
+```
+
+### With containerd worker
+
+```bash
+# BUILDKIT_BIN_PATH="${BUILDKIT_STARGZ}" ./script/buildkit/run.sh \
+       --oci-worker=false --containerd-worker=true \
+       --containerd-worker-snapshotter=stargz
+```
+
+## Building a sample image
+
+```bash
+# "${BUILDKIT_STARGZ}/buildctl" build --progress=plain \
+       --frontend=dockerfile.v0 \
+       --local context=./script/buildkit/sample_sgz \
+       --local dockerfile=./script/buildkit/sample_sgz \
+       --output type=docker,name=sample,dest=/buildkit-sample.tar
+```
+
+You can check the contents from outside the testing container.
+
+```
+$ docker cp buildkit-integration:/buildkit-sample.tar /tmp/
+$ BLOBPATH=$(cat /tmp/buildkit-sample.tar | tar -xf - 'manifest.json' -O | jq -r '.[0].Layers[1]')
+$ cat /tmp/buildkit-sample.tar | tar -xf - "${BLOBPATH}" -O | tar -zxf - 'hello.txt' -O
+hello
+$ rm /tmp/buildkit-sample.tar
+```
+
+## Cleaning up(on the host)
+
+```
+$ docker-compose -f "${DOCKER_COMPOSE_TMP}" down -v
+$ rm "${DOCKER_COMPOSE_TMP}"
+```

--- a/script/buildkit/tools/plot.sh
+++ b/script/buildkit/tools/plot.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+JSON="$(mktemp)"
+cat > "${JSON}"
+
+if [ "${1}" == "" ] ; then
+    echo "Specify directory for output"
+    exit 1
+fi
+
+if [ "${2}" == "" ] ; then
+    echo "Specify worker"
+    exit 1
+fi
+
+DATADIR="${1}/"
+echo "output into: ${DATADIR}"
+BUILDKIT_WORKER="${2}"
+
+MODES=( ${TARGET_MODES:-} )
+if [ ${#MODES[@]} -eq 0 ] ; then
+    MODES=("legacy" "stargz" "estargz")
+fi
+
+IMAGES=( ${TARGET_IMAGES:-} )
+if [ ${#IMAGES[@]} -eq 0 ] ; then
+    IMAGES=( $(cat "${JSON}" | jq -r '.[0] | keys[]') )
+fi
+
+PLTFILE_ALL="${DATADIR}result_${BUILDKIT_WORKER}.plt"
+GRAPHFILE_ALL="${DATADIR}result_${BUILDKIT_WORKER}.png"
+
+cat <<EOF > "${PLTFILE_ALL}"
+set output '${GRAPHFILE_ALL}'
+set title "Time to take for building containers with ${BUILDKIT_WORKER}"
+set terminal png size 1000, 750
+set style data histogram
+set style histogram rowstack gap 1
+set style fill solid 1.0 border -1
+set key autotitle columnheader
+set xtics rotate by -45
+set ylabel 'time[sec]'
+set lmargin 10
+set rmargin 5
+set tmargin 5
+set bmargin 5
+plot \\
+EOF
+
+NOTITLE=
+INDEX=1
+for IMGNAME in "${IMAGES[@]}" ; do
+    echo "[${INDEX}]Processing: ${IMGNAME}"
+    IMAGE=$(echo "${IMGNAME}" | sed 's|[/:]|-|g')
+    DATAFILE="${DATADIR}${IMAGE}.dat"
+    SUFFIX=', \'
+    if [ ${INDEX} -eq ${#IMAGES[@]} ] ; then
+        SUFFIX=''
+    fi
+    
+    echo "mode build" > "${DATAFILE}"
+    for MODE in "${MODES[@]}"; do
+        BUILDTIME=$(cat "${JSON}" | jq -r '.[0]."'"${IMGNAME}"'"[] | select(.mode=="'"${MODE}"'").elapsed')
+        echo "${MODE} ${BUILDTIME}" >> "${DATAFILE}"
+    done
+
+    echo 'newhistogram "'"${IMAGE}"'", "'"${DATAFILE}"'" u 2:xtic(1) fs pattern 1 lt -1 '"${NOTITLE}""${SUFFIX}" \
+         >> "${PLTFILE_ALL}"
+    NOTITLE=notitle
+    ((INDEX+=1))
+done
+
+gnuplot "${PLTFILE_ALL}"


### PR DESCRIPTION
The re-opened version of #52.
Thread on buildkit is moby/buildkit#1396.

This is an experimental integration with buildkit for speeding up fetching base image.

Our patched version of buildkit is [here](https://github.com/ktock/buildkit/tree/remote-snapshotter).

This commit includes benchmark scripts to measure the time for buliding sample images.
See [this doc](https://github.com/ktock/stargz-snapshotter/blob/aeaf298d27b0cb87fd3c297a0d61c33308619ebe/script/buildkit/testing.md) for manual testing.

Though it seems good for the lazy distribution of the base images, we currently have two problems for exporting output image.

1. Archiving layers takes a long time. It is because of the low READ performance including fetching contents from the registry.
2. We only support exporting type `tar`. It is because when we use remote snapshotters, containerd doesn't store the image contents in the content store but buildkit needs to use these contents for exporting images.

cc @AkihiroSuda @tonistiigi