### PR TITLE
Check layers in parallel

### DIFF
--- a/stargz/fs.go
+++ b/stargz/fs.go
@@ -415,15 +415,15 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string) error {
 		return fmt.Errorf("layer not registered")
 	}
 
-	// Wait for prefetch compeletion
-	if err := l.waitForPrefetchCompletion(); err != nil {
-		logCtx.WithError(err).Warn("failed to sync with prefetch completion")
-	}
-
 	// Check the blob connectivity and refresh the connection if possible
 	if err := fs.check(ctx, l); err != nil {
 		logCtx.WithError(err).Warn("check failed")
 		return err
+	}
+
+	// Wait for prefetch compeletion
+	if err := l.waitForPrefetchCompletion(); err != nil {
+		logCtx.WithError(err).Warn("failed to sync with prefetch completion")
 	}
 
 	return nil


### PR DESCRIPTION
Currently, the snapshotter checks layer sequentially but it's possible for some of the checks to wait for the prefetch completion long time and this will block the checking other layers. For avoiding this, snapshotter should check layers in parallel.
