### PR TITLE
Add CRI validation tests for stargz snapshotter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,3 +44,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: Run test for pulling image from private registry on Kubernetes
       run: ./script/make.sh test-pullsecrets
+  test-cri:
+    runs-on: ubuntu-18.04
+    name: CRIValidation
+    steps:
+    - uses: actions/checkout@v1
+    - name: Varidate the runtime through CRI
+      run: ./script/make.sh test-cri

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,6 @@ benchmark:
 
 test-pullsecrets:
 	@./script/make.sh test-pullsecrets
+
+test-cri:
+	@./script/make.sh test-cri

--- a/script/cri/build.sh
+++ b/script/cri/build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+NODE_TEST_IMAGE_NAME="cri-integration-node-testimage"
+NODE_BASE_IMAGE_NAME="cri-integration-node-baseimage"
+
+REPO="${1}"
+
+if [ "${CRI_NO_RECREATE:-}" != "true" ] ; then
+    echo "Preparing node image..."
+    docker build -t "${NODE_BASE_IMAGE_NAME}" "${REPO}"
+fi
+
+TMP_CONTEXT=$(mktemp -d)
+function cleanup {
+    ORG_EXIT_CODE="${1}"
+    rm -rf "${TMP_CONTEXT}"
+    exit "${ORG_EXIT_CODE}"
+}
+trap 'cleanup "$?"' EXIT SIGHUP SIGINT SIGQUIT SIGTERM
+
+# Prepare the testing node
+cat <<EOF > "${TMP_CONTEXT}/Dockerfile"
+FROM ${NODE_BASE_IMAGE_NAME}
+
+ENV PATH=$PATH:/usr/local/go/bin
+ENV GOPATH=/go
+RUN apt install -y --no-install-recommends git make gcc build-essential && \
+    curl https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz \
+    | tar -C /usr/local -xz && \
+    go get -u github.com/onsi/ginkgo/ginkgo && \
+    git clone -b v1.18.0 https://github.com/kubernetes-sigs/cri-tools \
+              \${GOPATH}/src/github.com/kubernetes-sigs/cri-tools && \
+    cd \${GOPATH}/src/github.com/kubernetes-sigs/cri-tools && \
+    make critest && make install-critest -e BINDIR=\${GOPATH}/bin && \
+    git clone -b v1.11.1 https://github.com/containerd/cri \
+              \${GOPATH}/src/github.com/containerd/cri && \
+    cd \${GOPATH}/src/github.com/containerd/cri && \
+    NOSUDO=true ./hack/install/install-cni.sh && \
+    NOSUDO=true ./hack/install/install-cni-config.sh && \
+    systemctl disable kubelet
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]
+EOF
+docker build -t "${NODE_TEST_IMAGE_NAME}" "${TMP_CONTEXT}"

--- a/script/cri/test-legacy.sh
+++ b/script/cri/test-legacy.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+NODE_TEST_IMAGE_NAME="cri-integration-node-testimage"
+CONTAINERD_SOCK=unix:///run/containerd/containerd.sock
+
+IMAGE_LIST="${1}"
+
+TEST_NODE_ID=$(docker run --rm -d --privileged \
+                      -v /dev/fuse:/dev/fuse \
+                      --tmpfs=/var/lib/containerd:suid \
+                      --tmpfs=/var/lib/containerd-stargz-grpc:suid \
+                      "${NODE_TEST_IMAGE_NAME}")
+echo "Running node on: ${TEST_NODE_ID}"
+FAIL=
+for i in $(seq 100) ; do
+    if docker exec -i "${TEST_NODE_ID}" ctr version ; then
+        break
+    fi
+    echo "Fail(${i}). Retrying..."
+    if [ $i == 100 ] ; then
+        FAIL=true
+    fi
+    sleep 1
+done
+
+# If container started successfully, varidate the runtime through CRI
+if [ "${FAIL}" == "" ] ; then
+    if ! docker exec -i "${TEST_NODE_ID}" /go/bin/critest --runtime-endpoint=${CONTAINERD_SOCK} ; then
+        FAIL=true
+    fi
+fi
+
+# Dump all names of images used in the test
+docker exec -i "${TEST_NODE_ID}" journalctl -xu containerd \
+    | grep PullImage | sed -E 's/.*PullImage \\"([^\\]*)\\".*/\1/g' | sort | uniq > "${IMAGE_LIST}"
+
+docker kill "${TEST_NODE_ID}"
+if [ "${FAIL}" != "" ] ; then
+    exit 1
+fi
+
+exit 0

