### PR TITLE
fix remote snapshot is unavailable after service restart

### DIFF
--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -89,7 +89,7 @@ func main() {
 	if err != nil {
 		log.G(ctx).WithError(err).Fatalf("failed to configure filesystem")
 	}
-	rs, err := snbase.NewSnapshotter(filepath.Join(*rootDir, "snapshotter"), fs, snbase.AsynchronousRemove)
+	rs, err := snbase.NewSnapshotter(ctx, filepath.Join(*rootDir, "snapshotter"), fs, snbase.AsynchronousRemove)
 	if err != nil {
 		log.G(ctx).WithError(err).Fatalf("failed to configure snapshotter")
 	}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -97,7 +97,7 @@ type snapshotter struct {
 // as snapshots. This is implemented based on the overlayfs snapshotter, so
 // diffs are stored under the provided root and a metadata file is stored under
 // the root as same as overlayfs snapshotter.
-func NewSnapshotter(root string, targetFs FileSystem, opts ...Opt) (snapshots.Snapshotter, error) {
+func NewSnapshotter(ctx context.Context, root string, targetFs FileSystem, opts ...Opt) (snapshots.Snapshotter, error) {
 	if targetFs == nil {
 		return nil, fmt.Errorf("Specify filesystem to use")
 	}
@@ -128,12 +128,18 @@ func NewSnapshotter(root string, targetFs FileSystem, opts ...Opt) (snapshots.Sn
 		return nil, err
 	}
 
-	return &snapshotter{
+	o := &snapshotter{
 		root:        root,
 		ms:          ms,
 		asyncRemove: config.asyncRemove,
 		fs:          targetFs,
-	}, nil
+	}
+
+	if err := o.restoreRemoteSnapshot(ctx); err != nil {
+		return nil, errors.Wrap(err, "failed to restore remote snapshot")
+	}
+
+	return o, nil
 }
 
 // Stat returns the info for an active or committed snapshot by name or
@@ -676,4 +682,35 @@ func (o *snapshotter) checkAvailability(ctx context.Context, key string) bool {
 		return false
 	}
 	return true
+}
+
+func (o *snapshotter) restoreRemoteSnapshot(ctx context.Context) error {
+	mounts, err := mount.Self()
+	if err != nil {
+		return err
+	}
+	for _, m := range mounts {
+		if strings.HasPrefix(m.Mountpoint, filepath.Join(o.root, "snapshots")) {
+			if err := syscall.Unmount(m.Mountpoint, syscall.MNT_FORCE); err != nil {
+				return errors.Wrapf(err, "failed to unmount %s", m.Mountpoint)
+			}
+		}
+	}
+
+	var task []snapshots.Info
+	if err := o.Walk(ctx, func(ctx context.Context, info snapshots.Info) error {
+		if _, ok := info.Labels[remoteLabel]; ok {
+			task = append(task, info)
+		}
+		return nil
+	}); err != nil && !errdefs.IsNotFound(err) {
+		return err
+	}
+	for _, info := range task {
+		if err := o.prepareRemoteSnapshot(ctx, info.Name, info.Labels); err != nil {
+			return errors.Wrapf(err, "failed to prepare remote snapshot: %s", info.Name)
+		}
+	}
+
+	return nil
 }

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -60,7 +60,7 @@ func TestRemotePrepare(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(root)
-	sn, err := NewSnapshotter(root, bindFileSystem(t))
+	sn, err := NewSnapshotter(context.TODO(), root, bindFileSystem(t))
 	if err != nil {
 		t.Fatalf("failed to make new remote snapshotter: %q", err)
 	}
@@ -111,7 +111,7 @@ func TestRemoteOverlay(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(root)
-	sn, err := NewSnapshotter(root, bindFileSystem(t))
+	sn, err := NewSnapshotter(context.TODO(), root, bindFileSystem(t))
 	if err != nil {
 		t.Fatalf("failed to make new remote snapshotter: %q", err)
 	}
@@ -170,7 +170,7 @@ func TestRemoteCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(root)
-	sn, err := NewSnapshotter(root, bindFileSystem(t))
+	sn, err := NewSnapshotter(context.TODO(), root, bindFileSystem(t))
 	if err != nil {
 		t.Fatalf("failed to make new remote snapshotter: %q", err)
 	}
@@ -313,7 +313,7 @@ func TestFailureDetection(t *testing.T) {
 			}
 			defer os.RemoveAll(root)
 			fi := bindFileSystem(t)
-			sn, err := NewSnapshotter(root, fi)
+			sn, err := NewSnapshotter(context.TODO(), root, fi)
 			if err != nil {
 				t.Fatalf("failed to make new Snapshotter: %q", err)
 			}
@@ -439,7 +439,7 @@ func (fs *dummyFs) Unmount(ctx context.Context, mountpoint string) error {
 // Tests backword-comaptibility of overlayfs snapshotter.
 
 func newSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
-	snapshotter, err := NewSnapshotter(root, dummyFileSystem())
+	snapshotter, err := NewSnapshotter(context.TODO(), root, dummyFileSystem())
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
I found that restarting the stargz-snapshot service will cause the previous data to be unavailable.

1.  pull image
```
[root@F24core-2 lib]# ctr-remote i rpull --plain-http  192.168.120.238:5000/busybox:stargz
fetching sha256:822b941c... application/vnd.docker.distribution.manifest.v2+json
fetching sha256:0f5d3ed6... application/vnd.docker.container.image.v1+json
```
2. run container
```
[root@F24core-2 lib]# ctr-remote run  --snapshotter=stargz -t --rm 192.168.120.238:5000/busybox:stargz test hostname
F24core-2
```
3. restart stargz-snapshotter service
`[root@F24core-2 lib]# systemctl restart stargz-snapshotter`
4. run the container again
```
[root@F24core-2 lib]# ctr-remote run  --snapshotter=stargz -t --rm 192.168.120.238:5000/busybox:stargz test hostname
ctr: failed to stat parent: stat /var/lib/containerd-stargz-grpc/snapshotter/snapshots/26/fs: transport endpoint is not connected: unknown
```

**-How I did it**
reload remote snapshot when stargz-snapshot service starts

**-How to verify it**
1.  pull image
```
[root@F24core-2 ~]# ctr-remote i rpull --plain-http  192.168.120.238:5000/busybox:stargz
fetching sha256:822b941c... application/vnd.docker.distribution.manifest.v2+json
fetching sha256:0f5d3ed6... application/vnd.docker.container.image.v1+json
```
2. run container
```
[root@F24core-2 ~]# ctr-remote run  --snapshotter=stargz -t --rm 192.168.120.238:5000/busybox:stargz test hostname
F24core-2
```
3. restart stargz-snapshotter service
`[root@F24core-2 ~]# systemctl restart stargz-snapshotter`
4. run the container again successfully
```
[root@F24core-2 ~]# ctr-remote run  --snapshotter=stargz -t --rm 192.168.120.238:5000/busybox:stargz test hostname
F24core-2
```



Signed-off-by: Zhangjianming <zhang.jianming7@zte.com.cn>