### PR TITLE
Add `Unmount` API to the FileSystem

### DIFF
--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -415,6 +415,10 @@ func (fs *bindFs) Check(ctx context.Context, mountpoint string) error {
 	return nil
 }
 
+func (fs *bindFs) Unmount(ctx context.Context, mountpoint string) error {
+	return syscall.Unmount(mountpoint, 0)
+}
+
 func dummyFileSystem() FileSystem { return &dummyFs{} }
 
 type dummyFs struct{}
@@ -424,6 +428,10 @@ func (fs *dummyFs) Mount(ctx context.Context, mountpoint string, labels map[stri
 }
 
 func (fs *dummyFs) Check(ctx context.Context, mountpoint string) error {
+	return fmt.Errorf("dummy")
+}
+
+func (fs *dummyFs) Unmount(ctx context.Context, mountpoint string) error {
 	return fmt.Errorf("dummy")
 }
 


### PR DESCRIPTION
Our `FileSystem` implementation holds a `map[string]*layer` for tracking the
state of each stargz mountpoint. Currently, `FileSystem` interface defined in
`snapshot` package doesn't have `Unmount` API and `syscall.Unmount` is directly
called to the mountpoint. Filesystem implementation asynchronously finalizes
that `map`, which is hard to be done safely and rather race condition will possibly
occur.

This is good timing for us to add `Unmount` method to the `FileSystem` API,
which delegates the actual `unmount` task to the filesystem implementation. This
also enables the filesystem to do necessary finalization before/after the
`unmount` syscall.
