### PR TITLE
Get instance location and type during benchmarking

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,11 @@ jobs:
     - uses: actions/checkout@v2
     - name: Prepare output directory
       run: mkdir "${BENCHMARK_RESULT_DIR}"
+    - name: Get instance information
+      run: |
+          curl -H "Metadata:true" "http://169.254.169.254/metadata/instance?api-version=2019-11-01" | \
+          jq '{ location : .compute.location, vmSize : .compute.vmSize }' | \
+          tee ${{ env.BENCHMARK_RESULT_DIR }}/instance.json
     - name: Run benchmark
       run: make benchmark
     - uses: actions/upload-artifact@v1


### PR DESCRIPTION
Though the VM spec is documented in the [Github Actions documentation](https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources), we should get the concrete instance type and location used during benchmarking for reproducibility.

Output from https://github.com/ktock/stargz-snapshotter/runs/876409478:
```json
{
  "location": "eastus2",
  "vmSize": "Standard_DS2_v2"
}
```
In this case, we run [`Standard_DS2_v2`](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series#dsv2-series) instance in `eastus2`.
