### PR TITLE
Parallelize building stargz blob

### DIFF
--- a/cmd/ctr-remote/builder/build.go
+++ b/cmd/ctr-remote/builder/build.go
@@ -1,0 +1,298 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package builder
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strconv"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/stargz-snapshotter/cmd/ctr-remote/sorter"
+	"github.com/google/crfs/stargz"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+// jtoc is the TOC JSON schema of stargz
+// https://github.com/google/crfs/blob/71d77da419c90be7b05d12e59945ac7a8c94a543/stargz/stargz.go
+type jtoc struct {
+
+	// Version is a field to store the version information of TOC JSON.
+	Version int `json:"version"`
+
+	// Entries is a field to store TOCEntries in this archive.
+	Entries []*stargz.TOCEntry `json:"entries"`
+}
+
+type options struct {
+	chunkSize int
+}
+
+type Option func(o *options)
+
+func WithChunkSize(chunkSize int) Option {
+	return func(o *options) {
+		o.chunkSize = chunkSize
+	}
+}
+
+// BuildStargz builds a stargz layer according to the passed entries and write the result
+// to the specified writer. This function builds a stargz blob in parallel, with dividing
+// that blob into several (at least the number of runtime.GOMAXPROCS(0)) sub-blobs.
+func BuildStargz(ctx context.Context, entries []*sorter.TarEntry, w io.Writer, opt ...Option) error {
+	var opts options
+	for _, o := range opt {
+		o(&opts)
+	}
+	var sgzParts []*os.File
+	var eg errgroup.Group
+	for i, parts := range divideEntries(entries, runtime.GOMAXPROCS(0)) {
+		partFile, err := ioutil.TempFile("", "partdata")
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := partFile.Close(); err != nil {
+				log.G(ctx).WithError(err).Warnf("failed to close tmpfile %v",
+					partFile.Name())
+			}
+			if err := os.Remove(partFile.Name()); err != nil {
+				log.G(ctx).WithError(err).Warnf("failed to remove tmpfile %v",
+					partFile.Name())
+			}
+		}()
+		sgzParts = append(sgzParts, partFile)
+		i, parts := i, parts
+		eg.Go(func() error {
+			log.G(ctx).WithField("entries", len(parts)).Debugf("converting(%d)", i)
+			defer log.G(ctx).WithField("entries", len(parts)).Debugf("converted(%d)", i)
+			sw := stargz.NewWriter(partFile)
+			sw.ChunkSize = opts.chunkSize
+			if err := sw.AppendTar(sorter.ReaderFromEntries(parts...)); err != nil {
+				return err
+			}
+			return sw.Close()
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+	var partBlobs []*io.SectionReader
+	for _, f := range sgzParts {
+		info, err := f.Stat()
+		if err != nil {
+			return err
+		}
+		partBlobs = append(partBlobs, io.NewSectionReader(f, 0, info.Size()))
+	}
+	whole, err := combineBlobs(partBlobs...)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(w, whole)
+	return err
+}
+
+// divideEntries divides passed entries to the parts at least the number specified by the
+// argument.
+func divideEntries(entries []*sorter.TarEntry, minPartsNum int) (set [][]*sorter.TarEntry) {
+	var estimatedSize int64
+	for _, e := range entries {
+		estimatedSize += e.Header.Size
+	}
+	unitSize := estimatedSize / int64(minPartsNum)
+	var (
+		nextEnd = unitSize
+		offset  int64
+	)
+	set = append(set, []*sorter.TarEntry{})
+	for _, e := range entries {
+		set[len(set)-1] = append(set[len(set)-1], e)
+		offset += e.Header.Size
+		if offset > nextEnd {
+			set = append(set, []*sorter.TarEntry{})
+			nextEnd += unitSize
+		}
+	}
+	return
+}
+
+type stargzBlob struct {
+	payload     io.Reader
+	payloadSize int64
+	tocJSON     *jtoc
+}
+
+// combineBlobs combines passed stargz blobs and returns one reader of stargz.
+func combineBlobs(sgz ...*io.SectionReader) (newSgz io.Reader, err error) {
+	if len(sgz) == 0 {
+		return nil, fmt.Errorf("at least one reader must be passed")
+	}
+	var blobs []*stargzBlob
+	for _, r := range sgz {
+		blob, err := parseStargz(r)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse stargz")
+		}
+		blobs = append(blobs, blob)
+	}
+	var (
+		mjtoc         = new(jtoc)
+		mpayload      []io.Reader
+		currentOffset int64
+	)
+	mjtoc.Version = blobs[0].tocJSON.Version
+	for _, b := range blobs {
+		for _, e := range b.tocJSON.Entries {
+			// Recalculate Offset of non-empty files/chunks
+			if (e.Type == "reg" && e.Size > 0) || e.Type == "chunk" {
+				e.Offset += currentOffset
+			}
+			mjtoc.Entries = append(mjtoc.Entries, e)
+		}
+		if b.tocJSON.Version < mjtoc.Version {
+			mjtoc.Version = b.tocJSON.Version
+		}
+		mpayload = append(mpayload, b.payload)
+		currentOffset += b.payloadSize
+	}
+	tocjson, err := marshalTOCJSON(mjtoc)
+	if err != nil {
+		return nil, err
+	}
+	footerBuf := bytes.NewBuffer(make([]byte, 0, stargz.FooterSize))
+	zw, err := gzip.NewWriterLevel(footerBuf, gzip.BestCompression)
+	if err != nil {
+		return nil, err
+	}
+	zw.Extra = []byte(fmt.Sprintf("%016xSTARGZ", currentOffset)) // Extra header indicating the offset of TOCJSON: https://github.com/google/crfs/blob/71d77da419c90be7b05d12e59945ac7a8c94a543/stargz/stargz.go#L46
+	zw.Close()
+	if footerBuf.Len() != stargz.FooterSize {
+		return nil, fmt.Errorf("failed to make the footer: invalid size %d; must be %d",
+			footerBuf.Len(), stargz.FooterSize)
+	}
+	return io.MultiReader(
+		io.MultiReader(mpayload...),
+		tocjson,
+		bytes.NewReader(footerBuf.Bytes()),
+	), nil
+}
+
+// marshalTOCJSON marshals TOCJSON and returns a reader of the bytes.
+func marshalTOCJSON(toc *jtoc) (io.Reader, error) {
+	tocJSON, err := json.Marshal(*toc)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal TOC JSON")
+	}
+	pr, pw := io.Pipe()
+	go func() {
+		zw, err := gzip.NewWriterLevel(pw, gzip.BestCompression)
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		zw.Extra = []byte("stargz.toc") // this magic string might not be necessary but let's follow the official behaviour: https://github.com/google/crfs/blob/71d77da419c90be7b05d12e59945ac7a8c94a543/stargz/stargz.go#L596
+		tw := tar.NewWriter(zw)
+		if err := tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeReg,
+			Name:     stargz.TOCTarName,
+			Size:     int64(len(tocJSON)),
+		}); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if _, err := tw.Write(tocJSON); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if err := tw.Close(); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if err := zw.Close(); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		pw.Close()
+	}()
+	return pr, nil
+}
+
+// parseStargz parses the footer and TOCJSON of the stargz file
+// TODO: We have logics similar to this func in several places in this project so
+//       we should separate these logics out into a new pkg.
+func parseStargz(sgz *io.SectionReader) (blob *stargzBlob, err error) {
+	// Parse stargz footer and get the offset of TOC JSON
+	if sgz.Size() < stargz.FooterSize {
+		return nil, errors.New("stargz data is too small")
+	}
+	footerReader := io.NewSectionReader(sgz, sgz.Size()-stargz.FooterSize, stargz.FooterSize)
+	zr, err := gzip.NewReader(footerReader)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to uncompress footer")
+	}
+	defer zr.Close()
+	if len(zr.Header.Extra) != 22 {
+		return nil, errors.Wrap(err, "invalid extra size; must be 22 bytes")
+	} else if string(zr.Header.Extra[16:]) != "STARGZ" {
+		return nil, errors.New("invalid footer; extra must contain magic string \"STARGZ\"")
+	}
+	tocOffset, err := strconv.ParseInt(string(zr.Header.Extra[:16]), 16, 64)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid footer; failed to get the offset of TOC JSON")
+	} else if tocOffset > sgz.Size() {
+		return nil, fmt.Errorf("invalid footer; offset of TOC JSON is too large (%d > %d)",
+			tocOffset, sgz.Size())
+	}
+
+	// Decode the TOC JSON
+	tocReader := io.NewSectionReader(sgz, tocOffset, sgz.Size()-tocOffset-stargz.FooterSize)
+	if err := zr.Reset(tocReader); err != nil {
+		return nil, errors.Wrap(err, "failed to uncompress TOC JSON targz entry")
+	}
+	tr := tar.NewReader(zr)
+	h, err := tr.Next()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get TOC JSON tar entry")
+	} else if h.Name != stargz.TOCTarName {
+		return nil, fmt.Errorf("invalid TOC JSON tar entry name %q; must be %q",
+			h.Name, stargz.TOCTarName)
+	}
+	decodedJTOC := new(jtoc)
+	if err := json.NewDecoder(tr).Decode(&decodedJTOC); err != nil {
+		return nil, errors.Wrap(err, "failed to decode TOC JSON")
+	}
+	if _, err := tr.Next(); err != io.EOF {
+		// We only accept stargz file that its TOC JSON resides at the end of that
+		// file to avoid changing the offsets of the following file entries by
+		// rewriting TOC JSON (The official stargz lib also puts TOC JSON at the end
+		// of the stargz file at this mement).
+		// TODO: in the future, we should relax this restriction.
+		return nil, errors.New("TOC JSON must reside at the end of targz")
+	}
+
+	return &stargzBlob{io.LimitReader(sgz, tocOffset), tocOffset, decodedJTOC}, nil
+}

