### PR TITLE
Improve memory usage

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -106,10 +106,14 @@ func (dc *directoryCache) Fetch(blobHash string) (p []byte, err error) {
 }
 
 func (dc *directoryCache) Add(blobHash string, p []byte) {
-	dc.cacheMu.Lock()
-	defer dc.cacheMu.Unlock()
+	// Copy the original data for avoiding the cached contents to be edited accidentally
+	p2 := make([]byte, len(p))
+	copy(p2, p)
+	p = p2
 
+	dc.cacheMu.Lock()
 	dc.cache.Add(blobHash, p)
+	dc.cacheMu.Unlock()
 
 	addFunc := func() {
 		dc.fileMu.Lock()

--- a/cmd/ctr-remote/sorter/sorter.go
+++ b/cmd/ctr-remote/sorter/sorter.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/containerd/stargz-snapshotter/cmd/ctr-remote/util"
-	"github.com/containerd/stargz-snapshotter/stargz/reader"
+	"github.com/containerd/stargz-snapshotter/stargz"
 	"github.com/pkg/errors"
 )
 
@@ -49,7 +49,7 @@ func Sort(in io.ReaderAt, log []string) (io.Reader, error) {
 	if len(log) == 0 {
 		sorted.add(&tarEntry{
 			header: &tar.Header{
-				Name:     reader.NoPrefetchLandmark,
+				Name:     stargz.NoPrefetchLandmark,
 				Typeflag: tar.TypeReg,
 				Size:     int64(len([]byte{landmarkContents})),
 			},
@@ -58,7 +58,7 @@ func Sort(in io.ReaderAt, log []string) (io.Reader, error) {
 	} else {
 		sorted.add(&tarEntry{
 			header: &tar.Header{
-				Name:     reader.PrefetchLandmark,
+				Name:     stargz.PrefetchLandmark,
 				Typeflag: tar.TypeReg,
 				Size:     int64(len([]byte{landmarkContents})),
 			},
@@ -108,7 +108,7 @@ func importTar(in io.ReaderAt) (*tarFile, error) {
 				return nil, errors.Wrap(err, "failed to parse tar file")
 			}
 		}
-		if h.Name == reader.PrefetchLandmark || h.Name == reader.NoPrefetchLandmark {
+		if h.Name == stargz.PrefetchLandmark || h.Name == stargz.NoPrefetchLandmark {
 			// Ignore existing landmark
 			continue
 		}

--- a/cmd/ctr-remote/sorter/sorter_test.go
+++ b/cmd/ctr-remote/sorter/sorter_test.go
@@ -32,7 +32,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/stargz-snapshotter/stargz/reader"
+	"github.com/containerd/stargz-snapshotter/stargz"
 )
 
 func TestSort(t *testing.T) {
@@ -411,7 +411,7 @@ type tarent struct {
 func prefetchLandmark() tarent {
 	return tarent{
 		header: &tar.Header{
-			Name:     reader.PrefetchLandmark,
+			Name:     stargz.PrefetchLandmark,
 			Typeflag: tar.TypeReg,
 			Size:     int64(len([]byte{landmarkContents})),
 		},
@@ -422,7 +422,7 @@ func prefetchLandmark() tarent {
 func noPrefetchLandmark() tarent {
 	return tarent{
 		header: &tar.Header{
-			Name:     reader.NoPrefetchLandmark,
+			Name:     stargz.NoPrefetchLandmark,
 			Typeflag: tar.TypeReg,
 			Size:     int64(len([]byte{landmarkContents})),
 		},

--- a/script/demo/docker-compose.yml
+++ b/script/demo/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 services:
   containerd_demo:
     build: .
@@ -16,13 +16,25 @@ services:
     - https_proxy=${https_proxy}
     - GOPATH=/go
     tmpfs:
-    - /var/lib/containerd
-    - /var/lib/containerd-stargz-grpc
-    - /run/containerd-stargz-grpc
     - /tmp:exec,mode=777
     volumes:
     - /dev/fuse:/dev/fuse
     - "${GOPATH}/src/github.com/containerd/stargz-snapshotter:/go/src/github.com/containerd/stargz-snapshotter:ro"
+    - type: volume
+      source: demo-containerd-data
+      target: /var/lib/containerd
+      volume:
+        nosuid: false
+    - type: volume
+      source: demo-containerd-stargz-grpc-data
+      target: /var/lib/containerd-stargz-grpc
+      volume:
+        nosuid: false
+    - type: volume
+      source: demo-containerd-stargz-grpc-status
+      target: /run/containerd-stargz-grpc
+      volume:
+        nosuid: false
   registry2:
     image: registry:2
     container_name: registry2
@@ -31,3 +43,7 @@ services:
     - HTTPS_PROXY=${HTTPS_PROXY}
     - http_proxy=${http_proxy}
     - https_proxy=${https_proxy}
+volumes:
+  demo-containerd-data:
+  demo-containerd-stargz-grpc-data:
+  demo-containerd-stargz-grpc-status:

--- a/script/integration/test.sh
+++ b/script/integration/test.sh
@@ -66,17 +66,17 @@ services:
     - ${AUTH_DIR}:/auth
     - /dev/fuse:/dev/fuse
     - type: volume
-      source: containerd-data
+      source: integration-containerd-data
       target: /var/lib/containerd
       volume:
         nosuid: false
     - type: volume
-      source: containerd-stargz-grpc-data
+      source: integration-containerd-stargz-grpc-data
       target: /var/lib/containerd-stargz-grpc
       volume:
         nosuid: false
     - type: volume
-      source: containerd-stargz-grpc-status
+      source: integration-containerd-stargz-grpc-status
       target: /run/containerd-stargz-grpc
       volume:
         nosuid: false
@@ -99,9 +99,9 @@ services:
     image: registry:2
     container_name: registry-alt
 volumes:
-  containerd-data:
-  containerd-stargz-grpc-data:
-  containerd-stargz-grpc-status:
+  integration-containerd-data:
+  integration-containerd-stargz-grpc-data:
+  integration-containerd-stargz-grpc-status:
 EOF
 
 echo "Testing..."


### PR DESCRIPTION
Related: #88 

Recently it turned out stargz filesystem uses too much memory.
This commit improves the memory usage by the following fixes:

- Do not use bufio with huge buffer
- Make sure to close gzip Reader
- Make the default size of LRU memory cache smaller
- Avoid to loading whole prefetching regions to memory at once
- Mimimize []byte allocation and keep the scope as small as possible

## `ps` output after KinD demo on README

measured on Ubuntu 18.04(Linux 4.15.0-62-generic).

### `master` branch

```console
$ docker exec -it stargz-demo-control-plane  ps auxww | grep -e containerd-stargz-grpc -e MEM | grep -v grep
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root       148 27.7 21.2 9871492 3428132 ?     Ssl  06:57   1:31 /usr/local/bin/containerd-stargz-grpc --log-level=debug --config=/etc/containerd-stargz-grpc/config.toml
```

### `mem` branch

```console
$ docker exec -it stargz-demo-control-plane  ps auxww | grep -e containerd-stargz-grpc -e MEM | grep -v grep
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root       148 26.1  2.8 2904492 463216 ?      Ssl  07:06   1:00 /usr/local/bin/containerd-stargz-grpc --log-level=debug --config=/etc/containerd-stargz-grpc/config.toml
```
