### PR TITLE
Allow to disable pulling layers in background

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -65,7 +65,7 @@ In each metadata JSON file, the following fields are contained,
 
 - `digest` contains the layer digest. This is the same value as that in the image's manifest.
 - `size` is the size bytes of the layer.
-- `fetchedSize` and `fetchedPercent` indicate how many bytes have been fetched for this layer. Stargz snapshotter aggressively downloads this layer in the background so these values gradually increase. When `fetchedPercent` reaches to `100` percents, this layer has been fully downloaded on the node and no further access will occur for reading files.
+- `fetchedSize` and `fetchedPercent` indicate how many bytes have been fetched for this layer. Stargz snapshotter aggressively downloads this layer in the background - unless configured otherwise - so these values gradually increase. When `fetchedPercent` reaches to `100` percents, this layer has been fully downloaded on the node and no further access will occur for reading files.
 
 Note that the state directory layout and the metadata JSON structure are subject to change.
 

--- a/stargz/config/config.go
+++ b/stargz/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	PrefetchSize        int64  `toml:"prefetch_size"`
 	PrefetchTimeoutSec  int64  `toml:"prefetch_timeout_sec"`
 	NoPrefetch          bool   `toml:"noprefetch"`
+	NoBackgroundFetch   bool   `toml:"no_background_fetch"`
 	Debug               bool   `toml:"debug"`
 	AllowNoVerification bool   `toml:"allow_no_verification"`
 


### PR DESCRIPTION
Simple enhancement described in https://github.com/containerd/stargz-snapshotter/issues/145: lazy pulling can be disabled by setting `nolazypull = true` in _config.toml_.

I tested this option by executing `cat /.stargz-snapshotter/*` inside container - when it is enabled, then _fetchedSize_ is not growing up.