### PR TITLE
Fix actions/checkout conf to enable DCO check for merge commits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
     name: Check
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
     - name: Check all
       run: ./script/util/make.sh install-check-tools check
   integration:


### PR DESCRIPTION
DCO checker [requires history](https://github.com/vbatts/git-validation/blob/656ba47bb0be8aba4934bb4b2e91863edb406c36/rules/dco/dco.go#L30-L34) for skipping check for merged commits but actions/checkout V2 [doesn't fetch history by default](https://github.com/actions/checkout#usage). As a result, DCO checks fail for merge commits which don't have signature.