### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ jobs:
       BENCHMARK_TARGETS: --all
     steps:
     - name: Install gnuplot
-      run: sudo apt-get install -y gnuplot
+      run: sudo apt-get --no-install-recommends install -y gnuplot
     - uses: actions/checkout@v1
     - name: Prepare output directory
       run: mkdir "${BENCHMARK_RESULT_DIR}"

--- a/script/benchmark/hello-bench/Dockerfile
+++ b/script/benchmark/hello-bench/Dockerfile
@@ -16,7 +16,7 @@ FROM golang:1.14
 
 # basic tools
 RUN apt-get update -y && \
-    apt-get install -y libbtrfs-dev libseccomp-dev fuse python 
+    apt-get --no-install-recommends install -y libbtrfs-dev libseccomp-dev fuse python 
 
 # runtime dependencies
 RUN git clone https://github.com/opencontainers/runc \

--- a/script/demo/Dockerfile
+++ b/script/demo/Dockerfile
@@ -18,12 +18,12 @@ FROM golang:1.14
 # docker-ce-cli is used only for users to log into registries (e.g. DockerHub)
 # with ~/.docker/config.json
 RUN apt-get update -y && \
-    apt-get install -y libbtrfs-dev libseccomp-dev fuse \
+    apt-get --no-install-recommends install -y libbtrfs-dev libseccomp-dev fuse \
                        apt-transport-https gnupg2 software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
       "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update -y && apt-get install -y docker-ce-cli
+    apt-get update -y && apt-get --no-install-recommends install -y docker-ce-cli
 
 # runtime dependencies
 RUN git clone https://github.com/opencontainers/runc \

--- a/script/integration/containerd-stargz-grpc/Dockerfile
+++ b/script/integration/containerd-stargz-grpc/Dockerfile
@@ -16,8 +16,8 @@ FROM golang:1.14
 
 # Install FUSE for filesystems and Docker client for logging into the registry
 RUN apt-get update -y && \
-    apt-get install -y fuse apt-transport-https gnupg2 software-properties-common && \
+    apt-get --no-install-recommends install -y fuse apt-transport-https gnupg2 software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
       "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update -y && apt-get install -y docker-ce-cli
+    apt-get update -y && apt-get --no-install-recommends install -y docker-ce-cli

--- a/script/integration/containerd/Dockerfile
+++ b/script/integration/containerd/Dockerfile
@@ -17,12 +17,12 @@ FROM golang:1.14
 # basic tools
 # docker-ce-cli is used only to log into registry with ~/.docker/config.json
 RUN apt-get update -y && \
-    apt-get install -y libbtrfs-dev libseccomp-dev \
+    apt-get --no-install-recommends install -y libbtrfs-dev libseccomp-dev \
             apt-transport-https gnupg2 software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
       "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update -y && apt-get install -y docker-ce-cli && \
+    apt-get update -y && apt-get --no-install-recommends install -y docker-ce-cli && \
     git clone https://github.com/google/go-containerregistry \
               $GOPATH/src/github.com/google/go-containerregistry && \
     cd $GOPATH/src/github.com/google/go-containerregistry && \

--- a/script/make.sh
+++ b/script/make.sh
@@ -140,7 +140,7 @@ if [ "$TARGETS" != "" ] ; then
     MINI_CONTEXT=$(mktemp -d)
     cat <<EOF > "${MINI_CONTEXT}/Dockerfile"
 FROM golang:1.14
-RUN apt-get update -y && apt-get install -y fuse
+RUN apt-get update -y && apt-get --no-install-recommends install -y fuse
 EOF
     IMAGE_NAME="minienv:$(sha256sum ${MINI_CONTEXT}/Dockerfile | cut -f 1 -d ' ')"
     if ! ( docker build "${MINI_CONTEXT}" -t "${IMAGE_NAME}" ${DOCKER_BUILD_ARGS:-} && \

--- a/script/optimize/optimize/Dockerfile
+++ b/script/optimize/optimize/Dockerfile
@@ -17,8 +17,8 @@ FROM golang:1.14
 # basic tools
 # docker-ce-cli is used only to log into registry with ~/.docker/config.json
 RUN apt-get update -y && \
-    apt-get install -y fuse apt-transport-https gnupg2 software-properties-common jq && \
+    apt-get --no-install-recommends install -y fuse apt-transport-https gnupg2 software-properties-common jq && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
       "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update -y && apt-get install -y docker-ce-cli runc
+    apt-get update -y && apt-get --no-install-recommends install -y docker-ce-cli runc


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>