### PR TITLE
Fix wrong mtime calculation

### DIFF
--- a/stargz/fs.go
+++ b/stargz/fs.go
@@ -1067,8 +1067,8 @@ func entryToAttr(e *stargz.TOCEntry, out *fuse.Attr) fusefs.StableAttr {
 	if out.Size%uint64(out.Blksize) > 0 {
 		out.Blocks++
 	}
-	out.Mtime = uint64(e.ModTime().Unix())
-	out.Mtimensec = uint32(e.ModTime().UnixNano())
+	mtime := e.ModTime()
+	out.SetTimes(nil, &mtime, nil)
 	out.Mode = modeOfEntry(e)
 	out.Owner = fuse.Owner{Uid: uint32(e.Uid), Gid: uint32(e.Gid)}
 	out.Rdev = uint32(unix.Mkdev(uint32(e.DevMajor), uint32(e.DevMinor)))
@@ -1094,8 +1094,8 @@ func entryToWhAttr(e *stargz.TOCEntry, out *fuse.Attr) fusefs.StableAttr {
 	out.Size = 0
 	out.Blksize = blockSize
 	out.Blocks = 0
-	out.Mtime = uint64(fi.ModTime().Unix())
-	out.Mtimensec = uint32(fi.ModTime().UnixNano())
+	mtime := fi.ModTime()
+	out.SetTimes(nil, &mtime, nil)
 	out.Mode = syscall.S_IFCHR
 	out.Owner = fuse.Owner{Uid: 0, Gid: 0}
 	out.Rdev = uint32(unix.Mkdev(0, 0))


### PR DESCRIPTION
Currently we use `time.Time.UnixNano()` (unix time in nanoseconds https://golang.org/pkg/time/#Time.UnixNano) value for `(github.com/hanwen/go-fuse/fuse).Attr.Mtimensec` but [the filed requires `time.Time.Nanosecond()`](https://github.com/hanwen/go-fuse/blob/730713460d4fc41afdc2533bd37ff60c94c0c586/fuse/attr.go#L40) which is the nanosecond *offset* within the second specified by that time https://golang.org/pkg/time/#Time.Nanosecond . This difference leads to wrong calculation of mtime of that file as the following:

On overlayfs snapshotter:
```console
# ctr-remote image pull docker.io/stargz/python:3.7-esgz
# ctr-remote run --rm -t docker.io/stargz/python:3.7-esgz dummy stat -c %.Y /bin/cat
1551367831.000000000
```

On stargz-snapshotter:
```console
# ctr-remote image rpull docker.io/stargz/python:3.7-esgz
# ctr-remote run --rm -t --snapshotter=stargz docker.io/stargz/python:3.7-esgz dummy stat -c %.Y /bin/cat
1551367831.-1564924416
```

This commit fixes this issue by using the method provided by the go-fuse lib for setting times.
