### PR TITLE
containerd's RegistryHost-based registry logic

### DIFF
--- a/cmd/containerd-stargz-grpc/config.go
+++ b/cmd/containerd-stargz-grpc/config.go
@@ -23,9 +23,25 @@ type Config struct {
 
 	// KubeconfigKeychainConfig is config for kubeconfig-based keychain.
 	KubeconfigKeychainConfig `toml:"kubeconfig_keychain"`
+
+	// ResolverConfig is config for resolving registries.
+	ResolverConfig `toml:"resolver"`
 }
 
 type KubeconfigKeychainConfig struct {
 	EnableKeychain bool   `toml:"enable_keychain"`
 	KubeconfigPath string `toml:"kubeconfig_path"`
+}
+
+type ResolverConfig struct {
+	Host map[string]HostConfig `toml:"host"`
+}
+
+type HostConfig struct {
+	Mirrors []MirrorConfig `toml:"mirrors"`
+}
+
+type MirrorConfig struct {
+	Host     string `toml:"host"`
+	Insecure bool   `toml:"insecure"`
 }

--- a/stargz/config/config.go
+++ b/stargz/config/config.go
@@ -33,28 +33,11 @@ type Config struct {
 	Debug               bool   `toml:"debug"`
 	AllowNoVerification bool   `toml:"allow_no_verification"`
 
-	// ResolverConfig is config for resolving registries.
-	ResolverConfig `toml:"resolver"`
-
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob"`
 
 	// DirectoryCacheConfig is config for directory-based cache.
 	DirectoryCacheConfig `toml:"directory_cache"`
-}
-
-type ResolverConfig struct {
-	Host                map[string]HostConfig `toml:"host"`
-	ConnectionPoolEntry int                   `toml:"connection_pool_entry"`
-}
-
-type HostConfig struct {
-	Mirrors []MirrorConfig `toml:"mirrors"`
-}
-
-type MirrorConfig struct {
-	Host     string `toml:"host"`
-	Insecure bool   `toml:"insecure"`
 }
 
 type BlobConfig struct {

--- a/stargz/fs.go
+++ b/stargz/fs.go
@@ -43,7 +43,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -54,6 +53,7 @@ import (
 	"unsafe"
 
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/stargz-snapshotter/cache"
 	snbase "github.com/containerd/stargz-snapshotter/snapshot"
 	"github.com/containerd/stargz-snapshotter/stargz/config"
@@ -64,7 +64,6 @@ import (
 	"github.com/containerd/stargz-snapshotter/task"
 	"github.com/golang/groupcache/lru"
 	"github.com/google/crfs/stargz"
-	"github.com/google/go-containerregistry/pkg/authn"
 	fusefs "github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	digest "github.com/opencontainers/go-digest"
@@ -108,12 +107,12 @@ const (
 type Option func(*options)
 
 type options struct {
-	keychain []authn.Keychain
+	hosts remote.RegistryHosts
 }
 
-func WithKeychain(keychain []authn.Keychain) Option {
+func WithRegistryHosts(hosts remote.RegistryHosts) Option {
 	return func(opts *options) {
-		opts.keychain = keychain
+		opts.hosts = hosts
 	}
 }
 
@@ -154,9 +153,6 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snbase.Fil
 			return nil, errors.Wrap(err, "failed to prepare filesystem cache")
 		}
 	}
-	keychain := authn.NewMultiKeychain(append(
-		[]authn.Keychain{authn.DefaultKeychain},
-		fsOpts.keychain...)...)
 	resolveResultEntry := cfg.ResolveResultEntry
 	if resolveResultEntry == 0 {
 		resolveResultEntry = defaultResolveResultEntry
@@ -165,10 +161,16 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snbase.Fil
 	if prefetchTimeout == 0 {
 		prefetchTimeout = defaultPrefetchTimeoutSec * time.Second
 	}
+	hosts := fsOpts.hosts
+	if hosts == nil {
+		registries := docker.ConfigureDefaultRegistries(
+			docker.WithPlainHTTP(docker.MatchLocalhost))
+		hosts = func(host string, _ map[string]string) ([]docker.RegistryHost, error) {
+			return registries(host)
+		}
+	}
 	return &filesystem{
-		resolver:              remote.NewResolver(keychain, cfg.ResolverConfig),
-		blobConfig:            cfg.BlobConfig,
-		httpCache:             httpCache,
+		resolver:              remote.NewResolver(hosts, httpCache, cfg.BlobConfig),
 		fsCache:               fsCache,
 		prefetchSize:          cfg.PrefetchSize,
 		prefetchTimeout:       prefetchTimeout,
@@ -184,8 +186,6 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snbase.Fil
 
 type filesystem struct {
 	resolver              *remote.Resolver
-	blobConfig            config.BlobConfig
-	httpCache             cache.BlobCache
 	fsCache               cache.BlobCache
 	prefetchSize          int64
 	prefetchTimeout       time.Duration
@@ -237,7 +237,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 			}
 		}
 		if rr == nil { // missed cache
-			rr = fs.resolve(ctx, ref, dgst)
+			rr = fs.resolve(ctx, ref, dgst, labels)
 			fs.resolveResult.Add(key, rr)
 		}
 		if dgst == ldgst {
@@ -294,28 +294,15 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	fs.layer[mountpoint] = l
 	fs.layerMu.Unlock()
 
-	// RoundTripper only used for pre-/background-fetch.
-	// We use a separated transport because we don't want these fetching
-	// functionalities to disturb other HTTP-related operations
-	fetchTr := lazyTransport(func() (http.RoundTripper, error) {
-		return l.blob.Authn(http.DefaultTransport.(*http.Transport).Clone())
-	})
-
 	// Prefetch this layer. We prefetch several layers in parallel. The first
-	// Check() for this layer waits for the prefetch completion. We recreate
-	// RoundTripper to avoid disturbing other NW-related operations.
+	// Check() for this layer waits for the prefetch completion.
 	if !fs.noprefetch {
 		l.doPrefetch()
 		go func() {
 			defer l.donePrefetch()
 			fs.backgroundTaskManager.DoPrioritizedTask()
 			defer fs.backgroundTaskManager.DonePrioritizedTask()
-			tr, err := fetchTr()
-			if err != nil {
-				log.G(ctx).WithError(err).Debug("failed to prepare transport for prefetch")
-				return
-			}
-			if err := l.prefetch(prefetchSize, remote.WithRoundTripper(tr)); err != nil {
+			if err := l.prefetch(prefetchSize); err != nil {
 				log.G(ctx).WithError(err).Debug("failed to prefetched layer")
 				return
 			}
@@ -326,23 +313,15 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	// Fetch whole layer aggressively in background. We use background
 	// reader for this so prioritized tasks(Mount, Check, etc...) can
 	// interrupt the reading. This can avoid disturbing prioritized tasks
-	// about NW traffic. We read layer with a buffer to reduce num of
-	// requests to the registry.
+	// about NW traffic.
 	if !fs.noBackgroundFetch {
 		go func() {
 			br := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (retN int, retErr error) {
 				fs.backgroundTaskManager.InvokeBackgroundTask(func(ctx context.Context) {
-					tr, err := fetchTr()
-					if err != nil {
-						log.G(ctx).WithError(err).Debug("failed to prepare transport for background fetch")
-						retN, retErr = 0, err
-						return
-					}
 					retN, retErr = l.blob.ReadAt(
 						p,
 						offset,
 						remote.WithContext(ctx),              // Make cancellable
-						remote.WithRoundTripper(tr),          // Use dedicated Transport
 						remote.WithCacheOpts(cache.Direct()), // Do not pollute mem cache
 					)
 				}, 120*time.Second)
@@ -388,7 +367,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	return server.WaitMount()
 }
 
-func (fs *filesystem) resolve(ctx context.Context, ref, digest string) *resolveResult {
+func (fs *filesystem) resolve(ctx context.Context, ref, digest string, labels map[string]string) *resolveResult {
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("ref", ref).WithField("digest", digest))
 	var (
 		resolvedBlob   remote.Blob
@@ -404,7 +383,7 @@ func (fs *filesystem) resolve(ctx context.Context, ref, digest string) *resolveR
 		resolvedBlobMu.Unlock()
 		if blob == nil || blob.Check() != nil {
 			var err error
-			blob, err = fs.resolver.Resolve(ref, digest, fs.httpCache, fs.blobConfig)
+			blob, err = fs.resolver.Resolve(ref, digest, labels)
 			if err != nil {
 				log.G(ctx).WithError(err).Debugf("failed to resolve ref")
 				return nil, errors.Wrap(err, "failed to resolve the reference")
@@ -468,9 +447,10 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string) error {
 func (fs *filesystem) check(ctx context.Context, l *layer) error {
 	if err := l.blob.Check(); err != nil {
 		// Check failed. Try to refresh the connection
+		retrynum := 1
 		log.G(ctx).WithError(err).Warn("failed to connect to blob; refreshing...")
-		for retry := 0; retry < 3; retry++ {
-			if iErr := fs.resolver.Refresh(l.blob); iErr != nil {
+		for retry := 0; retry < retrynum; retry++ {
+			if iErr := l.blob.Refresh(); iErr != nil {
 				log.G(ctx).WithError(iErr).Warnf("failed to refresh connection(%d)",
 					retry)
 				err = errors.Wrapf(err, "error(%d): %v", retry, iErr)
@@ -538,26 +518,6 @@ func (fs *filesystem) parseLabels(labels map[string]string) (rRef, rDigest strin
 	}
 
 	return
-}
-
-func lazyTransport(trFunc func() (http.RoundTripper, error)) func() (http.RoundTripper, error) {
-	var (
-		tr   http.RoundTripper
-		trMu sync.Mutex
-	)
-	return func() (http.RoundTripper, error) {
-		trMu.Lock()
-		defer trMu.Unlock()
-		if tr != nil {
-			return tr, nil
-		}
-		gotTr, err := trFunc()
-		if err != nil {
-			return nil, err
-		}
-		tr = gotTr
-		return tr, nil
-	}
 }
 
 func newResolveResult(resolveFunc func() (*layer, error)) *resolveResult {


### PR DESCRIPTION
#149
https://github.com/moby/buildkit/pull/1666#discussion_r489907766

Currently, registry logic of stargz snapshotter is separated from containerd and is implemented in an incompatible way with other containerd-based tools (including buildkit which uses containerd's docker.RegistryHost). This makes it hard to integrate the logic with these tools.

This commit refactors registry logic based on containerd's docker.RegistryHost. This enables the client of stargz.FileSystem to configure docker.RegistryHost based on the client-side configuration. This will make the integration of the registry logic with other containerd-based tools easier.

[This buildkit branch](https://github.com/ktock/buildkit/commit/71a5c3198792b3ab5cee3b27cb7e1572773a0514) experimentally integrates buildkitd and snapshotter's registry logic based on this patch. This applies buildkitd's registry configuration to stargz snapshotter and enables it to fetch creds through session on each Prepare() of snapshots.

cc: @AkihiroSuda @tonistiigi