--- a/script/cri/test-stargz.sh
+++ b/script/cri/test-stargz.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+NODE_TEST_IMAGE_NAME="cri-integration-node-testimage"
+REGISTRY_HOST=registry-cri-validation
+CONTAINERD_SOCK=unix:///run/containerd/containerd.sock
+TEST_NODE_NAME=testenv_cri
+REMOTE_SNAPSHOT_FAILURE_LOG="failed to prepare remote snapshot"
+
+IMAGE_LIST="${1}"
+
+TMP_CONTEXT=$(mktemp -d)
+DOCKER_COMPOSE_YAML=$(mktemp)
+CONTAINERD_CONFIG=$(mktemp)
+SNAPSHOTTER_CONFIG=$(mktemp)
+TMPFILE=$(mktemp)
+function cleanup {
+    ORG_EXIT_CODE="${1}"
+    docker-compose -f "${DOCKER_COMPOSE_YAML}" down -v || true
+    rm -rf "${TMP_CONTEXT}" || true
+    rm "${DOCKER_COMPOSE_YAML}" || true
+    rm "${CONTAINERD_CONFIG}" || true
+    rm "${SNAPSHOTTER_CONFIG}" || true
+    rm "${TMPFILE}" || true
+    exit "${ORG_EXIT_CODE}"
+}
+trap 'cleanup "$?"' EXIT SIGHUP SIGINT SIGQUIT SIGTERM
+
+# Prepare the testing node and registry
+cat <<EOF > "${DOCKER_COMPOSE_YAML}"
+version: "3.3"
+services:
+  testenv:
+    image: ${NODE_TEST_IMAGE_NAME}
+    container_name: ${TEST_NODE_NAME}
+    privileged: true
+    volumes:
+    - /dev/fuse:/dev/fuse
+    - type: volume
+      source: containerd-data
+      target: /var/lib/containerd
+      volume:
+        nosuid: false
+    - type: volume
+      source: containerd-stargz-grpc-data
+      target: /var/lib/containerd-stargz-grpc
+      volume:
+        nosuid: false
+    - type: volume
+      source: containerd-stargz-grpc-status
+      target: /run/containerd-stargz-grpc
+      volume:
+        nosuid: false
+  registry:
+    image: registry:2
+    container_name: ${REGISTRY_HOST}
+volumes:
+  containerd-data:
+  containerd-stargz-grpc-data:
+  containerd-stargz-grpc-status:
+EOF
+docker-compose -f "${DOCKER_COMPOSE_YAML}" up -d --force-recreate
+
+CONNECTED=
+for i in $(seq 100) ; do
+    if docker exec "${TEST_NODE_NAME}" curl -k --head "http://${REGISTRY_HOST}:5000/v2/" ; then
+        CONNECTED=true
+        break
+    fi
+    echo "Fail(${i}). Retrying..."
+    sleep 1
+done
+if [ "${CONNECTED}" != "true" ] ; then
+    echo "Failed to connect to containerd"
+    exit 1
+fi
+
+# Mirror and stargzify all images used in tests
+cat "${IMAGE_LIST}" | sort | uniq | while read IMAGE ; do
+    MIRROR_URL="http://${REGISTRY_HOST}:5000"$(echo "${IMAGE}" | sed -E 's/^[^/]*//g' | sed -E 's/@.*//g')
+    STARGZIFY="ctr-remote images optimize --plain-http --stargz-only ${IMAGE} ${MIRROR_URL}"
+    echo "Mirroring: ${STARGZIFY}"
+    docker exec "${TEST_NODE_NAME}" /bin/bash -c "${STARGZIFY}"
+done
+
+# Configure mirror registries for containerd and snapshotter
+docker exec "${TEST_NODE_NAME}" cat /etc/containerd/config.toml > "${CONTAINERD_CONFIG}"
+docker exec "${TEST_NODE_NAME}" cat /etc/containerd-stargz-grpc/config.toml > "${SNAPSHOTTER_CONFIG}"
+cat "${IMAGE_LIST}" | sed -E 's/^([^/]*).*/\1/g' | sort | uniq | while read DOMAIN ; do
+    echo "Adding mirror config: ${DOMAIN}"
+    cat <<EOF >> "${CONTAINERD_CONFIG}"
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."${DOMAIN}"]
+endpoint = ["http://${REGISTRY_HOST}:5000"]
+EOF
+    cat <<EOF >> "${SNAPSHOTTER_CONFIG}"
+[[resolver."${DOMAIN}".mirrors]]
+host = "${REGISTRY_HOST}:5000"
+insecure = true
+EOF
+done
+echo "==== Containerd config ===="
+cat "${CONTAINERD_CONFIG}"
+echo "==== Snapshotter config ===="
+cat "${SNAPSHOTTER_CONFIG}"
+docker cp "${CONTAINERD_CONFIG}" "${TEST_NODE_NAME}":/etc/containerd/config.toml
+docker cp "${SNAPSHOTTER_CONFIG}" "${TEST_NODE_NAME}":/etc/containerd-stargz-grpc/config.toml
+
+# Replace digests specified in testing tool to stargz-formatted one
+cat "${IMAGE_LIST}" | grep "@sha256:" | while read IMAGE ; do
+    URL_PATH=$(echo "${IMAGE}" | sed -E 's/^[^/]*//g' | sed -E 's/@.*//g')
+    URL="http://${REGISTRY_HOST}:5000/v2${URL_PATH}/manifests/latest"
+    OLD_DIGEST=$(echo "${IMAGE}" | sed -E 's/.*(sha256:[a-z0-9]*).*/\1/g')
+    NEW_DIGEST=$(docker exec "${TEST_NODE_NAME}" curl -k --head \
+                        -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "${URL}" \
+                     | grep "Docker-Content-Digest" | sed -E 's/.*(sha256:[a-z0-9]*).*/\1/g')
+    echo "Converting: ${OLD_DIGEST} => ${NEW_DIGEST}"
+    docker exec "${TEST_NODE_NAME}" \
+           find /go/src/github.com/kubernetes-sigs/cri-tools/pkg -type f -exec \
+           sed -i -e "s|${OLD_DIGEST}|${NEW_DIGEST}|g" {} \;
+done
+
+# Rebuild cri testing tool
+docker exec "${TEST_NODE_NAME}" /bin/bash -c \
+       "cd /go/src/github.com/kubernetes-sigs/cri-tools && make critest && make install-critest -e BINDIR=/go/bin"
+
+# Varidate the runtime through CRI
+docker exec "${TEST_NODE_NAME}" systemctl restart stargz-snapshotter
+docker exec "${TEST_NODE_NAME}" systemctl restart containerd
+CONNECTED=
+for i in $(seq 100) ; do
+    if docker exec "${TEST_NODE_NAME}" ctr version ; then
+        CONNECTED=true
+        break
+    fi
+    echo "Fail(${i}). Retrying..."
+    sleep 1
+done
+if [ "${CONNECTED}" != "true" ] ; then
+    echo "Failed to connect to containerd"
+    exit 1
+fi
+docker exec "${TEST_NODE_NAME}" /go/bin/critest --runtime-endpoint=${CONTAINERD_SOCK}
+
+# Check if stargz snapshotter is working
+docker exec "${TEST_NODE_NAME}" \
+       ctr-remote --namespace=k8s.io snapshot --snapshotter=stargz ls \
+    | sed -E '1d' > "${TMPFILE}"
+if ! [ -s "${TMPFILE}" ] ; then
+    echo "No snapshots created; stargz snapshotter might be connected to containerd"
+    exit 1
+fi
+
+# Check all remote snapshots are created successfully
+if docker exec "${TEST_NODE_NAME}" journalctl -xu stargz-snapshotter \
+        | grep "${REMOTE_SNAPSHOT_FAILURE_LOG}" ; then
+    echo "Some layers hasn't been prepared as remote snapshots"
+    exit 1
+fi
+
+exit 0

