### PR TITLE
Support mirror registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  s
 We support private repository authentication powered by [go-containerregistry](https://github.com/google/go-containerregistry) which supports `~/.docker/config.json`-based credential management.
 You can authenticate yourself to private registries with normal operations (e.g. `docker login` command) using `~/.docker/config.json`.
 ```
-# docker login registry-1.docker.io
+# docker login
 (Enter username and password)
 # ctr-remote image rpull --user <username>:<password> docker.io/<your-repository>/ubuntu:18.04
 ```

--- a/script/demo/config.stargz.toml
+++ b/script/demo/config.stargz.toml
@@ -1,1 +1,3 @@
-insecure = ["127.0.0.1", "localhost", "registry2"]
+[[resolver."registry2:5000".mirrors]]
+host = "registry2:5000"
+insecure = true

--- a/script/integration/containerd-stargz-grpc/config.toml
+++ b/script/integration/containerd-stargz-grpc/config.toml
@@ -1,0 +1,3 @@
+[[resolver."registry-alt:5000".mirrors]]
+host = "registry-alt:5000"
+insecure = true

--- a/script/integration/containerd-stargz-grpc/entrypoint.sh
+++ b/script/integration/containerd-stargz-grpc/entrypoint.sh
@@ -68,8 +68,10 @@ mkdir -p /tmp/out
 GO111MODULE=off PREFIX=/tmp/out/ make clean && \
     GO111MODULE=off PREFIX=/tmp/out/ make -j2 && \
     GO111MODULE=off PREFIX=/tmp/out/ make install
+mkdir -p /etc/containerd-stargz-grpc && \
+    cp ./script/integration/containerd-stargz-grpc/config.toml /etc/containerd-stargz-grpc/config.toml
 
 echo "Running remote snapshotter..."
-containerd-stargz-grpc --log-level=debug &
+containerd-stargz-grpc --log-level=debug --config=/etc/containerd-stargz-grpc/config.toml &
 SSNAPSHOTD_PID=$! # tells cleanup code what PID needs be killed on exit (via ${SSNAPSHOTD_PID}).
 wait "${SSNAPSHOTD_PID}"

--- a/script/integration/docker-compose-integration.yml.sh
+++ b/script/integration/docker-compose-integration.yml.sh
@@ -78,6 +78,9 @@ services:
     - REGISTRY_HTTP_TLS_KEY=/auth/certs/domain.key
     volumes:
     - ${AUTH}:/auth
+  registry-alt:
+    image: registry:2
+    container_name: registry-alt
   remote_snapshotter_integration:
     build:
       context: "${REPO}/script/integration/containerd-stargz-grpc"

--- a/stargz/remote/resolver.go
+++ b/stargz/remote/resolver.go
@@ -1,0 +1,270 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
+*/
+
+package remote
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/reference/docker"
+	"github.com/containerd/stargz-snapshotter/cache"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+const (
+	defaultChunkSize     = 50000
+	defaultValidInterval = 60 * time.Second
+)
+
+type ResolverConfig struct {
+	Mirrors []MirrorConfig `toml:"mirrors"`
+}
+
+type MirrorConfig struct {
+	Host     string `toml:"host"`
+	Insecure bool   `toml:"insecure"`
+}
+
+type BlobConfig struct {
+	ValidInterval int64 `toml:"valid_interval"`
+	CheckAlways   bool  `toml:"check_always"`
+	ChunkSize     int64 `toml:"chunk_size"`
+}
+
+func NewResolver(config map[string]ResolverConfig) *Resolver {
+	if config == nil {
+		config = make(map[string]ResolverConfig)
+	}
+	return &Resolver{
+		transport: http.DefaultTransport,
+		trPool:    make(map[string]http.RoundTripper),
+		config:    config,
+	}
+}
+
+type Resolver struct {
+	transport http.RoundTripper
+	trPool    map[string]http.RoundTripper
+	trPoolMu  sync.Mutex
+	config    map[string]ResolverConfig
+}
+
+func (r *Resolver) Resolve(ref, digest string, cache cache.BlobCache, config BlobConfig) (*Blob, error) {
+	// Get blob information
+	var (
+		nref name.Reference
+		url  string
+		tr   http.RoundTripper
+		size int64
+		rErr = make(map[string]error)
+	)
+	named, err := docker.ParseDockerRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	hosts := append(r.config[docker.Domain(named)].Mirrors, MirrorConfig{
+		Host: docker.Domain(named),
+	})
+	for _, h := range hosts {
+		// Parse reference
+		if h.Host == "" || strings.Contains(h.Host, "/") {
+			rErr[h.Host] = fmt.Errorf("mirror must be a domain name; got %q", h.Host)
+			continue // try another host
+		}
+		var opts []name.Option
+		if h.Insecure {
+			opts = append(opts, name.Insecure)
+		}
+		nref, err = name.ParseReference(
+			fmt.Sprintf("%s/%s", h.Host, docker.Path(named)), opts...)
+		if err != nil {
+			rErr[h.Host] = fmt.Errorf("failed to parse ref %q (%q): %v", ref, digest, err)
+			continue // try another host
+		}
+
+		// Resolve redirection and get blob URL
+		url, err = r.resolveReference(nref, digest)
+		if err != nil {
+			rErr[h.Host] = fmt.Errorf("failed to resolve ref %q (%q): %v", ref, digest, err)
+			continue // try another host
+		}
+
+		// Get authenticated RoundTripper
+		r.trPoolMu.Lock()
+		tr = r.trPool[nref.Name()]
+		r.trPoolMu.Unlock()
+		if tr == nil {
+			rErr[h.Host] = fmt.Errorf("transport %q is not found in the pool", nref.Name())
+			continue
+
+		}
+
+		// Get size information
+		size, err = getSize(url, tr)
+		if err != nil {
+			rErr[h.Host] = fmt.Errorf("failed to get size of %q: %v", url, err)
+			continue // try another host
+		}
+
+		rErr = nil
+		break
+	}
+	if rErr != nil {
+		return nil, fmt.Errorf("cannot resolve ref %q (%q): %v", ref, digest, rErr)
+	}
+
+	// Configure the connection
+	var (
+		chunkSize     int64
+		checkInterval time.Duration
+	)
+	chunkSize = config.ChunkSize
+	if chunkSize == 0 { // zero means "use default chunk size"
+		chunkSize = defaultChunkSize
+	}
+	if config.ValidInterval == 0 { // zero means "use default interval"
+		checkInterval = defaultValidInterval
+	} else {
+		checkInterval = time.Duration(config.ValidInterval) * time.Second
+	}
+	if config.CheckAlways {
+		checkInterval = 0
+	}
+
+	return &Blob{
+		ref:           nref,
+		url:           url,
+		tr:            tr,
+		size:          size,
+		chunkSize:     chunkSize,
+		cache:         cache,
+		checkInterval: checkInterval,
+		lastCheck:     time.Now(),
+	}, nil
+}
+
+func (r *Resolver) resolveReference(ref name.Reference, digest string) (string, error) {
+	r.trPoolMu.Lock()
+	defer r.trPoolMu.Unlock()
+
+	// Construct endpoint URL from given ref
+	endpointURL := fmt.Sprintf("%s://%s/v2/%s/blobs/%s",
+		ref.Context().Registry.Scheme(),
+		ref.Context().RegistryStr(),
+		ref.Context().RepositoryStr(),
+		digest)
+
+	// Try to use cached transport (cahced per reference name)
+	if tr, ok := r.trPool[ref.Name()]; ok {
+		if url, err := redirect(endpointURL, tr); err == nil {
+			return url, nil
+		}
+	}
+
+	// transport is unavailable/expired so refresh the transport and try again
+	tr, err := authnTransport(ref, r.transport)
+	if err != nil {
+		return "", err
+	}
+	url, err := redirect(endpointURL, tr)
+	if err != nil {
+		return "", err
+	}
+
+	// Update transports cache
+	r.trPool[ref.Name()] = tr
+
+	return url, nil
+}
+
+func redirect(endpointURL string, tr http.RoundTripper) (url string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// We use GET request for GCR.
+	req, err := http.NewRequest("GET", endpointURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to request to the registry of %q: %v", endpointURL, err)
+	}
+	req = req.WithContext(ctx)
+	req.Close = false
+	req.Header.Set("Range", "bytes=0-1")
+	res, err := tr.RoundTrip(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to request to %q: %v", endpointURL, err)
+	}
+	defer func() {
+		io.Copy(ioutil.Discard, res.Body)
+		res.Body.Close()
+	}()
+
+	if res.StatusCode/100 == 2 {
+		url = endpointURL
+	} else if redir := res.Header.Get("Location"); redir != "" && res.StatusCode/100 == 3 {
+		// TODO: Support nested redirection
+		url = redir
+	} else {
+		return "", fmt.Errorf("failed to access to %q with code %v",
+			endpointURL, res.StatusCode)
+	}
+
+	return
+}
+
+func getSize(url string, tr http.RoundTripper) (int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req = req.WithContext(ctx)
+	req.Close = false
+	res, err := tr.RoundTrip(req)
+	if err != nil {
+		return 0, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("failed HEAD request with code %v", res.StatusCode)
+	}
+	return strconv.ParseInt(res.Header.Get("Content-Length"), 10, 64)
+}
+
+func authnTransport(ref name.Reference, tr http.RoundTripper) (http.RoundTripper, error) {
+	// Authn against the repository using `~/.docker/config.json`
+	auth, err := authn.DefaultKeychain.Resolve(ref.Context())
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve the reference %q: %v", ref, err)
+	}
+	return transport.New(ref.Context().Registry, auth, tr, []string{ref.Scope(transport.PullScope)})
+}

