### PR TITLE
Use pre-converted images on ghcr.io

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,7 +8,8 @@ jobs:
     env:
       BENCHMARK_LOG_DIR: ${{ github.workspace }}/log/
       BENCHMARK_RESULT_DIR: ${{ github.workspace }}/benchmark/
-      BENCHMARK_USER: stargz
+      BENCHMARK_REGISTRY: ghcr.io
+      BENCHMARK_USER: stargz-containers
       BENCHMARK_TARGETS: python:3.7 gcc:9.2.0 rethinkdb:2.3.6 glassfish:4.1-jdk8
       BENCHMARK_SAMPLES_NUM: 5
       BENCHMARK_PERCENTILE: 95

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ docker build -t stargz-kind-node https://github.com/containerd/stargz-snapshot
 $ kind create cluster --name stargz-demo --image stargz-kind-node
 ```
 
-Then you can create stargz pods on the cluster. In this example, we create a stargz-converted Node.js pod (`stargz/node:13.13-esgz`) as a demo.
+Then you can create stargz pods on the cluster. In this example, we create a stargz-converted Node.js pod (`ghcr.io/stargz-containers/node:13.13-esgz`) as a demo.
 
 ```yaml
 apiVersion: v1
@@ -52,7 +52,7 @@ metadata:
 spec:
   containers:
   - name: nodejs-stargz
-    image: stargz/node:13.13.0-esgz
+    image: ghcr.io/stargz-containers/node:13.13.0-esgz
     command: ["node"]
     args:
     - -e
@@ -65,7 +65,7 @@ spec:
     - containerPort: 80
 ```
 
-The following command lazily pulls `stargz/node:13.13.0-esgz` from Docker Hub and creates the pod so the time to take for it is shorter than the original image `library/node:13.13`.
+The following command lazily pulls `ghcr.io/stargz-containers/node:13.13.0-esgz` from Github Container Registry and creates the pod so the time to take for it is shorter than the original image `library/node:13.13`.
 
 ```console
 $ kubectl --context kind-stargz-demo apply -f stargz-pod.yaml && kubectl get po nodejs -w

--- a/docs/pre-converted-images.md
+++ b/docs/pre-converted-images.md
@@ -1,6 +1,6 @@
 # Trying pre-converted images
 
-We have several pre-converted stargz images on Docker Hub, mainly for benchmarking purpose. This doc lists these images in a table format. You can try them on your machine with our snapshotter. Please refer to README for the procedure.
+We have several pre-converted stargz images on Github Container Registry, mainly for benchmarking purpose. This doc lists these images in a table format. You can try them on your machine with our snapshotter. Please refer to README for the procedure.
 
 Please do not use them in production. You always can build your stargz images optimized for your workload, using `ctr-remote` command (Please also see README).
 
@@ -8,7 +8,9 @@ Please do not use them in production. You always can build your stargz images op
 
 This section contains a table of pre-converted images which can be used for benchmarking, testing, etc.
 
-In the following table, `Image Name` column contains placeholders `{{ suffix }}` for image names. One of the following suffixes comes there based on the type of image.
+We have pre-converted images on GitHub Container Registry. Images are stored under the repository `ghcr.io/stargz-containers`.
+
+Additionally, image names listed in `Image Name` contain the following suffixes based on the type of the image.
 
 - `org`: Legacy image copied from `docker.io/library` without optimization. Layers are normal tarballs.
 - `sgz`: Stargz-formatted version of the `org` images. Layers are stargz archives and we can see performance improvement on the pull operation.
@@ -18,19 +20,51 @@ In the following table, `Image Name` column contains placeholders `{{ suffix }}`
 
 |Image Name|Optimized Workload|
 ---|---
