### PR TITLE
Verify and cache files in parallel

### DIFF
--- a/stargz/fs_test.go
+++ b/stargz/fs_test.go
@@ -88,9 +88,9 @@ func nopVerifiableReader(ev verify.TOCEntryVerifier) reader.Reader {
 
 type nopreader struct{}
 
-func (r nopreader) OpenFile(name string) (io.ReaderAt, error)                     { return nil, nil }
-func (r nopreader) Lookup(name string) (*stargz.TOCEntry, bool)                   { return nil, false }
-func (r nopreader) CacheTarGzWithReader(ir io.Reader, opts ...cache.Option) error { return nil }
+func (r nopreader) OpenFile(name string) (io.ReaderAt, error)   { return nil, nil }
+func (r nopreader) Lookup(name string) (*stargz.TOCEntry, bool) { return nil, false }
+func (r nopreader) Cache(opts ...reader.CacheOption) error      { return nil }
 
 type breakBlob struct {
 	success bool

--- a/stargz/reader/reader_test.go
+++ b/stargz/reader/reader_test.go
@@ -54,9 +54,8 @@ func TestFailReader(t *testing.T) {
 		ReaderAt: stargzFile,
 		success:  true,
 	}
-	bsr := io.NewSectionReader(br, 0, stargzFile.Size())
 	bev := &testTOCEntryVerifier{true}
-	gr, _, err := newReader(bsr, &nopCache{}, bev)
+	gr, _, err := newReader(io.NewSectionReader(br, 0, stargzFile.Size()), &nopCache{}, bev)
 	if err != nil {
 		t.Fatalf("Failed to open stargz file: %v", err)
 	}
@@ -94,7 +93,7 @@ func TestFailReader(t *testing.T) {
 			}
 
 			// tests for caching reader
-			err = gr.CacheTarGzWithReader(bsr)
+			err = gr.Cache()
 			if rs && vs {
 				if err != nil {
 					t.Errorf("failed to cache reader but wanted to succeed")


### PR DESCRIPTION
Currently, the snapshotter verifies, decompresses and caches files in a layer sequentially during prefetch and background fetch. But it's possible for some of (large) files takes long for doing so and this will block caching other files. For avoiding this, snapshotter should cache files in parallel.
