### PR TITLE
Extend stargz for content verification

### DIFF
--- a/script/optimize/optimize/Dockerfile
+++ b/script/optimize/optimize/Dockerfile
@@ -21,4 +21,5 @@ RUN apt-get update -y && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository \
       "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update -y && apt-get --no-install-recommends install -y docker-ce-cli runc
+    apt-get update -y && apt-get --no-install-recommends install -y docker-ce-cli runc && \
+    GO111MODULE=on go install github.com/google/go-containerregistry/cmd/crane

--- a/stargz/verify/verify.go
+++ b/stargz/verify/verify.go
@@ -1,0 +1,232 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package verify
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/google/crfs/stargz"
+	"github.com/pkg/errors"
+)
+
+const (
+	// TOCJSONDigestAnnotation is an annotation for image manifest. This stores the
+	// digest of the TOC JSON
+	TOCJSONDigestAnnotation = "containerd.io/snapshot/stargz/toc.digest"
+)
+
+// jtoc is a TOC JSON schema which contains additional fields for chunk-level
+// content verification. This is still backward compatible to the official
+// definition:
+// https://github.com/google/crfs/blob/71d77da419c90be7b05d12e59945ac7a8c94a543/stargz/stargz.go
+type jtoc struct {
+
+	// Version is a field to store the version information of TOC JSON. This field
+	// is unused in this package but is for the backwards-compatibility to stargz.
+	Version int `json:"version"`
+
+	// Entries is a field to store TOCEntries in this archive. These TOCEntries
+	// are extended in this package for content verification, with keeping the
+	// backward-compatibility with stargz.
+	Entries []*TOCEntry `json:"entries"`
+}
+
+// TOCEntry extends stargz.TOCEntry with an additional field for storing chunks
+// digests.
+type TOCEntry struct {
+	stargz.TOCEntry
+
+	// ChunkDigest stores a digest of the chunk. This must be formed
+	// as "sha256:0123abcd...".
+	ChunkDigest string `json:"chunkDigest,omitempty"`
+}
+
+// NewVerifiableStagz takes stargz archive and returns modified one which contains
+// contents digests in the TOC JSON. This also returns the digest of TOC JSON
+// itself which can be used for verifying the TOC JSON.
+func NewVerifiableStagz(sgz *io.SectionReader) (newSgz io.Reader, jtocDigest string, err error) {
+	// Extract TOC JSON and some related parts
+	toc, tocOffset, footer, err := extractTOCJSON(sgz)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "failed to extract TOC JSON")
+	}
+
+	// Rewrite the original TOC JSON with chunks digests
+	if err := addDigests(toc, sgz); err != nil {
+		return nil, "", errors.Wrap(err, "failed to digest stargz")
+	}
+	tocJSON, err := json.Marshal(toc)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "failed to marshal TOC JSON")
+	}
+	tocHash := sha256.New()
+	if _, err := io.CopyN(tocHash, bytes.NewReader(tocJSON), int64(len(tocJSON))); err != nil {
+		return nil, "", errors.Wrap(err, "failed to calculate digest of TOC JSON")
+	}
+	pr, pw := io.Pipe()
+	go func() {
+		zw, err := gzip.NewWriterLevel(pw, gzip.BestCompression)
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		zw.Extra = []byte("stargz.toc") // this magic string might not be necessary but let's follow the official behaviour: https://github.com/google/crfs/blob/71d77da419c90be7b05d12e59945ac7a8c94a543/stargz/stargz.go#L596
+		tw := tar.NewWriter(zw)
+		if err := tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     stargz.TOCTarName,
+			Size:     int64(len(tocJSON)),
+		}); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if _, err := tw.Write(tocJSON); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if err := tw.Close(); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if err := zw.Close(); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		pw.Close()
+	}()
+
+	// Reconstruct stargz file with the modified TOC JSON
+	if _, err := sgz.Seek(0, io.SeekStart); err != nil {
+		return nil, "", errors.Wrap(err, "failed to reset the seek position of stargz")
+	}
+	if _, err := footer.Seek(0, io.SeekStart); err != nil {
+		return nil, "", errors.Wrap(err, "failed to reset the seek position of footer")
+	}
+	return io.MultiReader(
+		io.LimitReader(sgz, tocOffset), // Original stargz (before TOC JSON)
+		pr,                             // Rewritten TOC JSON
+		footer,                         // Unmodified footer (because tocOffset is unchanged)
+	), fmt.Sprintf("sha256:%x", tocHash.Sum(nil)), nil
+}
+
+// extractTOCJSON extracts TOC JSON from the given stargz reader, with avoiding
+// scanning the entire blob leveraging its footer. The parsed TOC JSON contains
+// additional fields usable for chunk-level content verification.
+func extractTOCJSON(sgz *io.SectionReader) (toc *jtoc, tocOffset int64, footer io.ReadSeeker, err error) {
+	// Parse stargz footer and get the offset of TOC JSON
+	if sgz.Size() < stargz.FooterSize {
+		return nil, 0, nil, errors.New("stargz data is too small")
+	}
+	footerReader := io.NewSectionReader(sgz, sgz.Size()-stargz.FooterSize, stargz.FooterSize)
+	zr, err := gzip.NewReader(footerReader)
+	if err != nil {
+		return nil, 0, nil, errors.Wrap(err, "failed to uncompress footer")
+	}
+	defer zr.Close()
+	if len(zr.Header.Extra) != 22 {
+		return nil, 0, nil, errors.Wrap(err, "invalid extra size; must be 22 bytes")
+	} else if string(zr.Header.Extra[16:]) != "STARGZ" {
+		return nil, 0, nil, errors.New("invalid footer; extra must contain magic string \"STARGZ\"")
+	}
+	tocOffset, err = strconv.ParseInt(string(zr.Header.Extra[:16]), 16, 64)
+	if err != nil {
+		return nil, 0, nil, errors.Wrap(err, "invalid footer; failed to get the offset of TOC JSON")
+	} else if tocOffset > sgz.Size() {
+		return nil, 0, nil, fmt.Errorf("invalid footer; offset of TOC JSON is too large (%d > %d)",
+			tocOffset, sgz.Size())
+	}
+
+	// Decode the TOC JSON
+	tocReader := io.NewSectionReader(sgz, tocOffset, sgz.Size()-tocOffset-stargz.FooterSize)
+	if err := zr.Reset(tocReader); err != nil {
+		return nil, 0, nil, errors.Wrap(err, "failed to uncompress TOC JSON targz entry")
+	}
+	tr := tar.NewReader(zr)
+	h, err := tr.Next()
+	if err != nil {
+		return nil, 0, nil, errors.Wrap(err, "failed to get TOC JSON tar entry")
+	} else if h.Name != stargz.TOCTarName {
+		return nil, 0, nil, fmt.Errorf("invalid TOC JSON tar entry name %q; must be %q",
+			h.Name, stargz.TOCTarName)
+	}
+	toc = new(jtoc)
+	if err := json.NewDecoder(tr).Decode(&toc); err != nil {
+		return nil, 0, nil, errors.Wrap(err, "failed to decode TOC JSON")
+	}
+	if _, err := tr.Next(); err != io.EOF {
+		// We only accept stargz file that its TOC JSON resides at the end of that
+		// file to avoid changing the offsets of the following file entries by
+		// rewriting TOC JSON (The official stargz lib also puts TOC JSON at the end
+		// of the stargz file at this mement).
+		// TODO: in the future, we should relax this restriction.
+		return nil, 0, nil, errors.New("TOC JSON must reside at the end of targz")
+	}
+
+	return toc, tocOffset, footerReader, nil
+}
+
+// addDigests calculates chunk digests and adds them to the TOC JSON
+func addDigests(toc *jtoc, sgz *io.SectionReader) error {
+	var (
+		sizeMap = make(map[string]int64)
+		zr      *gzip.Reader
+		err     error
+	)
+	for _, e := range toc.Entries {
+		if e.Type == "reg" || e.Type == "chunk" {
+			if e.Type == "reg" {
+				sizeMap[e.Name] = e.Size // saves the file size for futural use
+			}
+			size := e.ChunkSize
+			if size == 0 {
+				// In the seriarized form, ChunkSize field of the last chunk in a file
+				// is zero so we need to calculate it.
+				size = sizeMap[e.Name] - e.ChunkOffset
+			}
+			if size > 0 {
+				if _, err := sgz.Seek(e.Offset, io.SeekStart); err != nil {
+					return errors.Wrapf(err, "failed to seek to %q", e.Name)
+				}
+				if zr == nil {
+					if zr, err = gzip.NewReader(sgz); err != nil {
+						return errors.Wrapf(err, "failed to decomp %q", e.Name)
+					}
+				} else {
+					if err := zr.Reset(sgz); err != nil {
+						return errors.Wrapf(err, "failed to decomp %q", e.Name)
+					}
+				}
+				digest := sha256.New()
+				if _, err := io.CopyN(digest, zr, size); err != nil {
+					return errors.Wrapf(err, "failed to read %q; (file size: %d, e.Offset: %d, e.ChunkOffset: %d, chunk size: %d, end offset: %d, size of stargz file: %d)",
+						e.Name, sizeMap[e.Name], e.Offset, e.ChunkOffset, size,
+						e.Offset+size, sgz.Size())
+				}
+				e.ChunkDigest = fmt.Sprintf("sha256:%x", digest.Sum(nil))
+			}
+		}
+	}
+
+	return nil
+}