-|`docker.io/stargz/alpine:3.10.2-{{ suffix }}`|Executing `echo hello` on the shell|
-|`docker.io/stargz/drupal:8.7.6-{{ suffix }}`|Code execution until up and ready message (`apache2 -D FOREGROUND`) is printed|
-|`docker.io/stargz/fedora:30-{{ suffix }}`|Executing `echo hello` on the shell|
-|`docker.io/stargz/gcc:9.2.0-{{ suffix }}`|Compiling and executing a program which prints `hello`|
-|`docker.io/stargz/glassfish:4.1-jdk8-{{ suffix }}`|Code execution until up and ready message (`Running GlassFish`) is printed|
-|`docker.io/stargz/golang:1.12.9-{{ suffix }}`|Compiling and executing a program which prints `hello`|
-|`docker.io/stargz/jenkins:2.60.3-{{ suffix }}`|Code execution until up and ready message (`Jenkins is fully up and running`) is printed|
-|`docker.io/stargz/jruby:9.2.8.0-{{ suffix }}`|Printing `hello`|
-|`docker.io/stargz/node:13.13.0-{{ suffix }}`|Printing `hello`|
-|`docker.io/stargz/perl:5.30-{{ suffix }}`|Printing `hello`|
-|`docker.io/stargz/php:7.3.8-{{ suffix }}`|Printing `hello`|
-|`docker.io/stargz/pypy:3.5-{{ suffix }}`|Printing `hello`|
-|`docker.io/stargz/python:3.7-{{ suffix }}`|Printing `hello`|
-|`docker.io/stargz/r-base:3.6.1-{{ suffix }}`|Printing `hello`|
-|`docker.io/stargz/redis:5.0.5-{{ suffix }}`|Code execution until up and ready message (`Ready to accept connections`) is printed|
-|`docker.io/stargz/rethinkdb:2.3.6-{{ suffix }}`|Code execution until up and ready message (`Server ready`) is printed|
+|`ghcr.io/stargz-containers/alpine:3.10.2-org`|Executing `echo hello` on the shell|
+|`ghcr.io/stargz-containers/alpine:3.10.2-sgz`|Executing `echo hello` on the shell|
+|`ghcr.io/stargz-containers/alpine:3.10.2-esgz`|Executing `echo hello` on the shell|
+|`ghcr.io/stargz-containers/drupal:8.7.6-org`|Code execution until up and ready message (`apache2 -D FOREGROUND`) is printed|
+|`ghcr.io/stargz-containers/drupal:8.7.6-sgz`|Code execution until up and ready message (`apache2 -D FOREGROUND`) is printed|
+|`ghcr.io/stargz-containers/drupal:8.7.6-esgz`|Code execution until up and ready message (`apache2 -D FOREGROUND`) is printed|
+|`ghcr.io/stargz-containers/fedora:30-org`|Executing `echo hello` on the shell|
+|`ghcr.io/stargz-containers/fedora:30-sgz`|Executing `echo hello` on the shell|
+|`ghcr.io/stargz-containers/fedora:30-esgz`|Executing `echo hello` on the shell|
+|`ghcr.io/stargz-containers/gcc:9.2.0-org`|Compiling and executing a program which prints `hello`|
+|`ghcr.io/stargz-containers/gcc:9.2.0-sgz`|Compiling and executing a program which prints `hello`|
+|`ghcr.io/stargz-containers/gcc:9.2.0-esgz`|Compiling and executing a program which prints `hello`|
+|`ghcr.io/stargz-containers/glassfish:4.1-jdk8-org`|Code execution until up and ready message (`Running GlassFish`) is printed|
+|`ghcr.io/stargz-containers/glassfish:4.1-jdk8-sgz`|Code execution until up and ready message (`Running GlassFish`) is printed|
+|`ghcr.io/stargz-containers/glassfish:4.1-jdk8-esgz`|Code execution until up and ready message (`Running GlassFish`) is printed|
+|`ghcr.io/stargz-containers/golang:1.12.9-org`|Compiling and executing a program which prints `hello`|
+|`ghcr.io/stargz-containers/golang:1.12.9-sgz`|Compiling and executing a program which prints `hello`|
+|`ghcr.io/stargz-containers/golang:1.12.9-esgz`|Compiling and executing a program which prints `hello`|
+|`ghcr.io/stargz-containers/jenkins:2.60.3-org`|Code execution until up and ready message (`Jenkins is fully up and running`) is printed|
+|`ghcr.io/stargz-containers/jenkins:2.60.3-sgz`|Code execution until up and ready message (`Jenkins is fully up and running`) is printed|
+|`ghcr.io/stargz-containers/jenkins:2.60.3-esgz`|Code execution until up and ready message (`Jenkins is fully up and running`) is printed|
+|`ghcr.io/stargz-containers/jruby:9.2.8.0-org`|Printing `hello`|
+|`ghcr.io/stargz-containers/jruby:9.2.8.0-sgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/jruby:9.2.8.0-esgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/node:13.13.0-org`|Printing `hello`|
+|`ghcr.io/stargz-containers/node:13.13.0-sgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/node:13.13.0-esgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/perl:5.30-org`|Printing `hello`|
+|`ghcr.io/stargz-containers/perl:5.30-sgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/perl:5.30-esgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/php:7.3.8-org`|Printing `hello`|
+|`ghcr.io/stargz-containers/php:7.3.8-sgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/php:7.3.8-esgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/pypy:3.5-org`|Printing `hello`|
+|`ghcr.io/stargz-containers/pypy:3.5-sgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/pypy:3.5-esgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/python:3.7-org`|Printing `hello`|
+|`ghcr.io/stargz-containers/python:3.7-sgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/python:3.7-esgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/r-base:3.6.1-org`|Printing `hello`|
+|`ghcr.io/stargz-containers/r-base:3.6.1-sgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/r-base:3.6.1-esgz`|Printing `hello`|
+|`ghcr.io/stargz-containers/redis:5.0.5-org`|Code execution until up and ready message (`Ready to accept connections`) is printed|
+|`ghcr.io/stargz-containers/redis:5.0.5-sgz`|Code execution until up and ready message (`Ready to accept connections`) is printed|
+|`ghcr.io/stargz-containers/redis:5.0.5-esgz`|Code execution until up and ready message (`Ready to accept connections`) is printed|
+|`ghcr.io/stargz-containers/rethinkdb:2.3.6-org`|Code execution until up and ready message (`Server ready`) is printed|
+|`ghcr.io/stargz-containers/rethinkdb:2.3.6-sgz`|Code execution until up and ready message (`Server ready`) is printed|
+|`ghcr.io/stargz-containers/rethinkdb:2.3.6-esgz`|Code execution until up and ready message (`Server ready`) is printed|

