### PR TITLE
Enable to refresh registry configuration using the latest labels

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -63,7 +63,7 @@ const (
 // directory.
 type FileSystem interface {
 	Mount(ctx context.Context, mountpoint string, labels map[string]string) error
-	Check(ctx context.Context, mountpoint string) error
+	Check(ctx context.Context, mountpoint string, labels map[string]string) error
 	Unmount(ctx context.Context, mountpoint string) error
 }
 
@@ -667,7 +667,7 @@ func (o *snapshotter) checkAvailability(ctx context.Context, key string) bool {
 		if _, ok := info.Labels[remoteLabel]; ok {
 			eg.Go(func() error {
 				log.G(lCtx).Debug("checking mount point")
-				if err := o.fs.Check(egCtx, mp); err != nil {
+				if err := o.fs.Check(egCtx, mp, info.Labels); err != nil {
 					log.G(lCtx).WithError(err).Warn("layer is unavailable")
 					return err
 				}

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -406,7 +406,7 @@ func (fs *bindFs) Mount(ctx context.Context, mountpoint string, labels map[strin
 	return nil
 }
 
-func (fs *bindFs) Check(ctx context.Context, mountpoint string) error {
+func (fs *bindFs) Check(ctx context.Context, mountpoint string, labels map[string]string) error {
 	if fs.checkFailure {
 		if broken, ok := fs.broken[mountpoint]; ok && broken {
 			return fmt.Errorf("broken")
@@ -427,7 +427,7 @@ func (fs *dummyFs) Mount(ctx context.Context, mountpoint string, labels map[stri
 	return fmt.Errorf("dummy")
 }
 
-func (fs *dummyFs) Check(ctx context.Context, mountpoint string) error {
+func (fs *dummyFs) Check(ctx context.Context, mountpoint string, labels map[string]string) error {
 	return fmt.Errorf("dummy")
 }
 

--- a/stargz/fs_test.go
+++ b/stargz/fs_test.go
@@ -72,12 +72,12 @@ func TestCheck(t *testing.T) {
 		backgroundTaskManager: task.NewBackgroundTaskManager(1, time.Millisecond),
 	}
 	bb.success = true
-	if err := fs.Check(context.TODO(), "test"); err != nil {
+	if err := fs.Check(context.TODO(), "test", nil); err != nil {
 		t.Errorf("connection failed; wanted to succeed")
 	}
 
 	bb.success = false
-	if err := fs.Check(context.TODO(), "test"); err == nil {
+	if err := fs.Check(context.TODO(), "test", nil); err == nil {
 		t.Errorf("connection succeeded; wanted to fail")
 	}
 }
@@ -107,7 +107,7 @@ func (r *breakBlob) Check() error {
 	}
 	return nil
 }
-func (r *breakBlob) Refresh() error {
+func (r *breakBlob) Refresh(labels map[string]string) error {
 	if !r.success {
 		return fmt.Errorf("failed")
 	}
@@ -387,7 +387,7 @@ func (db *dummyBlob) Size() int64                                               
 func (db *dummyBlob) FetchedSize() int64                                                { return 5 }
 func (db *dummyBlob) Check() error                                                      { return nil }
 func (db *dummyBlob) Cache(offset int64, size int64, option ...remote.Option) error     { return nil }
-func (db *dummyBlob) Refresh() error                                                    { return nil }
+func (db *dummyBlob) Refresh(labels map[string]string) error                            { return nil }
 
 type chunkSizeInfo int
 
@@ -958,7 +958,7 @@ func (sb *sampleBlob) Cache(offset int64, size int64, option ...remote.Option) e
 	sb.calledPrefetchSize = size
 	return nil
 }
-func (sb *sampleBlob) Refresh() error { return nil }
+func (sb *sampleBlob) Refresh(labels map[string]string) error { return nil }
 
 type testCache struct {
 	membuf map[string]string

--- a/stargz/remote/resolver.go
+++ b/stargz/remote/resolver.go
@@ -110,7 +110,6 @@ func (r *Resolver) Resolve(ref, digest string, labels map[string]string) (Blob, 
 		resolver:      r,
 		refspec:       refspec,
 		digest:        digest,
-		labels:        labels,
 	}, nil
 }
 


### PR DESCRIPTION
Following-up: #149 #153
Related: moby/buildkit#1666 (comment)

Currently, if connectivity check on a layer fails during `FileSystem.Check` API,
the registry configuration(docker.RegistryHost) of that layer is refreshed based
on initially (during `FileSystem.Mount`) provided snapshot labels. But that
configuration should be refreshed using the *latest* labels stored in the
snapshot.

This enables snapshotter clients to update registry-configuration-related labels
through `snapshot.Update` API and the filesystem can use these labels on
refreshing the configuration.