--- a/stargz/verify/verify_test.go
+++ b/stargz/verify/verify_test.go
@@ -1,0 +1,339 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package verify
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/crfs/stargz"
+)
+
+const chunkSize = 3
+
+func TestDigest(t *testing.T) {
+	tests := []struct {
+		name    string
+		tarInit func(t *testing.T, dgstMap map[string]string) (stream io.ReadCloser)
+	}{
+		{
+			name: "no-regfile",
+			tarInit: func(t *testing.T, dgstMap map[string]string) (stream io.ReadCloser) {
+				return tarStream(
+					directory("test/"),
+				)
+			},
+		},
+		{
+			name: "small-files",
+			tarInit: func(t *testing.T, dgstMap map[string]string) (stream io.ReadCloser) {
+				return tarStream(
+					regDigest(t, "baz.txt", "", dgstMap),
+					regDigest(t, "foo.txt", "a", dgstMap),
+					directory("test/"),
+					regDigest(t, "test/bar.txt", "bbb", dgstMap),
+				)
+			},
+		},
+		{
+			name: "big-files",
+			tarInit: func(t *testing.T, dgstMap map[string]string) (stream io.ReadCloser) {
+				return tarStream(
+					regDigest(t, "baz.txt", "bazbazbazbazbazbazbaz", dgstMap),
+					regDigest(t, "foo.txt", "a", dgstMap),
+					directory("test/"),
+					regDigest(t, "test/bar.txt", "testbartestbar", dgstMap),
+				)
+			},
+		},
+		{
+			name: "with-non-regfiles",
+			tarInit: func(t *testing.T, dgstMap map[string]string) (stream io.ReadCloser) {
+				return tarStream(
+					regDigest(t, "baz.txt", "bazbazbazbazbazbazbaz", dgstMap),
+					regDigest(t, "foo.txt", "a", dgstMap),
+					symLink("barlink", "test/bar.txt"),
+					directory("test/"),
+					regDigest(t, "test/bar.txt", "testbartestbar", dgstMap),
+					directory("test2/"),
+					link("test2/bazlink", "baz.txt"),
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+
+			// Get original tar file and chunk digests
+			dgstMap := make(map[string]string)
+			ts := tt.tarInit(t, dgstMap)
+
+			// Convert tar to stargz
+			w := stargz.NewWriter(buf)
+			w.ChunkSize = chunkSize
+			if err := w.AppendTar(ts); err != nil {
+				t.Fatalf("failed to append tar: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("failed to finalize stargz: %v", err)
+			}
+			orgStargz := buf.Bytes()
+
+			// Rewrite stargz TOC JSON with chunk-level digests
+			r, tocDigest, err := NewVerifiableStagz(io.NewSectionReader(
+				bytes.NewReader(orgStargz), 0, int64(len(orgStargz))))
+			if err != nil {
+				t.Errorf("failed to convert stargz: %v", err)
+				return
+			}
+			buf.Reset()
+			if _, err := io.Copy(buf, r); err != nil {
+				t.Fatalf("failed to get converted stargz")
+			}
+			newStargz := buf.Bytes()
+
+			// Check the newly created TOC JSON based on the actual contents
+			// Walk all entries in the stargz and check all chunks are stored to the TOC JSON
+			sgz, err := stargz.Open(io.NewSectionReader(
+				bytes.NewReader(newStargz), 0, int64(len(newStargz))))
+			if err != nil {
+				t.Errorf("failed to parse converted stargz: %v", err)
+				return
+			}
+			digestMapTOC, err := listDigests(io.NewSectionReader(
+				bytes.NewReader(newStargz), 0, int64(len(newStargz))))
+			if err != nil {
+				t.Fatalf("failed to list digest: %v", err)
+			}
+			found := make(map[string]bool)
+			for id := range dgstMap {
+				found[id] = false
+			}
+			zr, err := gzip.NewReader(bytes.NewReader(newStargz))
+			if err != nil {
+				t.Fatalf("failed to decompress converted stargz: %v", err)
+			}
+			defer zr.Close()
+			tr := tar.NewReader(zr)
+			for {
+				h, err := tr.Next()
+				if err != nil {
+					if err != io.EOF {
+						t.Errorf("failed to read tar entry: %v", err)
+						return
+					}
+					break
+				}
+				if h.Name == stargz.TOCTarName {
+					// Check the digest of TOC JSON based on the actual contents
+					// It's sure that TOC JSON exists in this archive because
+					// stargz.Open succeeded.
+					tocHash := sha256.New()
+					if _, err := io.Copy(tocHash, tr); err != nil {
+						t.Fatalf("failed to calculate digest of TOC JSON: %v",
+							err)
+					}
+					want := fmt.Sprintf("sha256:%x", tocHash.Sum(nil))
+					if want != tocDigest {
+						t.Errorf("invalid TOC JSON %q; want %q", tocDigest, want)
+					}
+					continue
+				}
+				if _, ok := sgz.Lookup(strings.TrimSuffix(h.Name, "/")); !ok {
+					t.Errorf("lost stargz entry %q in the converted TOC", h.Name)
+					return
+				}
+				var n int64
+				for n < h.Size {
+					ce, ok := sgz.ChunkEntryForOffset(h.Name, n)
+					if !ok {
+						t.Errorf("lost chunk %q(offset=%d) in the converted TOC",
+							h.Name, n)
+						return
+					}
+
+					// Get the original digest to make sure the file contents are
+					// kept unchanged from the original tar, during the whole
+					// conversion steps.
+					id := chunkID(h.Name, n, ce.ChunkSize)
+					want, ok := dgstMap[id]
+					if !ok {
+						t.Errorf("Unexpected chunk %q(offset=%d,size=%d): %v",
+							h.Name, n, ce.ChunkSize, dgstMap)
+						return
+					}
+					found[id] = true
+
+					// Check the file contents
+					digest := sha256.New()
+					if _, err := io.CopyN(digest, tr, ce.ChunkSize); err != nil {
+						t.Fatalf("failed to calculate digest of %q (offset=%d,size=%d)",
+							h.Name, n, ce.ChunkSize)
+					}
+					dgst := fmt.Sprintf("sha256:%x", digest.Sum(nil))
+					if want != dgst {
+						t.Errorf("Invalid contents in converted stargz %q: %q; want %q",
+							h.Name, dgst, want)
+						return
+					}
+
+					// Check the digest stored in TOC JSON
+					dgstTOC, ok := digestMapTOC[ce.Offset]
+					if !ok {
+						t.Errorf("digest of %q(offset=%d,size=%d,chunkOffset=%d) isn't registered",
+							h.Name, ce.Offset, ce.ChunkSize, ce.ChunkOffset)
+					}
+					if want != dgstTOC {
+						t.Errorf("Invalid digest in TOCEntry %q: %q; want %q",
+							h.Name, dgstTOC, want)
+						return
+					}
+
+					n += ce.ChunkSize
+				}
+			}
+
+			for id, ok := range found {
+				if !ok {
+					t.Errorf("required chunk %q not found in the converted stargz: %v", id, found)
+				}
+			}
+		})
+	}
+}
+
+func chunkID(name string, offset, size int64) string {
+	return fmt.Sprintf("%s-%d-%d", name, offset, size)
+}
+
+type appender func(w *tar.Writer) error
+
+func tarStream(appenders ...appender) io.ReadCloser {
+	pr, pw := io.Pipe()
+	go func() {
+		tw := tar.NewWriter(pw)
+		for _, f := range appenders {
+			if err := f(tw); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+		}
+		if err := tw.Close(); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+	}()
+	return pr
+}
+
+func directory(name string) appender {
+	if !strings.HasSuffix(name, "/") {
+		panic(fmt.Sprintf("dir %q must have suffix /", name))
+	}
+	return func(w *tar.Writer) error {
+		return w.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeDir,
+			Name:     name,
+		})
+	}
+}
+
+func regDigest(t *testing.T, name string, contentStr string, digestMap map[string]string) appender {
+	if digestMap == nil {
+		t.Fatalf("digest map mustn't be nil")
+	}
+	content := []byte(contentStr)
+
+	var n int64
+	for n < int64(len(content)) {
+		size := int64(chunkSize)
+		remain := int64(len(content)) - n
+		if remain < size {
+			size = remain
+		}
+		digest := sha256.New()
+		if _, err := io.CopyN(digest, bytes.NewReader(content[n:n+size]), size); err != nil {
+			t.Fatalf("failed to calculate digest of %q (name=%q,offset=%d,size=%d)",
+				string(content[n:n+size]), name, n, size)
+		}
+		digestMap[chunkID(name, n, size)] = fmt.Sprintf("sha256:%x", digest.Sum(nil))
+		n += size
+	}
+
+	return func(w *tar.Writer) error {
+		if err := w.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     name,
+			Size:     int64(len(content)),
+		}); err != nil {
+			return err
+		}
+		if _, err := io.CopyN(w, bytes.NewReader(content), int64(len(content))); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func link(name string, linkname string) appender {
+	return func(w *tar.Writer) error {
+		return w.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeLink,
+			Name:     name,
+			Linkname: linkname,
+		})
+	}
+}
+
+func symLink(name string, linkname string) appender {
+	return func(w *tar.Writer) error {
+		return w.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeSymlink,
+			Name:     name,
+			Linkname: linkname,
+		})
+	}
+}
+
+func listDigests(sgz *io.SectionReader) (map[int64]string, error) {
+	toc, _, _, err := extractTOCJSON(sgz)
+	if err != nil {
+		return nil, err
+	}
+	digestMap := make(map[int64]string)
+	for _, e := range toc.Entries {
+		if e.Type == "reg" || e.Type == "chunk" {
+			if e.Type == "reg" && e.Size == 0 {
+				continue // ignores empty file
+			}
+			if e.ChunkDigest == "" {
+				return nil, fmt.Errorf("ChunkDigest of %q(off=%d) not found in TOC JSON",
+					e.Name, e.Offset)
+			}
+			digestMap[e.Offset] = e.ChunkDigest
+		}
+	}
+	return digestMap, nil
+}


