### PR TITLE
Vendor google/go-containerregistry 48f605c3b60a55e8029e3ec6d98f36bd43d59a9c

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gogo/googleapis v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9
 	github.com/google/crfs v0.0.0-20191108021818-71d77da419c9
-	github.com/google/go-containerregistry v0.0.0-20200320200342-35f57d7d4930
+	github.com/google/go-containerregistry v0.0.0-20200425101607-48f605c3b60a
 	github.com/hanwen/go-fuse v1.0.0
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1.0.20180430190053-c9281466c8b2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,7 +186,6 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
@@ -200,8 +199,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-containerregistry v0.0.0-20191010200024-a3d713f9b7f8/go.mod h1:KyKXa9ciM8+lgMXwOVsXi7UxGrsf9mM61Mzs+xKUrKE=
-github.com/google/go-containerregistry v0.0.0-20200320200342-35f57d7d4930 h1:dRNlOGHybvWTNJFJgF/3t2kTTqVF9Ve4EXqtHzivZd8=
-github.com/google/go-containerregistry v0.0.0-20200320200342-35f57d7d4930/go.mod h1:pD1UFYs7MCAx+ZLShBdttcaOSbyc8F9Na/9IZLNwJeA=
+github.com/google/go-containerregistry v0.0.0-20200425101607-48f605c3b60a h1:ov0+Bhfvpg4POSTOvH0Uw9wzaswlFvVGhiCmIyXNkkQ=
+github.com/google/go-containerregistry v0.0.0-20200425101607-48f605c3b60a/go.mod h1:pD1UFYs7MCAx+ZLShBdttcaOSbyc8F9Na/9IZLNwJeA=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -559,7 +558,6 @@ google.golang.org/genproto v0.0.0-20181219182458-5a97ab628bfb/go.mod h1:7Ep/1NZk
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
-google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873 h1:nfPFGzJkUDX6uBmpN/pSw7MbOAWegH5QDQuoXFHedLg=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
@@ -570,7 +568,6 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
-google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.28.1 h1:C1QC6KzgSiLyBabDi87BbjaGreoRgGUF5nOyvfrAZ1k=

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/tarball/write.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/tarball/write.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -88,22 +90,41 @@ func MultiRefWrite(refToImage map[name.Reference]v1.Image, w io.Writer) error {
 	tf := tar.NewWriter(w)
 	defer tf.Close()
 
+	m, err := processImages(refToImage, tf)
+	if err != nil {
+		return err
+	}
+
+	mBytes, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return writeTarEntry(tf, "manifest.json", bytes.NewReader(mBytes), int64(len(mBytes)))
+}
+
+// processImages writes the images to the provider tar.Writer. Returns the manifest
+// for the written images as Manifest.`If the tar.Writer is nil, will just return
+// the Manifest.
+func processImages(refToImage map[name.Reference]v1.Image, tf *tar.Writer) (Manifest, error) {
 	imageToTags := dedupRefToImage(refToImage)
 	var m Manifest
 
 	seenLayerDigests := make(map[string]struct{})
+
 	for img, tags := range imageToTags {
 		// Write the config.
 		cfgName, err := img.ConfigName()
 		if err != nil {
-			return err
+			return nil, err
 		}
-		cfgBlob, err := img.RawConfigFile()
-		if err != nil {
-			return err
-		}
-		if err := writeTarEntry(tf, cfgName.String(), bytes.NewReader(cfgBlob), int64(len(cfgBlob))); err != nil {
-			return err
+		if tf != nil {
+			cfgBlob, err := img.RawConfigFile()
+			if err != nil {
+				return nil, err
+			}
+			if err := writeTarEntry(tf, cfgName.String(), bytes.NewReader(cfgBlob), int64(len(cfgBlob))); err != nil {
+				return nil, err
+			}
 		}
 
 		// Store foreign layer info.
@@ -112,13 +133,13 @@ func MultiRefWrite(refToImage map[name.Reference]v1.Image, w io.Writer) error {
 		// Write the layers.
 		layers, err := img.Layers()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		layerFiles := make([]string, len(layers))
 		for i, l := range layers {
 			d, err := l.Digest()
 			if err != nil {
-				return err
+				return nil, err
 			}
 			// Munge the file name to appease ancient technology.
 			//
@@ -139,27 +160,29 @@ func MultiRefWrite(refToImage map[name.Reference]v1.Image, w io.Writer) error {
 			// Add to LayerSources if it's a foreign layer.
 			desc, err := partial.BlobDescriptor(img, d)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if !desc.MediaType.IsDistributable() {
 				diffid, err := partial.BlobToDiffID(img, d)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				layerSources[diffid] = *desc
 			}
 
-			r, err := l.Compressed()
-			if err != nil {
-				return err
-			}
-			blobSize, err := l.Size()
-			if err != nil {
-				return err
-			}
+			if tf != nil {
+				r, err := l.Compressed()
+				if err != nil {
+					return nil, err
+				}
+				blobSize, err := l.Size()
+				if err != nil {
+					return nil, err
+				}
 
-			if err := writeTarEntry(tf, layerFiles[i], r, blobSize); err != nil {
-				return err
+				if err := writeTarEntry(tf, layerFiles[i], r, blobSize); err != nil {
+					return nil, err
+				}
 			}
 		}
 
@@ -171,12 +194,13 @@ func MultiRefWrite(refToImage map[name.Reference]v1.Image, w io.Writer) error {
 			LayerSources: layerSources,
 		})
 	}
+	// sort by name of the repotags so it is consistent. Alternatively, we could sort by hash of the
+	// descriptor, but that would make it hard for humans to process
+	sort.Slice(m, func(i, j int) bool {
+		return strings.Join(m[i].RepoTags, ",") < strings.Join(m[j].RepoTags, ",")
+	})
 
-	mBytes, err := json.Marshal(m)
-	if err != nil {
-		return err
-	}
-	return writeTarEntry(tf, "manifest.json", bytes.NewReader(mBytes), int64(len(mBytes)))
+	return m, nil
 }
 
 func dedupRefToImage(refToImage map[name.Reference]v1.Image) map[v1.Image][]string {
@@ -199,7 +223,7 @@ func dedupRefToImage(refToImage map[name.Reference]v1.Image) map[v1.Image][]stri
 	return imageToTags
 }
 
-// Writes a file to the provided writer with a corresponding tar header
+// writeTarEntry writes a file to the provided writer with a corresponding tar header
 func writeTarEntry(tf *tar.Writer, path string, r io.Reader, size int64) error {
 	hdr := &tar.Header{
 		Mode:     0644,
@@ -212,4 +236,10 @@ func writeTarEntry(tf *tar.Writer, path string, r io.Reader, size int64) error {
 	}
 	_, err := io.Copy(tf, r)
 	return err
+}
+
+// ComputeManifest get the manifest.json that will be written to the tarball
+// for multiple references
+func ComputeManifest(refToImage map[name.Reference]v1.Image) (Manifest, error) {
+	return processImages(refToImage, nil)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-containerregistry v0.0.0-20200320200342-35f57d7d4930
+# github.com/google/go-containerregistry v0.0.0-20200425101607-48f605c3b60a
 github.com/google/go-containerregistry/pkg/authn
 github.com/google/go-containerregistry/pkg/internal/retry
 github.com/google/go-containerregistry/pkg/internal/retry/wait


### PR DESCRIPTION
Notable change:
- Improving connection reusing for better performance of connecting to registries: https://github.com/google/go-containerregistry/pull/712