### PR TITLE
Add quick start for Kubernetes with KinD

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,58 +3,103 @@
 [![Tests Status](https://github.com/containerd/stargz-snapshotter/workflows/Tests/badge.svg)](https://github.com/containerd/stargz-snapshotter/actions?query=workflow%3ATests+branch%3Amaster)
 [![Benchmarking](https://github.com/containerd/stargz-snapshotter/workflows/Benchmark/badge.svg)](https://github.com/containerd/stargz-snapshotter/actions?query=workflow%3ABenchmark+branch%3Amaster)
 
-Pulling image is one of the time-consuming steps in the container lifecycle. Research shows that time to take for pull operation accounts for 76% of container startup time[[FAST '16]](https://www.usenix.org/node/194431). *Stargz Snapshotter* is an implementation of snapshotter which aims to solve this problem leveraging [stargz image format by CRFS](https://github.com/google/crfs). The following histogram is the benchmarking result for startup time of several containers measured on Github Actions, using Docker Hub as a registry.
+Pulling image is one of the time-consuming steps in the container lifecycle. Research shows that time to take for pull operation accounts for 76% of container startup time[[FAST '16]](https://www.usenix.org/node/194431). *Stargz Snapshotter* is an implementation of snapshotter which aims to solve this problem by *lazy pulling* leveraging [stargz image format by CRFS](https://github.com/google/crfs). The following histogram is the benchmarking result for startup time of several containers measured on Github Actions, using Docker Hub as a registry.
 
 <img src="docs/images/benchmarking-result-288c338.png" width="600" alt="The benchmarking result on 288c338">
 
 `legacy` shows the startup performance when we use containerd's default snapshotter (`overlayfs`) with images copied from `docker.io/library` without optimization. For this configuration, containerd pulls entire image contents and `pull` operation takes accordingly. When we use stargz snapshotter with `stargz` images we are seeing performance improvement on the `pull` operation because containerd can start the container before the entire image contents locally available and fetches each file on-demand. But at the same time, we see the performance drawback for `run` operation because each access to files takes extra time for fetching them from the registry. When we use the further optimized version of images(`estargz`) we can mitigate the performance drawback observed in `stargz` images. This is because stargz snapshotter prefetches and caches some files which will be most likely accessed during container workload. Stargz snapshotter waits for the first container creation until the prefetch completes so `create` sometimes takes longer than other types of image. But this wait only occurs just after the pull completion until the prefetch completion and it's shorter than waiting for downloading all files of all layers.
 
-The above histogram is [the benchmarking result on the commit `288c338`](https://github.com/containerd/stargz-snapshotter/actions/runs/50632674). We are constantly measuring the performance of this snapshotter so you can get the latest one through the badge shown top of this doc. Please note that we sometimes see dispersion among the results because of the NW condition on the internet and/or the location of the instance in the Github Actions, etc. Our benchmarking method is based on [HelloBench](https://github.com/Tintri/hello-bench).
+The above histogram is [the benchmarking result on the commit `288c338`](https://github.com/containerd/stargz-snapshotter/actions/runs/50632674). We are constantly measuring the performance of this snapshotter so you can get the latest one through the badge shown top of this doc. Please note that we sometimes see dispersion among the results because of the NW condition on the internet and the location of the instance in the Github Actions, etc. Our benchmarking method is based on [HelloBench](https://github.com/Tintri/hello-bench).
 
 Stargz Snapshotter is a **non-core** sub-project of containerd.
 
-## Demo
+## Quick Start with Kubernetes
 
-You can test this snapshotter with the latest containerd. Though we still need patches on clients and we are working on, you can use [a customized version of ctr command](cmd/ctr-remote) for a quick tasting. For an overview of the snapshotter, please check [this doc](./docs/overview.md).
+For using stargz snapshotter on kubernetes nodes, you need the following configuration to containerd as well as run stargz snapshotter daemon on the node. We assume that you are using containerd newer than at least [commit `d8506bf`](https://github.com/containerd/containerd/commit/d8506bfd7b407dcb346149bcec3ed3c19244e3f1) as a CRI runtime.
 
-### Build and run the environment
+```toml
+# Plug stargz snapshotter into containerd
+# Containerd recognizes stargz snapshotter through specified socket address.
+# The specified address below is the default which stargz snapshotter listen to.
+[proxy_plugins]
+  [proxy_plugins.stargz]
+    type = "snapshot"
+    address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
 
-First, please put this repo on your `GOPATH`(`${GOPATH}/src/github.com/containerd/stargz-snapshotter`).
+# Use stargz snapshotter through CRI
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  snapshotter = "stargz"
+```
+
+This repo contains [a Dockerfile as a KinD node image](./Dockerfile) which includes the above configuration. You can use it with [KinD](https://github.com/kubernetes-sigs/kind) like the following,
+
+```console
+$ docker build -t stargz-kind-node https://github.com/containerd/stargz-snapshotter.git
+$ kind create cluster --name stargz-demo --image stargz-kind-node
+```
+
+Then you can create stargz pods on the cluster. In this example, we create a stargz-converted Node.js pod (`stargz/node:13.13-esgz`) as a demo.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nodejs
+spec:
+  containers:
+  - name: nodejs-stargz
+    image: stargz/node:13.13.0-esgz
+    command: ["node"]
+    args:
+    - -e
+    - var http = require('http');
+      http.createServer(function(req, res) {
+        res.writeHead(200);
+        res.end('Hello World!\n');
+      }).listen(80);
+    ports:
+    - containerPort: 80
+```
+
+The following command lazily pulls `stargz/node:13.13.0-esgz` from Docker Hub and creates the pod so the time to take for it is shorter than the original image `library/node:13.13`.
+
+```console
+$ kubectl --context kind-stargz-demo apply -f stargz-pod.yaml && kubectl get po nodejs -w
+$ kubectl --context kind-stargz-demo port-forward nodejs 8080:80 &
+$ curl 127.0.0.1:8080
+Hello World!
+```
+
+## Creating stargz images and further optimization
+
+For lazy pulling images, you need to prepare stargz images first. You can use [CRFS-official `stargzify`](https://github.com/google/crfs/tree/master/stargz/stargzify) command or our `ctr-remote` command which has further optimization functionality. You can also try our pre-converted images listed in [this doc](./docs/pre-converted-images.md).
+
+In this section, we introduce `ctr-remote` command for converting images into stargz with further optimization for the performance of reading files. On-demand lazy pulling improves the performance of pull but it has runtime performance penalty because reading files induce remotely downloading contents. For solving this, `ctr-remote` has *workload-based* optimization for images. This section shows how to convert and pull an image lazily using `ctr-remote` command and briefly describes workload-based optimization.
+
+First, prepare the demo environment with the following command (put this repo on `${GOPATH}/src/github.com/containerd/stargz-snapshotter`).
 
 ```console
 $ cd ${GOPATH}/src/github.com/containerd/stargz-snapshotter/script/demo
-$ docker-compose build --build-arg HTTP_PROXY=$HTTP_PROXY \
-                       --build-arg HTTPS_PROXY=$HTTP_PROXY \
-                       --build-arg http_proxy=$HTTP_PROXY \
-                       --build-arg https_proxy=$HTTP_PROXY \
-                       containerd_demo
+$ docker-compose build containerd_demo
 $ docker-compose up -d
 $ docker exec -it containerd_demo /bin/bash
 (inside container) # ./script/demo/run.sh
 ```
 
-### Prepare stargz-formatted image on a registry
+Generally, container images are built with purpose and the *workloads* are defined in the Dockerfile with some parameters including entrypoint command, environment variables and user. By default, `ctr-remote` optimizes the performance of reading files that are most likely accessed in the workload defined in the Dockerfile. You can also specify the custom workload using options.
 
-For making and pushing a stargz image, you can use CRFS-official `stargzify` command or our `ctr-remote` command which has further optimization functionality. In this example, we use `ctr-remote`. You can also try our pre-converted images listed in [this doc](./docs/pre-converted-images.md).
+The following example converts the legacy `library/ubuntu:18.04` image into stargz. The command also optimizes the image for the workload of executing `ls` on `/bin/bash`. The thing actually done is it runs the specified workload in a sandboxed environment and profiles all file accesses. Then these files are marked in the image as likely accessed also in production. Then it pushes the converted image to the local registry (`registry2:5000`). The converted image is still __docker-compatible__ so you can run it with other runtimes (e.g. Docker).
 
-We optimize the image for speeding up the execution of `ls` command on `bash`.
 ```console
-# ctr-remote image optimize --plain-http --entrypoint='[ "/bin/bash", "-c" ]' --args='[ "ls" ]' \
-             ubuntu:18.04 http://registry2:5000/ubuntu:18.04
+# ctr-remote image optimize --plain-http --entrypoint='[ "/bin/bash", "-c" ]' --args='[ "ls" ]' ubuntu:18.04 http://registry2:5000/ubuntu:18.04
 ```
-The converted image is still __docker-compatible__ so you can push/pull/run it with existing tools (e.g. docker).
 
-### Run the container with stargz snapshots
+Finally, the following commands pull the stargz image lazily. Stargz snapshotter prefetches files that are most likely accessed in the optimized workload, which hopefully increases the cache hit rate for that workload and mitigates runtime overheads as shown in the benchmarking result shown top of this doc.
 
-Layer downloads don't occur. So this "pull" operation ends soon.
 ```console
 # time ctr-remote images rpull --plain-http registry2:5000/ubuntu:18.04
 fetching sha256:728332a6... application/vnd.docker.distribution.manifest.v2+json
 fetching sha256:80026893... application/vnd.docker.container.image.v1+json
-
-real	0m0.176s
-user	0m0.025s
-sys	0m0.005s
 # ctr-remote run --rm -t --snapshotter=stargz registry2:5000/ubuntu:18.04 test /bin/bash
 root@8dab301bd68d:/# ls
 bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
@@ -67,6 +112,7 @@ We support the following methods for private repository authentication.
 - Using Kubernetes secrets (type = `kubernetes.io/dockerconfigjson`)
 
 Following example enables stargz snapshotter to access to private registries using `docker login` command. Stargz snapshotter gets credentials from `DOCKER_CONFIG`(or `~/.docker/config.json`).
+
 ```console
 # docker login
 (Enter username and password)
@@ -74,6 +120,7 @@ Following example enables stargz snapshotter to access to private registries usi
 ```
 
 Following configuration enables stargz snapshotter to access to private registries using kubernetes secrets (type = `kubernetes.io/dockerconfigjson`) in the cluster using kubeconfig files. You can specify the path of kubeconfig file to use with `kubeconfig_path` option. It's no problem that the specified file doesn't exist when this snapshotter starts. In this case, snapsohtter polls the file until actually provided. This is useful for some environments (e.g. single node cluster with containerized apiserver) where stargz snapshotter needs to start before everything, including booting containerd/kubelet/apiserver and configuring users/roles. If no `kubeconfig_path` is specified, snapshotter searches kubeconfig files from `KUBECONFIG` or `~/.kube/config`.
+
 ```toml
 [kubeconfig_keychain]
 enable_keychain = true

--- a/docs/pre-converted-images.md
+++ b/docs/pre-converted-images.md
@@ -26,6 +26,7 @@ In the following table, `Image Name` column contains placeholders `{{ suffix }}`
 |`docker.io/stargz/golang:1.12.9-{{ suffix }}`|Compiling and executing a program which prints `hello`|
 |`docker.io/stargz/jenkins:2.60.3-{{ suffix }}`|Code execution until up and ready message (`Jenkins is fully up and running`) is printed|
 |`docker.io/stargz/jruby:9.2.8.0-{{ suffix }}`|Printing `hello`|
+|`docker.io/stargz/node:13.13.0-{{ suffix }}`|Printing `hello`|
 |`docker.io/stargz/perl:5.30-{{ suffix }}`|Printing `hello`|
 |`docker.io/stargz/php:7.3.8-{{ suffix }}`|Printing `hello`|
 |`docker.io/stargz/pypy:3.5-{{ suffix }}`|Printing `hello`|

--- a/script/benchmark/hello-bench/src/hello.py
+++ b/script/benchmark/hello-bench/src/hello.py
@@ -107,6 +107,7 @@ class BenchRunner:
     CMD_ARG = {'perl:5.30': RunArgs(arg='perl -e \'print("hello\\n")\''),
                'python:3.7': RunArgs(arg='python -c \'print("hello")\''),
                'pypy:3.5': RunArgs(arg='pypy3 -c \'print("hello")\''),
+               'node:13.13.0': RunArgs(arg='node -e \'console.log("hello")\''),
     }
 
     # complete listing
@@ -126,6 +127,7 @@ class BenchRunner:
                  Bench('glassfish:4.1-jdk8', 'web-server'),
                  Bench('drupal:8.7.6'),
                  Bench('jenkins:2.60.3'),
+                 Bench('node:13.13.0'),
              ]])
 
     def __init__(self, user='library', mode=LEGACY_MODE, optimizer=DEFAULT_OPTIMIZER):


### PR DESCRIPTION
Now stargz snapshotter supports CRI and has Dockerfile for kind so brief demo for kubernetes should be valuable for kubernetes users.