### PR TITLE
Refactor and fix docker compose file

### DIFF
--- a/script/cri/test-stargz.sh
+++ b/script/cri/test-stargz.sh
@@ -59,28 +59,14 @@ services:
     - /tmp:exec,mode=777
     volumes:
     - /dev/fuse:/dev/fuse
-    - type: volume
-      source: containerd-data
-      target: /var/lib/containerd
-      volume:
-        nosuid: false
-    - type: volume
-      source: containerd-stargz-grpc-data
-      target: /var/lib/containerd-stargz-grpc
-      volume:
-        nosuid: false
-    - type: volume
-      source: containerd-stargz-grpc-status
-      target: /run/containerd-stargz-grpc
-      volume:
-        nosuid: false
+    - "critest-containerd-data:/var/lib/containerd"
+    - "critest-containerd-stargz-grpc-data:/var/lib/containerd-stargz-grpc"
   registry:
     image: registry:2
     container_name: ${REGISTRY_HOST}
 volumes:
-  containerd-data:
-  containerd-stargz-grpc-data:
-  containerd-stargz-grpc-status:
+  critest-containerd-data:
+  critest-containerd-stargz-grpc-data:
 EOF
 docker-compose -f "${DOCKER_COMPOSE_YAML}" up -d --force-recreate
 

--- a/script/demo/docker-compose.yml
+++ b/script/demo/docker-compose.yml
@@ -22,21 +22,8 @@ services:
     volumes:
     - /dev/fuse:/dev/fuse
     - "${GOPATH}/src/github.com/containerd/stargz-snapshotter:/go/src/github.com/containerd/stargz-snapshotter:ro"
-    - type: volume
-      source: demo-containerd-data
-      target: /var/lib/containerd
-      volume:
-        nosuid: false
-    - type: volume
-      source: demo-containerd-stargz-grpc-data
-      target: /var/lib/containerd-stargz-grpc
-      volume:
-        nosuid: false
-    - type: volume
-      source: demo-containerd-stargz-grpc-status
-      target: /run/containerd-stargz-grpc
-      volume:
-        nosuid: false
+    - "demo-containerd-data:/var/lib/containerd"
+    - "demo-containerd-stargz-grpc-data:/var/lib/containerd-stargz-grpc"
   registry2:
     image: registry:2
     container_name: registry2
@@ -48,4 +35,3 @@ services:
 volumes:
   demo-containerd-data:
   demo-containerd-stargz-grpc-data:
-  demo-containerd-stargz-grpc-status:

--- a/script/integration/test.sh
+++ b/script/integration/test.sh
@@ -101,21 +101,8 @@ services:
     - "${REPO}:/go/src/github.com/containerd/stargz-snapshotter:ro"
     - ${AUTH_DIR}:/auth
     - /dev/fuse:/dev/fuse
-    - type: volume
-      source: integration-containerd-data
-      target: /var/lib/containerd
-      volume:
-        nosuid: false
-    - type: volume
-      source: integration-containerd-stargz-grpc-data
-      target: /var/lib/containerd-stargz-grpc
-      volume:
-        nosuid: false
-    - type: volume
-      source: integration-containerd-stargz-grpc-status
-      target: /run/containerd-stargz-grpc
-      volume:
-        nosuid: false
+    - "integration-containerd-data:/var/lib/containerd"
+    - "integration-containerd-stargz-grpc-data:/var/lib/containerd-stargz-grpc"
   registry:
     image: registry:2
     container_name: ${REGISTRY_HOST}
@@ -137,7 +124,6 @@ services:
 volumes:
   integration-containerd-data:
   integration-containerd-stargz-grpc-data:
-  integration-containerd-stargz-grpc-status:
 EOF
 
 echo "Testing..."


### PR DESCRIPTION
This fixes recent CI failure:
```
The Compose file '/tmp/tmp.JysBvRZ2An' is invalid because:
services.testenv_integration.volumes contains unsupported option: 'nosuid'
services.testenv_integration.volumes contains unsupported option: 'nosuid'
services.testenv_integration.volumes contains unsupported option: 'nosuid'
```