### PR TITLE
Allow client to configure blob URLs through RegistryHost configuration

### DIFF
--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -146,7 +146,7 @@ func waitForSIGINT() {
 }
 
 func hostsFromConfig(cfg ResolverConfig, keychain authn.Keychain) remote.RegistryHosts {
-	return func(host string, _ map[string]string) (hosts []docker.RegistryHost, _ error) {
+	return func(host string, _ map[string]string) (hosts []remote.RegistryHost, _ error) {
 		for _, h := range append(cfg.Host[host].Mirrors, MirrorConfig{
 			Host: host,
 		}) {
@@ -187,7 +187,7 @@ func hostsFromConfig(cfg ResolverConfig, keychain authn.Keychain) remote.Registr
 			if config.Host == "docker.io" {
 				config.Host = "registry-1.docker.io"
 			}
-			hosts = append(hosts, config)
+			hosts = append(hosts, remote.RegistryHost{RegistryHost: config})
 		}
 		return
 	}

--- a/stargz/fs.go
+++ b/stargz/fs.go
@@ -165,8 +165,16 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snbase.Fil
 	if hosts == nil {
 		registries := docker.ConfigureDefaultRegistries(
 			docker.WithPlainHTTP(docker.MatchLocalhost))
-		hosts = func(host string, _ map[string]string) ([]docker.RegistryHost, error) {
-			return registries(host)
+		hosts = func(host string, _ map[string]string) ([]remote.RegistryHost, error) {
+			reghosts, err := registries(host)
+			if err != nil {
+				return nil, err
+			}
+			var remoteHosts []remote.RegistryHost
+			for _, h := range reghosts {
+				remoteHosts = append(remoteHosts, remote.RegistryHost{RegistryHost: h})
+			}
+			return remoteHosts, nil
 		}
 	}
 	return &filesystem{

--- a/stargz/remote/blob.go
+++ b/stargz/remote/blob.go
@@ -72,9 +72,16 @@ func (b *blob) Refresh(labels map[string]string) error {
 	if err != nil {
 		return err
 	}
+	for i := range hosts {
+		if hosts[i].RefAlias.String() == "" {
+			// If an alias isn't specified by the config, use the default reference.
+			// TODO: maybe we shouldn't tie a snapshot to a single image reference.
+			hosts[i].RefAlias = b.refspec
+		}
+	}
 
 	// refresh the fetcher
-	new, newSize, err := newFetcher(hosts, b.refspec, b.digest)
+	new, newSize, err := newFetcher(hosts, b.digest)
 	if err != nil {
 		return err
 	} else if newSize != b.size {

--- a/stargz/remote/resolver_test.go
+++ b/stargz/remote/resolver_test.go
@@ -147,17 +147,22 @@ func TestMirror(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var hosts []docker.RegistryHost
+			var hosts []RegistryHost
 			for _, m := range append(tt.mirrors, refHost) {
-				hosts = append(hosts, docker.RegistryHost{
-					Client:       &http.Client{Transport: tt.tr},
-					Host:         m,
-					Scheme:       "https",
-					Path:         "/v2",
-					Capabilities: docker.HostCapabilityPull,
+				hosts = append(hosts, RegistryHost{
+					RegistryHost: docker.RegistryHost{
+						Client:       &http.Client{Transport: tt.tr},
+						Host:         m,
+						Scheme:       "https",
+						Path:         "/v2",
+						Capabilities: docker.HostCapabilityPull,
+					},
 				})
 			}
-			fetcher, _, err := newFetcher(hosts, refspec, blobDigest)
+			for i := range hosts {
+				hosts[i].RefAlias = refspec
+			}
+			fetcher, _, err := newFetcher(hosts, blobDigest)
 			if err != nil {
 				if tt.error {
 					return


### PR DESCRIPTION
Related to: #149
This commit adds a new field `RefAlias` to the registry configuration. This
enables the client to configure the destination URL of layers more flexibly. For
example, the client can change the URL of a layer blob on refresh, based on the
connectivity.

This implies that a snapshot (or layer) shouldn't be tied to a single image
reference and we might need more refactoring on the registry logic but let's
keep this separated from this patch.

Signed-off-by: Kohei Tokunaga <ktokunaga.mail@gmail.com>