### PR DESCRIPTION
Related: https://github.com/containerd/stargz-snapshotter/issues/114

Current stargz image has two problems towards content validation:
- The digest of TOC JSON isn't stored in verifiable image manifests
- Content digests are stored in file granularity (not in chunk granularity)

By solving them, we can construct a chain of verification (i.e. manifest -> TOC JSON -> chunk).

This commit solves them in backwards-compatible ways as the following.

For the first one, this commit adds an annotation `containerd.io/snapshot/stargz/toc.digest` to the image manifest for storing the digest of TOC JSON.

For the second one, this commit extends the TOCEntry with an additional (and optional) field `ChunkDigest` for storing chunk-level content digest. Stargz lib chunks a large file to smaller "chunk" entries (4MiB by default). In stargz snapshotter, we leverage this and fetch a large file in chunk granularity, selectively. However, stargz lib __doesn't__ calculate the digest for each chunk. Instead, it calculates the digest for the entire file and stores this to`TOCEntry.Digest` of the first chunk and `TOCEntry.Digest` of other chunks are kept empty (see also: https://github.com/google/crfs/pull/37). For keeping backwards-compatibility with stargz, this commit adds a new field for containing chunk-level digests instead of changing the semantics of `TOCEntry.Digest`.

This commit is for the archive format and the converter command. I'll post another PR for the verification functionality on the filesystem side leveraging this format.(or, should it be contained in this PR?)
