### PR TITLE
Enable to pull from ghcr.io

### DIFF
--- a/stargz/remote/blob.go
+++ b/stargz/remote/blob.go
@@ -269,7 +269,7 @@ func (b *blob) fetchRange(allData map[region]io.Writer, opts *options) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	mr, err := fr.fetch(ctx, req, opts)
+	mr, err := fr.fetch(ctx, req, true, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Related: https://github.com/containerd/stargz-snapshotter/issues/155

ghcr.io (recently?) uses s3 backend (`https://github-production-container-registry.s3.amazonaws.com`) for distributing layer blobs. But currently we are facing the following problems when lazypulling from that registry.

- The backend doesn't allow HEAD request : fails with 403 (seems related to #128 where HEAD from `docker-images-prod.s3.amazonaws.com` fails)
- The redirected URL (`https://github-production-container-registry.s3.amazonaws.com/blobs...`) expires soon (300sec?) : fails with 403

Reproducer for the HEAD issue:
```console
$ curl -v https://ghcr.io/token?scope=repository:stargz-containers/python:pull
 ... getting token here ....

$ curl -v -H "Authorization: ..." https://ghcr.io/v2/stargz-containers/python/blobs/sha256:c9340f06be1e5222045e58720d755a4054ce843b691b7c3e63b769c1b10a82c0
 ... getting 307 here ....

$ curl --head 'https://github-production-container-registry.s3.amazonaws.com/blobs/...
HTTP/1.1 403 Forbidden
...
```

This commit solves these issues by adding the following changes:

- falling back to GET method when getting size fails with HEAD
- re-redirecting and getting fresh backend URL when 403 is returned during fetching blob data

