### PR TITLE
Enable to cancel optimization on getting signal

### DIFF
--- a/cmd/ctr-remote/sampler/sampler.go
+++ b/cmd/ctr-remote/sampler/sampler.go
@@ -65,6 +65,7 @@ func Run(bundle string, config v1.Image, period int, opts ...Option) error {
 		syscall.SIGINT,
 		syscall.SIGTERM,
 		syscall.SIGQUIT)
+	defer signal.Stop(sc)
 
 	select {
 	case <-sc:


### PR DESCRIPTION
Currently, once image optimization starts we cannot cancel it and need to wait for the completion. This commit enables us to cancel the optimization.