### PR TITLE
Use dedicated org on Docker Hub for pre-converted images

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ jobs:
     name: HelloBench
     env:
       BENCHMARK_RESULT_DIR: ${{ github.workspace }}/benchmark/
-      BENCHMARK_USER: ktokunaga
+      BENCHMARK_USER: stargz
       BENCHMARK_TARGETS: python:3.7 gcc:9.2.0 rethinkdb:2.3.6 glassfish:4.1-jdk8
     steps:
     - name: Install gnuplot

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Stargz Snapshotter
 
-[![Tests Status](https://github.com/containerd/stargz-snapshotter/workflows/Tests/badge.svg?branch=master)](https://github.com/containerd/stargz-snapshotter/actions?query=workflow%3ATests+branch%3Amaster)
-[![Benchmarking](https://github.com/containerd/stargz-snapshotter/workflows/Benchmark/badge.svg?branch=master)](https://github.com/containerd/stargz-snapshotter/actions?query=workflow%3ABenchmark+branch%3Amaster)
+[![Tests Status](https://github.com/containerd/stargz-snapshotter/workflows/Tests/badge.svg)](https://github.com/containerd/stargz-snapshotter/actions?query=workflow%3ATests+branch%3Amaster)
+[![Benchmarking](https://github.com/containerd/stargz-snapshotter/workflows/Benchmark/badge.svg)](https://github.com/containerd/stargz-snapshotter/actions?query=workflow%3ABenchmark+branch%3Amaster)
 
 Pulling image is one of the time-consuming steps in the container lifecycle. Research shows that time to take for pull operation accounts for 76% of container startup time[[FAST '16]](https://www.usenix.org/node/194431). *Stargz Snapshotter* is an implementation of snapshotter which aims to solve this problem leveraging [stargz image format by CRFS](https://github.com/google/crfs). The following histogram is the benchmarking result for startup time of several containers measured on Github Actions, using Docker Hub as a registry.
 
@@ -17,12 +17,11 @@ Stargz Snapshotter is a **non-core** sub-project of containerd.
 
 You can test this snapshotter with the latest containerd. Though we still need patches on clients and we are working on, you can use [a customized version of ctr command](cmd/ctr-remote) for a quick tasting. For an overview of the snapshotter, please check [this doc](./docs/overview.md).
 
-__NOTICE:__
-
-- Put this repo on your `GOPATH`(`${GOPATH}/src/github.com/containerd/stargz-snapshotter`).
-
 ### Build and run the environment
-```
+
+First, please put this repo on your `GOPATH`(`${GOPATH}/src/github.com/containerd/stargz-snapshotter`).
+
+```console
 $ cd ${GOPATH}/src/github.com/containerd/stargz-snapshotter/script/demo
 $ docker-compose build --build-arg HTTP_PROXY=$HTTP_PROXY \
                        --build-arg HTTPS_PROXY=$HTTP_PROXY \
@@ -39,7 +38,7 @@ $ docker exec -it containerd_demo /bin/bash
 For making and pushing a stargz image, you can use CRFS-official `stargzify` command or our `ctr-remote` command which has further optimization functionality. In this example, we use `ctr-remote`. You can also try our pre-converted images listed in [this doc](./docs/pre-converted-images.md).
 
 We optimize the image for speeding up the execution of `ls` command on `bash`.
-```
+```console
 # ctr-remote image optimize --plain-http --entrypoint='[ "/bin/bash", "-c" ]' --args='[ "ls" ]' \
              ubuntu:18.04 http://registry2:5000/ubuntu:18.04
 ```
@@ -48,7 +47,7 @@ The converted image is still __docker-compatible__ so you can push/pull/run it w
 ### Run the container with stargz snapshots
 
 Layer downloads don't occur. So this "pull" operation ends soon.
-```
+```console
 # time ctr-remote images rpull --plain-http registry2:5000/ubuntu:18.04
 fetching sha256:728332a6... application/vnd.docker.distribution.manifest.v2+json
 fetching sha256:80026893... application/vnd.docker.container.image.v1+json
@@ -68,14 +67,14 @@ We support the following methods for private repository authentication.
 - Using Kubernetes secrets (type = `kubernetes.io/dockerconfigjson`)
 
 Following example enables stargz snapshotter to access to private registries using `docker login` command. Stargz snapshotter gets credentials from `DOCKER_CONFIG`(or `~/.docker/config.json`).
-```
+```console
 # docker login
 (Enter username and password)
 # ctr-remote image rpull --user <username>:<password> docker.io/<your-repository>/ubuntu:18.04
 ```
 
 Following configuration enables stargz snapshotter to access to private registries using kubernetes secrets (type = `kubernetes.io/dockerconfigjson`) in the cluster using kubeconfig files. You can specify the path of kubeconfig file to use with `kubeconfig_path` option. It's no problem that the specified file doesn't exist when this snapshotter starts. In this case, snapsohtter polls the file until actually provided. This is useful for some environments (e.g. single node cluster with containerized apiserver) where stargz snapshotter needs to start before everything, including booting containerd/kubelet/apiserver and configuring users/roles. If no `kubeconfig_path` is specified, snapshotter searches kubeconfig files from `KUBECONFIG` or `~/.kube/config`.
-```
+```toml
 [kubeconfig_keychain]
 enable_keychain = true
 kubeconfig_path = "/etc/kubernetes/snapshotter/config.conf"

--- a/docs/pre-converted-images.md
+++ b/docs/pre-converted-images.md
@@ -18,18 +18,18 @@ In the following table, `Image Name` column contains placeholders `{{ suffix }}`
 
 |Image Name|Optimized Workload|
 ---|---
-|`docker.io/ktokunaga/alpine:3.10.2-{{ suffix }}`|Executing `echo hello` on the shell|
-|`docker.io/ktokunaga/drupal:8.7.6-{{ suffix }}`|Code execution until up and ready message (`apache2 -D FOREGROUND`) is printed|
-|`docker.io/ktokunaga/fedora:30-{{ suffix }}`|Executing `echo hello` on the shell|
-|`docker.io/ktokunaga/gcc:9.2.0-{{ suffix }}`|Compiling and executing a program which prints `hello`|
-|`docker.io/ktokunaga/glassfish:4.1-jdk8-{{ suffix }}`|Code execution until up and ready message (`Running GlassFish`) is printed|
-|`docker.io/ktokunaga/golang:1.12.9-{{ suffix }}`|Compiling and executing a program which prints `hello`|
-|`docker.io/ktokunaga/jenkins:2.60.3-{{ suffix }}`|Code execution until up and ready message (`Jenkins is fully up and running`) is printed|
-|`docker.io/ktokunaga/jruby:9.2.8.0-{{ suffix }}`|Printing `hello`|
-|`docker.io/ktokunaga/perl:5.30-{{ suffix }}`|Printing `hello`|
-|`docker.io/ktokunaga/php:7.3.8-{{ suffix }}`|Printing `hello`|
-|`docker.io/ktokunaga/pypy:3.5-{{ suffix }}`|Printing `hello`|
-|`docker.io/ktokunaga/python:3.7-{{ suffix }}`|Printing `hello`|
-|`docker.io/ktokunaga/r-base:3.6.1-{{ suffix }}`|Printing `hello`|
-|`docker.io/ktokunaga/redis:5.0.5-{{ suffix }}`|Code execution until up and ready message (`Ready to accept connections`) is printed|
-|`docker.io/ktokunaga/rethinkdb:2.3.6-{{ suffix }}`|Code execution until up and ready message (`Server ready`) is printed|
+|`docker.io/stargz/alpine:3.10.2-{{ suffix }}`|Executing `echo hello` on the shell|
+|`docker.io/stargz/drupal:8.7.6-{{ suffix }}`|Code execution until up and ready message (`apache2 -D FOREGROUND`) is printed|
+|`docker.io/stargz/fedora:30-{{ suffix }}`|Executing `echo hello` on the shell|
+|`docker.io/stargz/gcc:9.2.0-{{ suffix }}`|Compiling and executing a program which prints `hello`|
+|`docker.io/stargz/glassfish:4.1-jdk8-{{ suffix }}`|Code execution until up and ready message (`Running GlassFish`) is printed|
+|`docker.io/stargz/golang:1.12.9-{{ suffix }}`|Compiling and executing a program which prints `hello`|
+|`docker.io/stargz/jenkins:2.60.3-{{ suffix }}`|Code execution until up and ready message (`Jenkins is fully up and running`) is printed|
+|`docker.io/stargz/jruby:9.2.8.0-{{ suffix }}`|Printing `hello`|
+|`docker.io/stargz/perl:5.30-{{ suffix }}`|Printing `hello`|
+|`docker.io/stargz/php:7.3.8-{{ suffix }}`|Printing `hello`|
+|`docker.io/stargz/pypy:3.5-{{ suffix }}`|Printing `hello`|
+|`docker.io/stargz/python:3.7-{{ suffix }}`|Printing `hello`|
+|`docker.io/stargz/r-base:3.6.1-{{ suffix }}`|Printing `hello`|
+|`docker.io/stargz/redis:5.0.5-{{ suffix }}`|Code execution until up and ready message (`Ready to accept connections`) is printed|
+|`docker.io/stargz/rethinkdb:2.3.6-{{ suffix }}`|Code execution until up and ready message (`Server ready`) is printed|


### PR DESCRIPTION
Following-up: https://github.com/containerd/stargz-snapshotter/pull/58#pullrequestreview-373316667

We started a new organization https://hub.docker.com/u/stargz on Docker Hub. Let's use this for our benchmarking. This commit includes some minor updates for docs.
