### PR TITLE
Use htpasswd command on the system during test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-18.04
     name: Integration
     steps:
+    - name: Install htpasswd for setting up private registry
+      run: sudo apt-get --no-install-recommends install -y apache2-utils
     - uses: actions/checkout@v2
     - name: Run integration test
       run: make integration
@@ -36,6 +38,8 @@ jobs:
     runs-on: ubuntu-18.04
     name: Optimize
     steps:
+    - name: Install htpasswd for setting up private registry
+      run: sudo apt-get --no-install-recommends install -y apache2-utils
     - uses: actions/checkout@v2
     - name: Run test for optimize subcommand of ctr-remote
       run: make test-optimize
@@ -43,6 +47,8 @@ jobs:
     runs-on: ubuntu-18.04
     name: PullSecrets
     steps:
+    - name: Install htpasswd for setting up private registry
+      run: sudo apt-get --no-install-recommends install -y apache2-utils
     - uses: actions/checkout@v2
     - name: Run test for pulling image from private registry on Kubernetes
       run: make test-pullsecrets

--- a/script/util/utils.sh
+++ b/script/util/utils.sh
@@ -25,7 +25,7 @@ function prepare_creds {
     openssl req -subj "/C=JP/ST=Remote/L=Snapshotter/O=TestEnv/OU=Integration/CN=${REGISTRY_HOST}" \
             -newkey rsa:2048 -nodes -keyout "${OUTPUT}/certs/domain.key" \
             -x509 -days 365 -out "${OUTPUT}/certs/domain.crt"
-    docker run --entrypoint htpasswd registry:2 -Bbn "${USER}" "${PASS}" > "${OUTPUT}/auth/htpasswd"
+    htpasswd -Bbn "${USER}" "${PASS}" > "${OUTPUT}/auth/htpasswd"
 }
 
 # Check if all snapshots logged in the specified file are prepared as remote snapshots.


### PR DESCRIPTION
The latest official registry:2 docker image doesn't contain htpasswd command which is used in our CI for setting up private registries for testing.
This seems the cause of the current CI failure.
