### PR TITLE
Use single range request for registries which don't support multi range request

### DIFF
--- a/stargz/fs.go
+++ b/stargz/fs.go
@@ -184,6 +184,8 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	// will be stopped during the execution so this can avoid being disturbed for
 	// NW traffic by background tasks.
 	sr := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (n int, err error) {
+		fs.backgroundTaskManager.DoPrioritizedTask()
+		defer fs.backgroundTaskManager.DonePrioritizedTask()
 		return blob.ReadAt(p, offset)
 	}), 0, blob.Size())
 	gr, root, err := reader.NewReader(sr, fs.fsCache)

--- a/stargz/remote/util.go
+++ b/stargz/remote/util.go
@@ -31,6 +31,19 @@ func (c region) size() int64 {
 	return c.e - c.b + 1
 }
 
+func superRegion(regs []region) region {
+	s := regs[0]
+	for _, reg := range regs {
+		if reg.b < s.b {
+			s.b = reg.b
+		}
+		if reg.e > s.e {
+			s.e = reg.e
+		}
+	}
+	return s
+}
+
 // regionSet is a set of regions
 type regionSet struct {
 	rs []region


### PR DESCRIPTION
Some cloud-provided registries including GCR doesn't support multi range request (e.g. `range: bytes=0-3,5-9,16-20`)
For example, when we pull an image from GCR,
```console
# ctr-remote image rpull gcr.io/stargz-275102/ubuntu:18.04
fetching sha256:36d56a39... application/vnd.docker.distribution.manifest.v2+json
fetching sha256:b993a6c1... application/vnd.docker.container.image.v1+json
fetching sha256:ce77d9a4... application/vnd.docker.image.rootfs.diff.tar.gzip
fetching sha256:cc65679c... application/vnd.docker.image.rootfs.diff.tar.gzip
fetching sha256:dcc819e8... application/vnd.docker.image.rootfs.diff.tar.gzip
fetching sha256:1b677c82... application/vnd.docker.image.rootfs.diff.tar.gzip
```
We get 400 response because of multi range request.
```
DEBU[2020-04-23T02:27:15.607869311Z] failed to read layer                          digest="sha256:cc65679ceb37dd5d861fe76ced27bbca8897d3c73f9e5a4422491c5932837804" error="failed to parse stargz: error reading footer: unexpected status code on \"https://storage.googleapis.com/artifacts.stargz-275102.appspot.com/containers/images/sha256:cc65679ceb37dd5d861fe76ced27bbca8897d3c73f9e5a4422491c5932837804\": 400 Bad Request" mountpoint=/var/lib/containerd-stargz-grpc/snapshotter/snapshots/1/fs ref="gcr.io/stargz-275102/ubuntu:18.04"
```

This commit solves this issue by using a single request instead.
We might need tests with cloud-provided registries. I'll add them with another PR.