--- a/cmd/ctr-remote/builder/build_test.go
+++ b/cmd/ctr-remote/builder/build_test.go
@@ -1,0 +1,544 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package builder
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containerd/stargz-snapshotter/cmd/ctr-remote/sorter"
+	sgzsn "github.com/containerd/stargz-snapshotter/stargz"
+	"github.com/google/crfs/stargz"
+)
+
+// TestBuild tests the resulting stargz blob built by this pkg has the same
+// contents as the normal stargz blob.
+func TestBuild(t *testing.T) {
+	tests := []struct {
+		name      string
+		chunkSize int
+		tarBlob   blob
+	}{
+		{
+			name:      "regfiles and directories",
+			chunkSize: 4,
+			tarBlob: tarBlob(
+				reg("foo", "test1", nil),
+				directory("foo2/"),
+				reg("foo2/bar", "test2", map[string]string{"test": "sample"}),
+			),
+		},
+		{
+			name:      "empty files",
+			chunkSize: 4,
+			tarBlob: tarBlob(
+				reg("foo", "tttttt", nil),
+				reg("foo_empty", "", nil),
+				reg("foo2", "tttttt", nil),
+				reg("foo_empty2", "", nil),
+				reg("foo3", "tttttt", nil),
+				reg("foo_empty3", "", nil),
+				reg("foo4", "tttttt", nil),
+				reg("foo_empty4", "", nil),
+				reg("foo5", "tttttt", nil),
+				reg("foo_empty5", "", nil),
+				reg("foo6", "tttttt", nil),
+			),
+		},
+		{
+			name:      "various files",
+			chunkSize: 4,
+			tarBlob: tarBlob(
+				reg("baz.txt", "bazbazbazbazbazbazbaz", nil),
+				reg("foo.txt", "a", nil),
+				symLink("barlink", "test/bar.txt"),
+				directory("test/"),
+				directory("dev/"),
+				blockdev("dev/testblock", 3, 4),
+				fifo("dev/testfifo"),
+				chardev("dev/testchar1", 5, 6),
+				reg("test/bar.txt", "testbartestbar", map[string]string{"test2": "sample2"}),
+				directory("test2/"),
+				link("test2/bazlink", "baz.txt"),
+				chardev("dev/testchar2", 1, 2),
+			),
+		},
+		{
+			name:      "no contents",
+			chunkSize: 4,
+			tarBlob: tarBlob(
+				reg("baz.txt", "", nil),
+				symLink("barlink", "test/bar.txt"),
+				directory("test/"),
+				directory("dev/"),
+				blockdev("dev/testblock", 3, 4),
+				fifo("dev/testfifo"),
+				chardev("dev/testchar1", 5, 6),
+				reg("test/bar.txt", "", map[string]string{"test2": "sample2"}),
+				directory("test2/"),
+				link("test2/bazlink", "baz.txt"),
+				chardev("dev/testchar2", 1, 2),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tarBlob, err := tt.tarBlob()
+			if err != nil {
+				t.Fatalf("faield to get sample tar: %v", err)
+			}
+			entries, err := sorter.Sort(tarBlob, nil) // identical order
+			if err != nil {
+				t.Fatalf("faield to parse tar: %v", err)
+			}
+			var merged []*sorter.TarEntry
+			for _, part := range divideEntries(entries, 4) {
+				merged = append(merged, part...)
+			}
+			if !reflect.DeepEqual(entries, merged) {
+				for _, e := range entries {
+					t.Logf("Original: %v", e.Header)
+				}
+				for _, e := range merged {
+					t.Logf("Merged: %v", e.Header)
+				}
+				t.Errorf("divided entries couldn't be merged")
+				return
+			}
+
+			// Prepare sample data
+			wantBuf := new(bytes.Buffer)
+			sw := stargz.NewWriter(wantBuf)
+			sw.ChunkSize = tt.chunkSize
+			if err := sw.AppendTar(tarBlob); err != nil {
+				t.Fatalf("faield to append tar to want stargz: %v", err)
+			}
+			if err := sw.Close(); err != nil {
+				t.Fatalf("faield to prepare want stargz: %v", err)
+			}
+			wantData := wantBuf.Bytes()
+			want, err := stargz.Open(io.NewSectionReader(
+				bytes.NewReader(wantData), 0, int64(len(wantData))))
+			if err != nil {
+				t.Fatalf("failed to parse the want stargz: %v", err)
+			}
+
+			// Prepare testing data
+			gotBuf := new(bytes.Buffer)
+			if err := BuildStargz(context.Background(),
+				entries, gotBuf, WithChunkSize(tt.chunkSize)); err != nil {
+				t.Fatalf("faield to build stargz: %v", err)
+			}
+			gotData := gotBuf.Bytes()
+			got, err := stargz.Open(io.NewSectionReader(
+				bytes.NewReader(gotBuf.Bytes()), 0, int64(len(gotData))))
+			if err != nil {
+				t.Fatalf("failed to parse the got stargz: %v", err)
+			}
+
+			// Compare as stargz
+			if !isSameVersion(t, wantData, gotData) {
+				t.Errorf("built stargz hasn't same json")
+				return
+			}
+			if !isSameEntries(t, want, got) {
+				t.Errorf("built stargz isn't same as the original")
+				return
+			}
+
+			// Compare as tar.gz
+			if !isSameTarGz(t, wantData, gotData) {
+				t.Errorf("built stargz isn't same tar.gz")
+				return
+			}
+		})
+	}
+}
+
+func isSameTarGz(t *testing.T, a, b []byte) bool {
+	aGz, err := gzip.NewReader(bytes.NewReader(a))
+	if err != nil {
+		t.Fatalf("failed to read A as gzip")
+	}
+	defer aGz.Close()
+	bGz, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("failed to read B as gzip")
+	}
+	defer bGz.Close()
+
+	// Same as tar's Next() method but ignores landmarks and TOCJSON file
+	next := func(r *tar.Reader) (h *tar.Header, err error) {
+		for {
+			if h, err = r.Next(); err != nil {
+				return
+			}
+			if h.Name != sgzsn.PrefetchLandmark &&
+				h.Name != sgzsn.NoPrefetchLandmark &&
+				h.Name != stargz.TOCTarName {
+				return
+			}
+		}
+	}
+
+	aTar := tar.NewReader(aGz)
+	bTar := tar.NewReader(bGz)
+	for {
+		// Fetch and parse next header.
+		aH, aErr := next(aTar)
+		bH, bErr := next(bTar)
+		if aErr != nil || bErr != nil {
+			if aErr == io.EOF && bErr == io.EOF {
+				break
+			}
+			t.Fatalf("Failed to parse tar file: A: %v, B: %v", aErr, bErr)
+		}
+		if !reflect.DeepEqual(aH, bH) {
+			t.Logf("different header (A = %v; B = %v)", aH, bH)
+			return false
+
+		}
+		aFile, err := ioutil.ReadAll(aTar)
+		if err != nil {
+			t.Fatal("failed to read tar payload of A")
+		}
+		bFile, err := ioutil.ReadAll(bTar)
+		if err != nil {
+			t.Fatal("failed to read tar payload of B")
+		}
+		if !bytes.Equal(aFile, bFile) {
+			t.Logf("different tar payload (A = %q; B = %q)", string(a), string(b))
+			return false
+		}
+	}
+
+	return true
+}
+
+func isSameVersion(t *testing.T, a, b []byte) bool {
+	ablob, err := parseStargz(io.NewSectionReader(bytes.NewReader(a), 0, int64(len(a))))
+	if err != nil {
+		t.Fatalf("failed to parse A: %v", err)
+	}
+	bblob, err := parseStargz(io.NewSectionReader(bytes.NewReader(b), 0, int64(len(b))))
+	if err != nil {
+		t.Fatalf("failed to parse B: %v", err)
+	}
+	t.Logf("A: TOCJSON: %v", dumpTOCJSON(t, ablob.tocJSON))
+	t.Logf("B: TOCJSON: %v", dumpTOCJSON(t, bblob.tocJSON))
+	return ablob.tocJSON.Version == bblob.tocJSON.Version
+}
+
+func isSameEntries(t *testing.T, a, b *stargz.Reader) bool {
+	aroot, ok := a.Lookup("")
+	if !ok {
+		t.Fatalf("failed to get root of A")
+	}
+	broot, ok := b.Lookup("")
+	if !ok {
+		t.Fatalf("failed to get root of B")
+	}
+	aEntry := stargzEntry{aroot, a}
+	bEntry := stargzEntry{broot, b}
+	return contains(t, aEntry, bEntry) && contains(t, bEntry, aEntry)
+}
+
+type stargzEntry struct {
+	e *stargz.TOCEntry
+	r *stargz.Reader
+}
+
+// contains checks if all child entries in "b" are also contained in "a".
+// This function also checks if the files/chunks contain the same contents among "a" and "b".
+func contains(t *testing.T, a, b stargzEntry) bool {
+	ae, ar := a.e, a.r
+	be, br := b.e, b.r
+	t.Logf("Comparing: %q vs %q", ae.Name, be.Name)
+	if !equalEntry(ae, be) {
+		t.Logf("%q != %q: entry: a: %v, b: %v", ae.Name, be.Name, ae, be)
+		return false
+	}
+	if ae.Type == "dir" {
+		t.Logf("Directory: %q vs %q: %v vs %v", ae.Name, be.Name,
+			allChildrenName(ae), allChildrenName(be))
+		iscontain := true
+		ae.ForeachChild(func(aBaseName string, aChild *stargz.TOCEntry) bool {
+			// Walk through all files on this stargz file.
+
+			if aChild.Name == sgzsn.PrefetchLandmark ||
+				aChild.Name == sgzsn.NoPrefetchLandmark {
+				return true // Ignore landmarks
+			}
+
+			// Ignore a TOCEntry of "./" (formated as "" by stargz lib) on root directory
+			// because this points to the root directory itself.
+			if aChild.Name == "" && ae.Name == "" {
+				return true
+			}
+
+			bChild, ok := be.LookupChild(aBaseName)
+			if !ok {
+				t.Logf("%q (base: %q): not found in b: %v",
+					ae.Name, aBaseName, allChildrenName(be))
+				iscontain = false
+				return false
+			}
+
+			childcontain := contains(t, stargzEntry{aChild, a.r}, stargzEntry{bChild, b.r})
+			if !childcontain {
+				t.Logf("%q != %q: non-equal dir", ae.Name, be.Name)
+				iscontain = false
+				return false
+			}
+			return true
+		})
+		return iscontain
+	} else if ae.Type == "reg" {
+		af, err := ar.OpenFile(ae.Name)
+		if err != nil {
+			t.Fatalf("failed to open file %q on A: %v", ae.Name, err)
+		}
+		bf, err := br.OpenFile(be.Name)
+		if err != nil {
+			t.Fatalf("failed to open file %q on B: %v", be.Name, err)
+		}
+
+		var nr int64
+		for nr < ae.Size {
+			abytes, anext, aok := readOffset(t, af, nr, a)
+			bbytes, bnext, bok := readOffset(t, bf, nr, b)
+			if !aok && !bok {
+				break
+			} else if !(aok && bok) || anext != bnext {
+				t.Logf("%q != %q: chunk existence a=%v vs b=%v, anext=%v vs bnext=%v",
+					ae.Name, be.Name, aok, bok, anext, bnext)
+				return false
+			}
+			nr = anext
+			if !bytes.Equal(abytes, bbytes) {
+				t.Logf("%q != %q: different contents %v vs %v",
+					ae.Name, be.Name, string(abytes), string(bbytes))
+				return false
+			}
+		}
+		return true
+	}
+
+	return true
+}
+
+func allChildrenName(e *stargz.TOCEntry) (children []string) {
+	e.ForeachChild(func(baseName string, _ *stargz.TOCEntry) bool {
+		children = append(children, baseName)
+		return true
+	})
+	return
+}
+
+func equalEntry(a, b *stargz.TOCEntry) bool {
+	// Here, we selectively compare fileds that we are interested in.
+	return a.Name == b.Name &&
+		a.Type == b.Type &&
+		a.Size == b.Size &&
+		a.ModTime3339 == b.ModTime3339 &&
+		a.Stat().ModTime().Equal(b.Stat().ModTime()) && // modTime     time.Time
+		a.LinkName == b.LinkName &&
+		a.Mode == b.Mode &&
+		a.Uid == b.Uid &&
+		a.Gid == b.Gid &&
+		a.Uname == b.Uname &&
+		a.Gname == b.Gname &&
+		(a.Offset > 0) == (b.Offset > 0) &&
+		(a.NextOffset() > 0) == (b.NextOffset() > 0) &&
+		a.DevMajor == b.DevMajor &&
+		a.DevMinor == b.DevMinor &&
+		a.NumLink == b.NumLink &&
+		reflect.DeepEqual(a.Xattrs, b.Xattrs) &&
+		// chunk-related infomations aren't compared in this function.
+		// ChunkOffset int64 `json:"chunkOffset,omitempty"`
+		// ChunkSize   int64 `json:"chunkSize,omitempty"`
+		// children map[string]*TOCEntry
+		a.Digest == b.Digest
+}
+
+func readOffset(t *testing.T, r *io.SectionReader, offset int64, e stargzEntry) ([]byte, int64, bool) {
+	ce, ok := e.r.ChunkEntryForOffset(e.e.Name, offset)
+	if !ok {
+		return nil, 0, false
+	}
+	data := make([]byte, ce.ChunkSize)
+	t.Logf("Offset: %v, NextOffset: %v", ce.Offset, ce.NextOffset())
+	n, err := r.ReadAt(data, ce.ChunkOffset)
+	if err != nil {
+		t.Fatalf("failed to read file payload of %q (offset:%d,size:%d): %v",
+			e.e.Name, ce.ChunkOffset, ce.ChunkSize, err)
+	}
+	if int64(n) != ce.ChunkSize {
+		t.Fatalf("unexpected copied data size %d; want %d",
+			n, ce.ChunkSize)
+	}
+	return data[:n], offset + ce.ChunkSize, true
+}
+
+func dumpTOCJSON(t *testing.T, tocJSON *jtoc) string {
+	jtocData, err := json.Marshal(*tocJSON)
+	if err != nil {
+		t.Fatalf("failed to marshal TOC JSON: %v", err)
+	}
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, bytes.NewReader(jtocData)); err != nil {
+		t.Fatalf("failed to read toc json blob: %v", err)
+	}
+	return buf.String()
+}
+
+type appender func(w *tar.Writer) error
+type blob func() (*io.SectionReader, error)
+
+func tarBlob(appenders ...appender) blob {
+	return func() (*io.SectionReader, error) {
+		buf := new(bytes.Buffer)
+		tw := tar.NewWriter(buf)
+		for _, f := range appenders {
+			if err := f(tw); err != nil {
+				return nil, err
+			}
+		}
+		if err := tw.Close(); err != nil {
+			return nil, err
+		}
+		data := buf.Bytes()
+		return io.NewSectionReader(bytes.NewReader(data), 0, int64(len(data))), nil
+	}
+}
+
+func directory(name string) appender {
+	if !strings.HasSuffix(name, "/") {
+		panic(fmt.Sprintf("dir %q must have suffix /", name))
+	}
+	now := time.Now()
+	return func(w *tar.Writer) error {
+		return w.WriteHeader(&tar.Header{
+			Typeflag:   tar.TypeDir,
+			Name:       name,
+			ModTime:    now,
+			AccessTime: now,
+			ChangeTime: now,
+		})
+	}
+}
+
+func reg(name string, contentStr string, xattrs map[string]string) appender {
+	now := time.Now()
+	return func(w *tar.Writer) error {
+		if err := w.WriteHeader(&tar.Header{
+			Typeflag:   tar.TypeReg,
+			Name:       name,
+			Size:       int64(len(contentStr)),
+			Xattrs:     xattrs,
+			ModTime:    now,
+			AccessTime: now,
+			ChangeTime: now,
+		}); err != nil {
+			return err
+		}
+		if _, err := io.CopyN(w, bytes.NewReader([]byte(contentStr)), int64(len(contentStr))); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func link(name string, linkname string) appender {
+	now := time.Now()
+	return func(w *tar.Writer) error {
+		return w.WriteHeader(&tar.Header{
+			Typeflag:   tar.TypeLink,
+			Name:       name,
+			Linkname:   linkname,
+			ModTime:    now,
+			AccessTime: now,
+			ChangeTime: now,
+		})
+	}
+}
+
+func symLink(name string, linkname string) appender {
+	now := time.Now()
+	return func(w *tar.Writer) error {
+		return w.WriteHeader(&tar.Header{
+			Typeflag:   tar.TypeSymlink,
+			Name:       name,
+			Linkname:   linkname,
+			ModTime:    now,
+			AccessTime: now,
+			ChangeTime: now,
+		})
+	}
+}
+
+func chardev(name string, major, minor int64) appender {
+	now := time.Now()
+	return func(w *tar.Writer) error {
+		return w.WriteHeader(&tar.Header{
+			Typeflag:   tar.TypeChar,
+			Name:       name,
+			Devmajor:   major,
+			Devminor:   minor,
+			ModTime:    now,
+			AccessTime: now,
+			ChangeTime: now,
+		})
+	}
+}
+
+func blockdev(name string, major, minor int64) appender {
+	now := time.Now()
+	return func(w *tar.Writer) error {
+		return w.WriteHeader(&tar.Header{
+			Typeflag:   tar.TypeBlock,
+			Name:       name,
+			Devmajor:   major,
+			Devminor:   minor,
+			ModTime:    now,
+			AccessTime: now,
+			ChangeTime: now,
+		})
+	}
+}
+func fifo(name string) appender {
+	now := time.Now()
+	return func(w *tar.Writer) error {
+		return w.WriteHeader(&tar.Header{
+			Typeflag:   tar.TypeFifo,
+			Name:       name,
+			ModTime:    now,
+			AccessTime: now,
+			ChangeTime: now,
+		})
+	}
+}

--- a/cmd/ctr-remote/commands/optimize.go
+++ b/cmd/ctr-remote/commands/optimize.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/stargz-snapshotter/cmd/ctr-remote/builder"
 	"github.com/containerd/stargz-snapshotter/cmd/ctr-remote/logger"
 	"github.com/containerd/stargz-snapshotter/cmd/ctr-remote/sampler"
 	"github.com/containerd/stargz-snapshotter/cmd/ctr-remote/sorter"
@@ -376,27 +377,21 @@ func optimize(ctx gocontext.Context, clicontext *cli.Context, in []regpkg.Layer,
 				defer log.G(ctx).Infof("converted")
 
 				// Sort file entry by the accessed order
-				r, err := sorter.Sort(decompressedLayer, mon.DumpLog())
+				entries, err := sorter.Sort(decompressedLayer, mon.DumpLog())
 				if err != nil {
 					return mutate.Addendum{}, errors.Wrap(err, "failed to sort tar")
 				}
 
-				// Compress the archive with stargz
-				w := stargz.NewWriter(stargzFile)
-				if err := w.AppendTar(r); err != nil {
-					return mutate.Addendum{}, errors.Wrapf(err,
-						"failed to append to stargz %q", stargzFile.Name())
-				}
-				if err := w.Close(); err != nil {
-					return mutate.Addendum{}, errors.Wrapf(err,
-						"failed to make stargz file %q", stargzFile.Name())
-				}
-				sinfo, err := stargzFile.Stat()
-				if err != nil {
+				// Build stargz
+				if err := builder.BuildStargz(ctx, entries, stargzFile); err != nil {
 					return mutate.Addendum{}, err
 				}
 
 				// Add chunks digests to TOC JSON
+				sinfo, err := stargzFile.Stat()
+				if err != nil {
+					return mutate.Addendum{}, err
+				}
 				r, jtocDigest, err := verify.NewVerifiableStagz(
 					io.NewSectionReader(stargzFile, 0, sinfo.Size()))
 				if err != nil {

--- a/cmd/ctr-remote/sorter/sorter_test.go
+++ b/cmd/ctr-remote/sorter/sorter_test.go
@@ -291,11 +291,11 @@ func TestSort(t *testing.T) {
 			wantTar := tar.NewReader(bytes.NewReader(wantTarData))
 
 			// Sort tar file
-			r, err := Sort(bytes.NewReader(inTarData), tt.log)
+			entries, err := Sort(bytes.NewReader(inTarData), tt.log)
 			if err != nil {
 				t.Fatalf("failed to sort: %q", err)
 			}
-			gotTar := tar.NewReader(r)
+			gotTar := tar.NewReader(ReaderFromEntries(entries...))
 
 			// Compare all
 			for {


### PR DESCRIPTION
Related: #169 

This commit parallelize building stargz blob into several goroutines. The number
of goroutines is currently at least the number of the
`runtime.GOMAXPROCS(0)`.

In this patch, during building a stargz blob, the original tar archive is divided into several
parts. These parts are converted to stargz in parallel. Finally, the converted
(parts of) stargz blobs are combined into one blob.

### Benchmarking

Converting `ghcr.io/stargz-containers/fedora:30-org` into eStargz on Github Actions.
https://github.com/ktock/stargz-snapshotter/actions/runs/366409761

```console
ctr-remote i optimize --args='[ "echo", "hello" ]' \
           --plain-http ghcr.io/stargz-containers/fedora:30-org http://registry-ctr2:5000/fedora:30-esgz
```

#### Master branch

Measured 3 times:

```
real	0m54.206s
user	0m56.162s
sys	0m1.495s

real	0m54.850s
user	0m56.889s
sys	0m1.621s

real	0m54.598s
user	0m56.673s
sys	0m1.568s
```

#### This PR's branch

Measured 3 times:

```
real	0m36.004s
user	0m53.794s
sys	0m1.562s

real	0m36.599s
user	0m54.749s
sys	0m1.688s

real	0m37.043s
user	0m55.170s
sys	0m1.523s

```
