### PR TITLE
Enable snapshotter to force content verification

### DIFF
--- a/script/benchmark/hello-bench/src/hello.py
+++ b/script/benchmark/hello-bench/src/hello.py
@@ -177,7 +177,7 @@ class BenchRunner:
 
     def pull_subcmd(self):
         if self.lazypull():
-            return "rpull"
+            return "rpull --skip-content-verify"
         else:
             return "pull"
         

--- a/script/demo/config.stargz.toml
+++ b/script/demo/config.stargz.toml
@@ -1,3 +1,4 @@
+allow_no_verification = true
 [[resolver.host."registry2:5000".mirrors]]
 host = "registry2:5000"
 insecure = true

--- a/stargz/fs.go
+++ b/stargz/fs.go
@@ -259,7 +259,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 			return errors.Wrapf(err, "invalid stargz layer")
 		}
 		logCtx.Debugf("verified (%q,%q)", ref, ldgst)
-	} else if _, ok := labels[TargetSkipVerifyLabel]; ok || fs.allowNoVerification {
+	} else if _, ok := labels[TargetSkipVerifyLabel]; ok && fs.allowNoVerification {
 		// If unverified layer is allowed, use it with warning.
 		// This mode is for legacy stargz archives which don't contain digests
 		// necessary for layer verification.


### PR DESCRIPTION
Related: https://github.com/containerd/stargz-snapshotter/issues/114

Currently, we can bypath content verification when the image has an annotation `containerd.io/snapshot/remote/stargz.skipverify`, even if the snapshotter config doesn't allow non-verifiable images (= `allow_no_verification = false`).

This commit fixes this behaviour and tighten the restriction for non-verifiable images. Non-verifiable images can be mounted only if both of the following conditions meet:

- `allow_no_verification = true` is specified in `config.toml` of stargz snapshotter, and
- the content descriptor of the layer has an annotation `containerd.io/snapshot/remote/stargz.skipverify` (the value will be ignored).

I'm currently working on the content verification documentation and will include this restriction definition.
At this moment, non-verifiable images are allowed in demo and benchmarking environment for supporting stargz (non-eStargz) images.
