### PR TITLE
Use Github Actions artifact for benchmarking output

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,5 @@
 name: Benchmark
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+on: [push, pull_request]
 
 jobs:
   hello-bench:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,19 +9,17 @@ jobs:
     name: HelloBench
     env:
       BENCHMARK_RESULT_DIR: ${{ github.workspace }}/benchmark/
-      BENCHMARK_RESULT_FILENAME: result.md
       BENCHMARK_USER: ktokunaga
       BENCHMARK_TARGETS: --all
     steps:
+    - name: Install gnuplot
+      run: sudo apt-get install -y gnuplot
     - uses: actions/checkout@v1
     - name: Prepare output directory
       run: mkdir "${BENCHMARK_RESULT_DIR}"
     - name: Run benchmark
       run: ./script/make.sh benchmark
-    - name: Post the result as a comment
-      run: |
-        jq -n --arg result "$(cat ${BENCHMARK_RESULT_DIR}/${BENCHMARK_RESULT_FILENAME})" '{"body": $result}' | \
-        curl -X POST -d @- \
-             -H "Content-Type: application/json" \
-             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-             ${{ github.event.pull_request.comments_url }}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: benchmarking-result
+        path: ${{ env.BENCHMARK_RESULT_DIR }}

--- a/script/make.sh
+++ b/script/make.sh
@@ -98,20 +98,16 @@ if [ "${BENCHMARK}" == "true" ] ; then
                    | tee "${BENCHMARK_LOG}" ) ; then
         FAIL=true
     else
-        OUTPUTDIR=${BENCHMARK_RESULT_DIR:-}
-        if [ "${OUTPUTDIR}" == "" ] ; then
-            OUTPUTDIR=$(mktemp -d)
+        LOGDIR=$(mktemp -d)
+        cat "${BENCHMARK_LOG}" | "${CONTEXT}/tools/format.sh" | "${CONTEXT}/tools/plot.sh" "${LOGDIR}"
+        cat "${BENCHMARK_LOG}" | "${CONTEXT}/tools/format.sh" | "${CONTEXT}/tools/table.sh" > "${LOGDIR}/result.md"
+        mv "${BENCHMARK_LOG}" "${LOGDIR}/result.log"
+        echo "See logs for >>> ${LOGDIR}"
+        OUTPUTDIR="${BENCHMARK_RESULT_DIR:-}"
+        if [ "${OUTPUTDIR}" != "" ] ; then
+            cp "${LOGDIR}/result.md" "${LOGDIR}/result.png" "${LOGDIR}/result.log" "${OUTPUTDIR}"
+            cat "${LOGDIR}/result.log" | "${CONTEXT}/tools/format.sh" > "${OUTPUTDIR}/result.json"
         fi
-        OUTPUTFILENAME=${BENCHMARK_RESULT_FILENAME:-}
-        if [ "${OUTPUTFILENAME}" == "" ] ; then
-            OUTPUTFILENAME="result.md"
-        fi
-        if [ "${BENCHMARK_WITH_PLOT:-}" == "true" ] ; then
-            cat "${BENCHMARK_LOG}" | "${CONTEXT}/tools/format.sh" | "${CONTEXT}/tools/plot.sh" "${OUTPUTDIR}"
-        fi
-        cat "${BENCHMARK_LOG}" | "${CONTEXT}/tools/format.sh" | "${CONTEXT}/tools/table.sh" > "${OUTPUTDIR}/${OUTPUTFILENAME}"
-        mv "${BENCHMARK_LOG}" "${OUTPUTDIR}/out.log"
-        echo "See output for >>> ${OUTPUTDIR}"
     fi
 
     echo "Cleaning up environment..."


### PR DESCRIPTION
Our benchmarking CI currently shows the result by posting it as a comment on PR([example](https://github.com/containerd/stargz-snapshotter/pull/49#issuecomment-591762620)). But Github Actions [prohibit actions in forked repos to post comments to PRs](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token). For example, PR #53 from a forked repo (`ktock/stargz-snapshotter`) [fails to get benchmarking result comment from Github Actions](https://github.com/containerd/stargz-snapshotter/pull/53/checks?check_run_id=484397124).

This commit enables us to use Github Actions ["artifacts" functionality](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts#about-workflow-artifacts) to get the benchmarking result from Github Actions. Github stores artifacts 90 days and it seems enough for checking the performance on each PR.

In the artifact, the following contents are included as the benchmarking result,
- `result.md`: Benchmarking result overview (previously posted on PRs as "Benchmarking Result" comments)
- `result.png`: Histogram of benchmarking result data.
- `result.json`: JSON-formatted benchmarking result data.
- `result.log`: All logs generated during benchmarking.
