### PR TITLE
Resolve layers in parallel

### DIFF
--- a/stargz/remote/blob.go
+++ b/stargz/remote/blob.go
@@ -171,6 +171,9 @@ func (b *blob) fetchRange(target region, opts ...Option) (map[region][]byte, err
 		return nil, err
 	}
 
+	// Update the check timer because we succeeded to access the blob
+	b.lastCheck = time.Now()
+
 	// chunk and cache responsed data
 	// TODO: Reorganize remoteData to make it be aligned by chunk size
 	b.fetchedRegionSetMu.Lock()


### PR DESCRIPTION
Currently, resolving each layer in an image are done sequentially. But it can be done in parallel by passing all layer digests in the image to `Prepare` of this snapshotter.

This commit enables this by adding a new optional label `containerd.io/snapshot/remote/stargz.chain` for passing all digests in the target image and by resolving all digests in parallel.
