### PR TITLE
Enable to use optimize command in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,17 @@ VOLUME /run/containerd-stargz-grpc
 ENV CONTAINERD_SNAPSHOTTER=stargz
 ENTRYPOINT [ "/entrypoint.sh" ]
 
+# Image which can be used as containerized `ctr-remote images optimize` command
+FROM ubuntu:20.04 AS oind
+
+RUN apt-get update -y && \
+    apt-get --no-install-recommends install -y fuse runc ca-certificates
+
+COPY --from=snapshotter-dev /out/ctr-remote /usr/local/bin/
+COPY --from=runc-dev /out/sbin/* /usr/local/sbin/
+
+ENTRYPOINT [ "/usr/local/bin/ctr-remote", "images", "optimize" ]
+
 # Image which can be used as a node image for KinD
 FROM kindest/node:v1.19.0
 COPY --from=containerd-dev /out/bin/containerd /out/bin/containerd-shim-runc-v2 /usr/local/bin/


### PR DESCRIPTION
This commit adds an all-in-one image enables users having docker accessibility
to use `ctr-remote images optimize` command without installing additional
dependencies.

```console
$ docker build --target oind -t optimize .
$ docker run --rm --privileged --device=/dev/fuse --tmpfs=/tmp:exec,mode=777 \
             -v ~/.docker/config.json:/root/.docker/config.json:ro \
             optimize --args='[ "echo", "hello" ]' ubuntu:20.04 ktokunaga/ubs:1
time="2020-09-08T14:41:17Z" level=info msg="unpacked sha256:b66c17bbf772fa072c280b10fe87bc999420042b5fce5b111db38b4fe7c40b49"
time="2020-09-08T14:41:18Z" level=info msg="unpacked sha256:f7bfea53ad120b47cea5488f0b8331e737a97b33003517b0bd05e83925b578f0"
time="2020-09-08T14:41:18Z" level=info msg="unpacked sha256:46d371e02073acecf750a166495a63358517af793de739a51b680c973fae8fb9"
time="2020-09-08T14:41:19Z" level=info msg="unpacked sha256:54ee1f796a1e650627269605cb8e6a596b77b324e6f0a1e4443dc41def0e58a6"
time="2020-09-08T14:41:19Z" level=info msg="running container \"btbpg3opt0hefogkja30\""
hello
time="2020-09-08T14:41:19Z" level=info msg="container \"btbpg3opt0hefogkja30\" stopped"
time="2020-09-08T14:41:19Z" level=info msg="converted sha256:b66c17bbf772fa072c280b10fe87bc999420042b5fce5b111db38b4fe7c40b49"
time="2020-09-08T14:41:19Z" level=info msg="converted sha256:46d371e02073acecf750a166495a63358517af793de739a51b680c973fae8fb9"
time="2020-09-08T14:41:19Z" level=info msg="converted sha256:f7bfea53ad120b47cea5488f0b8331e737a97b33003517b0bd05e83925b578f0"
time="2020-09-08T14:41:37Z" level=info msg="converted sha256:54ee1f796a1e650627269605cb8e6a596b77b324e6f0a1e4443dc41def0e58a6"
time="2020-09-08T14:41:39Z" level=info msg="2020/09/08 14:41:39 pushed blob: sha256:3baaf10e75731ba0ecf85dbd05227f84982c4a0c4fe7b784a5f9a39b3392a85e"
time="2020-09-08T14:41:39Z" level=info msg="2020/09/08 14:41:39 pushed blob: sha256:8e1506ab2c9783025f2abf4d632a0736bc338dd4b06e011e3ad89db29e58f839"
time="2020-09-08T14:41:40Z" level=info msg="2020/09/08 14:41:40 pushed blob: sha256:e9daf028591a71fad091339b8a37ebce65f2d70d703915020b169b9061faf8c5"
time="2020-09-08T14:41:56Z" level=info msg="2020/09/08 14:41:56 pushed blob: sha256:bd31edc194ad8ce955844aa2bae74966b556c9b569ca3d7d3e13aeaa832f2fc5"
time="2020-09-08T14:41:57Z" level=info msg="2020/09/08 14:41:57 existing blob: sha256:ca41ce5547fc25b8f32ef0b70369ac6f270e33d7a4a983a310e24b6a6d1ee95d"
time="2020-09-08T14:41:57Z" level=info msg="2020/09/08 14:41:57 ktokunaga/ubs:1: digest: sha256:96f6c32995f4173906c7e230f05aeceb90ec02aa4320e3c88309cb4ed7876c70 size: 1443"
```
