### PR TITLE
Make keychain selection configurable

### DIFF
--- a/cmd/containerd-stargz-grpc/config.go
+++ b/cmd/containerd-stargz-grpc/config.go
@@ -1,0 +1,31 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import "github.com/containerd/stargz-snapshotter/stargz/config"
+
+type Config struct {
+	config.Config
+
+	// KubeconfigKeychainConfig is config for kubeconfig-based keychain.
+	KubeconfigKeychainConfig `toml:"kubeconfig_keychain"`
+}
+
+type KubeconfigKeychainConfig struct {
+	EnableKeychain bool   `toml:"enable_keychain"`
+	KubeconfigPath string `toml:"kubeconfig_path"`
+}

--- a/stargz/config/config.go
+++ b/stargz/config/config.go
@@ -38,9 +38,6 @@ type Config struct {
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob"`
 
-	// KubeconfigKeychainConfig is config for kubeconfig-based keychain.
-	KubeconfigKeychainConfig `toml:"kubeconfig_keychain"`
-
 	// DirectoryCacheConfig is config for directory-based cache.
 	DirectoryCacheConfig `toml:"directory_cache"`
 }
@@ -63,11 +60,6 @@ type BlobConfig struct {
 	ValidInterval int64 `toml:"valid_interval"`
 	CheckAlways   bool  `toml:"check_always"`
 	ChunkSize     int64 `toml:"chunk_size"`
-}
-
-type KubeconfigKeychainConfig struct {
-	EnableKeychain bool   `toml:"enable_keychain"`
-	KubeconfigPath string `toml:"kubeconfig_path"`
 }
 
 type DirectoryCacheConfig struct {


### PR DESCRIPTION
Currently, kubeconfig-based keychain is imported to the filesystem by default
but this comes with a lot of dependencies (including `k8s.io` pkg) and this
makes importing `github.com/containerd/stargz-snapshotter/stargz` harder. Since
this commit, the filesystem doesn't import the keychain by default and the
keychain selection is configurable through the option. There is no change in
`config.toml`.