### PR TITLE
Enable to pass mount config to runc during optimize

### DIFF
--- a/cmd/ctr-remote/commands/optimize.go
+++ b/cmd/ctr-remote/commands/optimize.go
@@ -104,6 +104,10 @@ var OptimizeCommand = cli.Command{
 			Name:  "env",
 			Usage: "environment valulable to add or override to the image's default config",
 		},
+		cli.StringSliceFlag{
+			Name:  "mount",
+			Usage: "additional mounts for the container (e.g. type=foo,source=/path,destination=/target,options=bind)",
+		},
 	},
 	Action: func(context *cli.Context) error {
 
@@ -147,6 +151,9 @@ var OptimizeCommand = cli.Command{
 func parseArgs(clicontext *cli.Context) (opts []sampler.Option, err error) {
 	if env := clicontext.StringSlice("env"); len(env) > 0 {
 		opts = append(opts, sampler.WithEnvs(env))
+	}
+	if mounts := clicontext.StringSlice("mount"); len(mounts) > 0 {
+		opts = append(opts, sampler.WithMounts(mounts))
 	}
 	if args := clicontext.String("args"); args != "" {
 		var as []string

--- a/cmd/ctr-remote/sampler/options.go
+++ b/cmd/ctr-remote/sampler/options.go
@@ -25,11 +25,18 @@ type options struct {
 	user       string
 	workingDir string
 	terminal   bool
+	mounts     []string
 }
 
 func WithEnvs(envs []string) Option {
 	return func(opts *options) {
 		opts.envs = envs
+	}
+}
+
+func WithMounts(mounts []string) Option {
+	return func(opts *options) {
+		opts.mounts = mounts
 	}
 }
 


### PR DESCRIPTION
Related: #169

Currently, `ctr-remote i optimize` doesn't set runc's mount configration.
This commit add a new option for enabling to pass mount config to runc.
The syntax of this option is compatible to containerd's ctr command.

```console
# mkdir /tmp/src
# echo "hello" > /tmp/src/hello
# ctr-remote i optimize --mount="source=/tmp/src,destination=/host,options=bind" --args='[ "cat", "/host/hello" ]' --plain-http ghcr.io/stargz-containers/python:3.7-esgz http://registry2:5000/python:3.7
WARN[0000] 2020/11/10 09:49:51 No matching credentials were found, falling back on anonymous 
INFO[0004] unpacked sha256:04a987509d1e5d70dbfe6aad61f2ee3d70a512c0f3434723639b70b24d072c0d 
INFO[0006] unpacked sha256:2b7dda57fc554194146e95280cdd43f06eb365fe7e899fb3e72ceed98830a9bf 
INFO[0008] unpacked sha256:652b54dc0d9a7defffa4164e74b17f290c50a24138bb10b99cd37b042790dce2 
INFO[0010] unpacked sha256:52dc0ed31371840fb6adae9a4c0cfc7b04a047ee55ee17b90e2fbe24f05eac97 
INFO[0011] unpacked sha256:02f29fcc3f22186a0f62a6b7f171d8e851191ad902b3d57622137b501f53b041 
INFO[0012] unpacked sha256:4901ffcb139c20ac2d6947efee23ce5f0664738feaa5c9794adaeff43db3ea67 
INFO[0016] unpacked sha256:efd30710d5baf5bd2b9c7070b201a2f3ce0b9590d0a84d0556d7fcb7355c772f 
INFO[0026] unpacked sha256:6e76dad46d5baedef751086b18d59b4caa40461e6e14e53c3a84fa12ebad331c 
INFO[0050] unpacked sha256:c9340f06be1e5222045e58720d755a4054ce843b691b7c3e63b769c1b10a82c0 
INFO[0050] running container "bul64s8pt0h1q8n803bg"     
hello
INFO[0050] container "bul64s8pt0h1q8n803bg" stopped     
INFO[0050] converted sha256:04a987509d1e5d70dbfe6aad61f2ee3d70a512c0f3434723639b70b24d072c0d 
INFO[0054] converted sha256:2b7dda57fc554194146e95280cdd43f06eb365fe7e899fb3e72ceed98830a9bf 
INFO[0056] converted sha256:02f29fcc3f22186a0f62a6b7f171d8e851191ad902b3d57622137b501f53b041 
INFO[0058] converted sha256:52dc0ed31371840fb6adae9a4c0cfc7b04a047ee55ee17b90e2fbe24f05eac97 
INFO[0062] converted sha256:652b54dc0d9a7defffa4164e74b17f290c50a24138bb10b99cd37b042790dce2 
INFO[0075] converted sha256:4901ffcb139c20ac2d6947efee23ce5f0664738feaa5c9794adaeff43db3ea67 
INFO[0087] converted sha256:efd30710d5baf5bd2b9c7070b201a2f3ce0b9590d0a84d0556d7fcb7355c772f 
INFO[0091] converted sha256:6e76dad46d5baedef751086b18d59b4caa40461e6e14e53c3a84fa12ebad331c 
INFO[0182] converted sha256:c9340f06be1e5222045e58720d755a4054ce843b691b7c3e63b769c1b10a82c0 
WARN[0182] 2020/11/10 09:52:53 No matching credentials were found, falling back on anonymous 
INFO[0183] 2020/11/10 09:52:54 pushed blob: sha256:04a987509d1e5d70dbfe6aad61f2ee3d70a512c0f3434723639b70b24d072c0d 
INFO[0183] 2020/11/10 09:52:55 pushed blob: sha256:c913c0e002255adfb66b218965246a6b6c4620eb99a9bffc7ee7420d128d2b5c 
INFO[0184] 2020/11/10 09:52:56 pushed blob: sha256:652b54dc0d9a7defffa4164e74b17f290c50a24138bb10b99cd37b042790dce2 
INFO[0185] 2020/11/10 09:52:56 pushed blob: sha256:52dc0ed31371840fb6adae9a4c0cfc7b04a047ee55ee17b90e2fbe24f05eac97 
INFO[0185] 2020/11/10 09:52:56 pushed blob: sha256:02f29fcc3f22186a0f62a6b7f171d8e851191ad902b3d57622137b501f53b041 
INFO[0186] 2020/11/10 09:52:57 pushed blob: sha256:0870eaafb1a46304dbb45df97a52d43a42b7830484a69b8cd2c9cd8f4753ea1f 
INFO[0189] 2020/11/10 09:53:01 pushed blob: sha256:ab230d5f7de7ede7037e0da6cb7500938961f7322b423ff49d7a10d461c5f674 
INFO[0190] 2020/11/10 09:53:01 pushed blob: sha256:6e76dad46d5baedef751086b18d59b4caa40461e6e14e53c3a84fa12ebad331c 
INFO[0202] 2020/11/10 09:53:13 pushed blob: sha256:c9340f06be1e5222045e58720d755a4054ce843b691b7c3e63b769c1b10a82c0 
INFO[0202] 2020/11/10 09:53:13 pushed blob: sha256:e92d97f04ffa9e004fb6eca29237cd65b4247c18f55c7538330e01e9b37b5b91 
INFO[0202] 2020/11/10 09:53:14 registry2:5000/python:3.7: digest: sha256:1dbb2d98331cddb7cc7cc7eeda363cfea8a8515c804bf674a79fceb5261afb13 size: 2939
```
