### PR TITLE
Use cri-tools version 75ef33dc2b4ecb08e0237d91de1b664909d262de

### DIFF
--- a/script/cri/test.sh
+++ b/script/cri/test.sh
@@ -46,9 +46,10 @@ RUN apt install -y --no-install-recommends git make gcc build-essential jq && \
     curl https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz \
     | tar -C /usr/local -xz && \
     go get -u github.com/onsi/ginkgo/ginkgo && \
-    git clone -b v1.18.0 https://github.com/kubernetes-sigs/cri-tools \
+    git clone https://github.com/kubernetes-sigs/cri-tools \
               \${GOPATH}/src/github.com/kubernetes-sigs/cri-tools && \
     cd \${GOPATH}/src/github.com/kubernetes-sigs/cri-tools && \
+    git checkout 75ef33dc2b4ecb08e0237d91de1b664909d262de && \
     make critest && make install-critest -e BINDIR=\${GOPATH}/bin && \
     git clone -b v1.11.1 https://github.com/containerd/cri \
               \${GOPATH}/src/github.com/containerd/cri && \


### PR DESCRIPTION
This mitigates recent flaky in our CI; See also https://github.com/kubernetes-sigs/cri-tools/pull/618 .