### PR TITLE
demo/compose: Add proxy config for build

### DIFF
--- a/script/demo/docker-compose.yml
+++ b/script/demo/docker-compose.yml
@@ -4,6 +4,12 @@ services:
     build:
       context: ../../
       target: containerd-base
+      args:
+        NO_PROXY: "${NO_PROXY}"
+        HTTP_PROXY: "${HTTP_PROXY}"
+        HTTPS_PROXY: "${HTTPS_PROXY}"
+        http_proxy: "${http_proxy}"
+        https_proxy: "${https_proxy}"
     container_name: containerd_demo
     privileged: true
     stdin_open: true


### PR DESCRIPTION
When behind a proxy, we need proxy env variables
for the build stage.

Signed-off-by: Spyros Trigazis <spyridon.trigazis@cern.ch>