--- a/script/make.sh
+++ b/script/make.sh
@@ -50,11 +50,13 @@ INTEGRATION=false
 OPTIMIZE=false
 BENCHMARK=false
 PULLSECRETS=false
+CRI_TEST=false
 for T in ${@} ; do
     case "${T}" in
         "integration" ) INTEGRATION=true ;;
         "test-optimize" ) OPTIMIZE=true ;;
         "test-pullsecrets" ) PULLSECRETS=true ;;
+        "test-cri" ) CRI_TEST=true ;;
         "benchmark" ) BENCHMARK=true ;;
         * ) TARGETS="${TARGETS} ${T}" ;;
     esac
@@ -195,6 +197,16 @@ if [ "${PULLSECRETS}" == "true" ] ; then
     rm "${DOCKER_COMPOSE_YAML}"
     rm "${KIND_KUBECONFIG}"
     rm -rf "${AUTH_DIR}"
+fi
+
+if [ "${CRI_TEST}" == "true" ] ; then
+    IMAGE_LIST=$(mktemp)
+    if ! ( "${REPO}/script/cri/build.sh" "${REPO}" && \
+               "${REPO}/script/cri/test-legacy.sh" "${IMAGE_LIST}" && \
+               "${REPO}/script/cri/test-stargz.sh" "${IMAGE_LIST}" ) ; then
+        FAIL=true
+    fi
+    rm "${IMAGE_LIST}"
 fi
 
 if [ "$TARGETS" != "" ] ; then

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -604,6 +604,8 @@ func (o *snapshotter) prepareRemoteSnapshot(ctx context.Context, key string, lab
 	}
 
 	if err := o.fs.Mount(o.context, o.upperPath(id), labels); err != nil {
+		log.G(ctx).WithField("key", key).
+			WithError(err).Debug("failed to prepare remote snapshot")
 		return err
 	}
 


### PR DESCRIPTION
This commit adds CRI validation tests for containerd + this snapshotter using [ones provided by `kubernetes-sigs/cri-tools`](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md).

They will be applied for the following situations:
- all images used in the tests are legacy docker images
- they are stargz images (hence all snapshots will be remote snapshots)

Through the first situation, we can check the snapshoter's fallback behaviour being valid for CRI and through the second one we can check remote snapshots meets specs required by CRI.