--- a/stargz/remote/resolver_test.go
+++ b/stargz/remote/resolver_test.go
@@ -1,0 +1,415 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
+*/
+
+package remote
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func TestMirror(t *testing.T) {
+	ref, err := name.ParseReference("dummyexample.com/library/test")
+	if err != nil {
+		t.Fatalf("failed to prepare dummy reference: %v", err)
+	}
+	var (
+		blobDigest = "sha256:deadbeaf"
+		blobPath   = fmt.Sprintf("/v2/%s/blobs/%s", ref.Context().RepositoryStr(), blobDigest)
+		refHost    = ref.Context().RegistryStr()
+	)
+
+	tests := []struct {
+		name     string
+		tr       http.RoundTripper
+		mirrors  []string
+		wantHost string
+		error    bool
+	}{
+		{
+			name:     "no-mirror",
+			tr:       &sampleRoundTripper{okURLs: []string{refHost}},
+			mirrors:  nil,
+			wantHost: refHost,
+		},
+		{
+			name:     "valid-mirror",
+			tr:       &sampleRoundTripper{okURLs: []string{"mirrorexample.com"}},
+			mirrors:  []string{"mirrorexample.com"},
+			wantHost: "mirrorexample.com",
+		},
+		{
+			name: "invalid-mirror",
+			tr: &sampleRoundTripper{
+				withCode: map[string]int{
+					"mirrorexample1.com": http.StatusInternalServerError,
+					"mirrorexample2.com": http.StatusUnauthorized,
+					"mirrorexample3.com": http.StatusNotFound,
+				},
+				okURLs: []string{"mirrorexample4.com", refHost},
+			},
+			mirrors: []string{
+				"mirrorexample1.com",
+				"mirrorexample2.com",
+				"mirrorexample3.com",
+				"mirrorexample4.com",
+			},
+			wantHost: "mirrorexample4.com",
+		},
+		{
+			name: "invalid-all-mirror",
+			tr: &sampleRoundTripper{
+				withCode: map[string]int{
+					"mirrorexample1.com": http.StatusInternalServerError,
+					"mirrorexample2.com": http.StatusUnauthorized,
+					"mirrorexample3.com": http.StatusNotFound,
+				},
+				okURLs: []string{refHost},
+			},
+			mirrors: []string{
+				"mirrorexample1.com",
+				"mirrorexample2.com",
+				"mirrorexample3.com",
+			},
+			wantHost: refHost,
+		},
+		{
+			name: "invalid-hostname-of-mirror",
+			tr: &sampleRoundTripper{
+				okURLs: []string{`.*`},
+			},
+			mirrors:  []string{"mirrorexample.com/somepath/"},
+			wantHost: refHost,
+		},
+		{
+			name: "redirected-mirror",
+			tr: &sampleRoundTripper{
+				redirectURL: map[string]string{
+					regexp.QuoteMeta(fmt.Sprintf("mirrorexample.com%s", blobPath)): "https://backendexample.com/blobs/sha256:deadbeaf",
+				},
+				okURLs: []string{`.*`},
+			},
+			mirrors:  []string{"mirrorexample.com"},
+			wantHost: "backendexample.com",
+		},
+		{
+			name: "invalid-redirected-mirror",
+			tr: &sampleRoundTripper{
+				withCode: map[string]int{
+					"backendexample.com": http.StatusInternalServerError,
+				},
+				redirectURL: map[string]string{
+					regexp.QuoteMeta(fmt.Sprintf("mirrorexample.com%s", blobPath)): "https://backendexample.com/blobs/sha256:deadbeaf",
+				},
+				okURLs: []string{`.*`},
+			},
+			mirrors:  []string{"mirrorexample.com"},
+			wantHost: refHost,
+		},
+		{
+			name:     "fail-all",
+			tr:       &sampleRoundTripper{},
+			mirrors:  []string{"mirrorexample.com"},
+			wantHost: "",
+			error:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mirrors []MirrorConfig
+			for _, m := range tt.mirrors {
+				mirrors = append(mirrors, MirrorConfig{
+					Host: m,
+				})
+			}
+			r := &Resolver{
+				transport: tt.tr,
+				trPool:    make(map[string]http.RoundTripper),
+				config: map[string]ResolverConfig{
+					refHost: {
+						Mirrors: mirrors,
+					},
+				},
+			}
+			blob, err := r.Resolve(ref.String(), blobDigest, nil, BlobConfig{})
+			if err != nil {
+				if tt.error {
+					return
+				}
+				t.Fatalf("failed to resolve reference: %v", err)
+			}
+			nurl, err := url.Parse(blob.url)
+			if err != nil {
+				t.Fatalf("failed to parse url %q: %v", blob.url, err)
+			}
+			if nurl.Hostname() != tt.wantHost {
+				t.Errorf("invalid hostname %q(%q); want %q",
+					nurl.Hostname(), nurl.String(), tt.wantHost)
+			}
+		})
+	}
+}
+
+func TestPool(t *testing.T) {
+	ref, err := name.ParseReference("dummyexample.com/library/test")
+	if err != nil {
+		t.Fatalf("failed to prepare dummy reference: %v", err)
+	}
+	var (
+		digest  = "sha256:deadbeaf"
+		blobURL = fmt.Sprintf("%s://%s/v2/%s/blobs/%s",
+			ref.Context().Registry.Scheme(),
+			ref.Context().RegistryStr(),
+			ref.Context().RepositoryStr(),
+			digest)
+		redirectedURL  = "https://backendexample.com/blobs/sha256:deadbeaf"
+		okRoundTripper = &sampleRoundTripper{
+			okURLs: []string{`.*`},
+		}
+		redirectRoundTripper = &sampleRoundTripper{
+			redirectURL: map[string]string{
+				regexp.QuoteMeta(blobURL): redirectedURL,
+			},
+			okURLs: []string{regexp.QuoteMeta(ref.Context().RegistryStr())},
+		}
+		unauthorizedRoundTripper = &sampleRoundTripper{
+			withCode: map[string]int{
+				regexp.QuoteMeta(ref.Context().RegistryStr()): http.StatusUnauthorized,
+			},
+			okURLs: []string{`.*`},
+		}
+		notFoundRoundTripper = &sampleRoundTripper{}
+	)
+	tests := []struct {
+		name  string
+		pool  http.RoundTripper
+		base  http.RoundTripper
+		check func(t *testing.T, pool http.RoundTripper, url string, err error)
+	}{
+		{
+			name: "create-new-tr",
+			pool: nil,
+			base: okRoundTripper,
+			check: func(t *testing.T, pool http.RoundTripper, url string, err error) {
+				if err != nil {
+					t.Errorf("want to success: %v", err)
+					return
+				}
+				if pool == nil {
+					t.Error("new RoundTripper isn't pooled")
+					return
+				}
+				if url != blobURL {
+					t.Errorf("invalid URL %q; want %q", url, blobURL)
+					return
+				}
+			},
+		},
+		{
+			name: "create-new-tr-with-redirect",
+			pool: nil,
+			base: redirectRoundTripper,
+			check: func(t *testing.T, pool http.RoundTripper, url string, err error) {
+				if err != nil {
+					t.Errorf("want to success: %v", err)
+					return
+				}
+				if pool == nil {
+					t.Error("new RoundTripper isn't pooled")
+					return
+				}
+				if url != redirectedURL {
+					t.Errorf("invalid URL %q; want %q", url, redirectedURL)
+					return
+				}
+			},
+		},
+		{
+			name: "fail-to-create-new-tr-with-unauthorized",
+			pool: nil,
+			base: unauthorizedRoundTripper,
+			check: func(t *testing.T, pool http.RoundTripper, url string, err error) {
+				if err == nil {
+					t.Error("want to fail")
+					return
+				}
+			},
+		},
+		{
+			name: "use-pooled-ok-tr",
+			pool: okRoundTripper,
+			base: notFoundRoundTripper, // won't be used
+			check: func(t *testing.T, pool http.RoundTripper, url string, err error) {
+				if err != nil {
+					t.Errorf("want to success: %v", err)
+					return
+				}
+				if pool != okRoundTripper {
+					t.Error("got RoundTripper isn't same as pooled one")
+					return
+				}
+				if url != blobURL {
+					t.Errorf("invalid URL %q; want %q", url, blobURL)
+					return
+				}
+			},
+		},
+		{
+			name: "use-pooled-redirect-tr",
+			pool: redirectRoundTripper,
+			base: notFoundRoundTripper, // won't be used
+			check: func(t *testing.T, pool http.RoundTripper, url string, err error) {
+				if err != nil {
+					t.Errorf("want to success: %v", err)
+					return
+				}
+				if pool != redirectRoundTripper {
+					t.Error("got RoundTripper isn't same as pooled one")
+					return
+				}
+				if url != redirectedURL {
+					t.Errorf("invalid URL %q; want %q", url, redirectedURL)
+					return
+				}
+			},
+		},
+		{
+			name: "refresh-unauthorized-tr",
+			pool: unauthorizedRoundTripper,
+			base: okRoundTripper,
+			check: func(t *testing.T, pool http.RoundTripper, url string, err error) {
+				if err != nil {
+					t.Errorf("want to success: %v", err)
+					return
+				}
+				if pool == unauthorizedRoundTripper {
+					t.Error("RoundTripper must be refreshed")
+					return
+				}
+				if url != blobURL {
+					t.Errorf("invalid URL %q; want %q", url, blobURL)
+					return
+				}
+			},
+		},
+		{
+			name: "refresh-unauthorized-tr-with-redirect",
+			pool: unauthorizedRoundTripper,
+			base: redirectRoundTripper,
+			check: func(t *testing.T, pool http.RoundTripper, url string, err error) {
+				if err != nil {
+					t.Errorf("want to success: %v", err)
+					return
+				}
+				if pool == unauthorizedRoundTripper {
+					t.Error("RoundTripper must be refreshed")
+					return
+				}
+				if url != redirectedURL {
+					t.Errorf("invalid URL %q; want %q", url, redirectedURL)
+					return
+				}
+			},
+		},
+		{
+			name: "fail-to-refresh",
+			pool: unauthorizedRoundTripper,
+			base: notFoundRoundTripper,
+			check: func(t *testing.T, pool http.RoundTripper, url string, err error) {
+				if err == nil {
+					t.Error("want to fail")
+					return
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Resolver{
+				transport: tt.base,
+				trPool:    make(map[string]http.RoundTripper),
+			}
+			if tt.pool != nil {
+				r.trPool[ref.Name()] = tt.pool
+			}
+			url, err := r.resolveReference(ref, digest)
+			if r.trPool == nil {
+				t.Fatal("transport pool is empty")
+			}
+			tt.check(t, r.trPool[ref.Name()], url, err)
+		})
+	}
+}
+
+type sampleRoundTripper struct {
+	withCode    map[string]int
+	redirectURL map[string]string
+	okURLs      []string
+}
+
+func (tr *sampleRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	for host, code := range tr.withCode {
+		if ok, _ := regexp.Match(host, []byte(req.URL.String())); ok {
+			return &http.Response{
+				StatusCode: code,
+				Header:     make(http.Header),
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			}, nil
+		}
+	}
+	for host, rurl := range tr.redirectURL {
+		if ok, _ := regexp.Match(host, []byte(req.URL.String())); ok {
+			header := make(http.Header)
+			header.Add("Location", rurl)
+			return &http.Response{
+				StatusCode: http.StatusMovedPermanently,
+				Header:     header,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			}, nil
+		}
+	}
+	for _, host := range tr.okURLs {
+		if ok, _ := regexp.Match(host, []byte(req.URL.String())); ok {
+			header := make(http.Header)
+			header.Add("Content-Length", "1")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     header,
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte{0})),
+			}, nil
+		}
+	}
+	return &http.Response{
+		StatusCode: http.StatusNotFound,
+		Header:     make(http.Header),
+		Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+	}, nil
+}


### PR DESCRIPTION
#61

This patch enables to configure mirror registries for this snapshotter, independent to containerd.
We can configure mirror registries in our config file like:

```toml
[resolver.mirrors]
registryexample.io = ["mirrorexample.com:5000", "mirrorexample2.com:5000"]
```
Authentication is done with `~/.docker/config.json` like as before.

The patch is a bit large but what is done is relatively simple.
- Moved resolver-related codes from `/stargz/fs.go` to `/stargz/remote/...`
- Added mirror registry support to `/stargz/remote/resolver.go` and added some tests
- Renamed `URLReaderAt`(`stargz/remote/urlreaderat.go`) to `Blob` (`stargz/remote/blob.go`) because its feature became richer by some codes (authentication of `RoundTripper` and getter of the blob size info) ported from `/stargz/fs.go`.
