### PR TITLE
Use finite caches for pools

### DIFF
--- a/script/cri/test-stargz.sh
+++ b/script/cri/test-stargz.sh
@@ -112,7 +112,7 @@ cat "${IMAGE_LIST}" | sed -E 's/^([^/]*).*/\1/g' | sort | uniq | while read DOMA
 endpoint = ["http://${REGISTRY_HOST}:5000"]
 EOF
     cat <<EOF >> "${SNAPSHOTTER_CONFIG}"
-[[resolver."${DOMAIN}".mirrors]]
+[[resolver.host."${DOMAIN}".mirrors]]
 host = "${REGISTRY_HOST}:5000"
 insecure = true
 EOF

--- a/script/demo/config.stargz.toml
+++ b/script/demo/config.stargz.toml
@@ -1,3 +1,3 @@
-[[resolver."registry2:5000".mirrors]]
+[[resolver.host."registry2:5000".mirrors]]
 host = "registry2:5000"
 insecure = true

--- a/script/integration/containerd/config.stargz.toml
+++ b/script/integration/containerd/config.stargz.toml
@@ -1,6 +1,6 @@
 [blob]
 check_always = true
 
-[[resolver."registry-integration:5000".mirrors]]
+[[resolver.host."registry-integration:5000".mirrors]]
 host = "registry-alt:5000"
 insecure = true


### PR DESCRIPTION
Currently, filesystem uses infinitely growing map for pooling connections, etc,
which potentially run out available memory on the system. This commit fixes this
by using finite LRU caches as these pools.
