### PR TITLE
Define log message for failure of remote snapshot preparation

### DIFF
--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -55,9 +55,8 @@ func main() {
 		log.L.WithError(err).Fatal("failed to prepare logger")
 	}
 	logrus.SetLevel(lvl)
-	logrus.SetFormatter(&logrus.TextFormatter{
+	logrus.SetFormatter(&logrus.JSONFormatter{
 		TimestampFormat: log.RFC3339NanoFixed,
-		FullTimestamp:   true,
 	})
 
 	var (

--- a/script/benchmark/hello-bench/Dockerfile
+++ b/script/benchmark/hello-bench/Dockerfile
@@ -16,7 +16,7 @@ FROM golang:1.13
 
 # basic tools
 RUN apt-get update -y && \
-    apt-get install --no-install-recommends -y libbtrfs-dev libseccomp-dev fuse python \
+    apt-get install --no-install-recommends -y libbtrfs-dev libseccomp-dev fuse python jq \
             apt-transport-https software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \

--- a/script/cri/test.sh
+++ b/script/cri/test.sh
@@ -42,7 +42,7 @@ FROM ${NODE_BASE_IMAGE_NAME}
 
 ENV PATH=$PATH:/usr/local/go/bin
 ENV GOPATH=/go
-RUN apt install -y --no-install-recommends git make gcc build-essential && \
+RUN apt install -y --no-install-recommends git make gcc build-essential jq && \
     curl https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz \
     | tar -C /usr/local -xz && \
     go get -u github.com/onsi/ginkgo/ginkgo && \

--- a/script/integration/containerd/Dockerfile
+++ b/script/integration/containerd/Dockerfile
@@ -18,7 +18,7 @@ FROM golang:1.13
 # docker-ce-cli is used only to log into registry with ~/.docker/config.json
 RUN apt-get update -y && \
     apt-get --no-install-recommends install -y fuse iptables libbtrfs-dev libseccomp-dev \
-            apt-transport-https gnupg2 software-properties-common && \
+            apt-transport-https gnupg2 software-properties-common jq && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
       "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \


### PR DESCRIPTION
Currently, we have two ways to check the success of remote snapshot
preparation. Integration test checks output messages from `ctr-remote`
command. CRI test checks the log from stargz daemon. We should unify them
because we want to keep the consideration the about log messages as small as
possible.

We use the log from stargz daemon for both tests. For preventing the message
from accidentally changed, this commit defines the message as `const` value and
adds some comments.

This commit also adds this check to the benchmarking script.