--- a/script/benchmark/hello-bench/prepare.sh
+++ b/script/benchmark/hello-bench/prepare.sh
@@ -20,11 +20,11 @@ MEASURING_SCRIPT=./script/benchmark/hello-bench/src/hello.py
 
 if [ $# -lt 1 ] ; then
     echo "Specify benchmark target."
-    echo "Ex) ${0} <YOUR_ACCOUNT_NAME> --all"
-    echo "Ex) ${0} <YOUR_ACCOUNT_NAME> alpine busybox"
+    echo "Ex) ${0} <YOUR_REPOSITORY_NAME> --all"
+    echo "Ex) ${0} <YOUR_REPOSITORY_NAME> alpine busybox"
     exit 1
 fi
-TARGET_REPOUSER="${1}"
+TARGET_REPOSITORY="${1}"
 TARGET_IMAGES=${@:2}
 
 if ! which ctr-remote ; then
@@ -35,4 +35,4 @@ if ! which ctr-remote ; then
         install /tmp/out/ctr-remote /usr/local/bin
 fi
 
-"${MEASURING_SCRIPT}" --user=${TARGET_REPOUSER} --op=prepare ${TARGET_IMAGES}
+"${MEASURING_SCRIPT}" --repository=${TARGET_REPOSITORY} --op=prepare ${TARGET_IMAGES}

--- a/script/benchmark/hello-bench/run.sh
+++ b/script/benchmark/hello-bench/run.sh
@@ -38,11 +38,11 @@ BENCHMARKOUT_MARK_OUTPUT="BENCHMARK_OUTPUT: "
 
 if [ $# -lt 1 ] ; then
     echo "Specify benchmark target."
-    echo "Ex) ${0} <YOUR_ACCOUNT_NAME> --all"
-    echo "Ex) ${0} <YOUR_ACCOUNT_NAME> alpine busybox"
+    echo "Ex) ${0} <YOUR_REPOSITORY_NAME> --all"
+    echo "Ex) ${0} <YOUR_REPOSITORY_NAME> alpine busybox"
     exit 1
 fi
-TARGET_REPOUSER="${1}"
+TARGET_REPOSITORY="${1}"
 TARGET_IMAGES=${@:2}
 NUM_OF_SAMPLES="${BENCHMARK_SAMPLES_NUM:-1}"
 
@@ -67,8 +67,8 @@ function set_noprefetch {
 
 function measure {
     local OPTION="${1}"
-    local USER="${2}"
-    "${MEASURING_SCRIPT}" ${OPTION} --user=${USER} --op=run --experiments=1 ${@:3}
+    local REPOSITORY="${2}"
+    "${MEASURING_SCRIPT}" ${OPTION} --repository=${REPOSITORY} --op=run --experiments=1 ${@:3}
 }
 
 echo "========="
@@ -110,14 +110,14 @@ for SAMPLE_NO in $(seq ${NUM_OF_SAMPLES}) ; do
 
         if [ "${MODE}" == "${LEGACY_MODE}" ] ; then
             NO_STARGZ_SNAPSHOTTER="true" "${REBOOT_CONTAINERD_SCRIPT}"
-            measure "--mode=legacy" ${TARGET_REPOUSER} ${IMAGE}
+            measure "--mode=legacy" ${TARGET_REPOSITORY} ${IMAGE}
         fi
 
         if [ "${MODE}" == "${STARGZ_MODE}" ] ; then
             echo -n "" > "${TMP_LOG_FILE}"
             set_noprefetch "true" # disable prefetch
             LOG_FILE="${TMP_LOG_FILE}" "${REBOOT_CONTAINERD_SCRIPT}"
-            measure "--mode=stargz" ${TARGET_REPOUSER} ${IMAGE}
+            measure "--mode=stargz" ${TARGET_REPOSITORY} ${IMAGE}
             check_remote_snapshots "${TMP_LOG_FILE}"
         fi
 
@@ -125,7 +125,7 @@ for SAMPLE_NO in $(seq ${NUM_OF_SAMPLES}) ; do
             echo -n "" > "${TMP_LOG_FILE}"
             set_noprefetch "false" # enable prefetch
             LOG_FILE="${TMP_LOG_FILE}" "${REBOOT_CONTAINERD_SCRIPT}"
-            measure "--mode=estargz" ${TARGET_REPOUSER} ${IMAGE}
+            measure "--mode=estargz" ${TARGET_REPOSITORY} ${IMAGE}
             check_remote_snapshots "${TMP_LOG_FILE}"
         fi
     done

--- a/script/benchmark/test.sh
+++ b/script/benchmark/test.sh
@@ -112,7 +112,8 @@ if ! ( cd "${CONTEXT}" && \
            docker-compose -f "${DOCKER_COMPOSE_YAML}" up -d --force-recreate && \
            docker exec -e BENCHMARK_SAMPLES_NUM -i "${BENCHMARKING_CONTAINER}" \
                   script/benchmark/hello-bench/run.sh \
-                  "${BENCHMARK_USER}" ${BENCHMARK_TARGETS} &> "${LOG_FILE}" ) ; then
+                  "${BENCHMARK_REGISTRY:-docker.io}/${BENCHMARK_USER}" \
+                  ${BENCHMARK_TARGETS} &> "${LOG_FILE}" ) ; then
     echo "Failed to run benchmark."
     FAIL=true
 fi

--- a/stargz/remote/resolver.go
+++ b/stargz/remote/resolver.go
@@ -437,10 +437,7 @@ func (f *fetcher) refreshURL(ctx context.Context) error {
 }
 
 func (f *fetcher) genID(reg region) string {
-	f.urlMu.Lock()
-	url := f.url
-	f.urlMu.Unlock()
-	sum := sha256.Sum256([]byte(fmt.Sprintf("%s-%d-%d", url, reg.b, reg.e)))
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s-%d-%d", f.blobURL, reg.b, reg.e)))
 	return fmt.Sprintf("%x", sum)
 }
 


### PR DESCRIPTION
Fixes: #155

This commit uses pre-converted images stored on ghcr.io in our Github Actions
jobs. This also updates some docs in this repo to use images on ghcr.io.