### PR TITLE
Enable ctr-remote to handle image index

### DIFF
--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/README.md
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/README.md
@@ -1,0 +1,5 @@
+# `layout`
+
+[![GoDoc](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout?status.svg)](https://godoc.org/github.com/google/go-containerregistry/pkg/v1/layout)
+
+The `layout` package implements support for interacting with an [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/master/image-layout.md).

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/blob.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/blob.go
@@ -1,0 +1,38 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// Blob returns a blob with the given hash from the Path.
+func (l Path) Blob(h v1.Hash) (io.ReadCloser, error) {
+	return os.Open(l.blobPath(h))
+}
+
+// Bytes is a convenience function to return a blob from the Path as
+// a byte slice.
+func (l Path) Bytes(h v1.Hash) ([]byte, error) {
+	return ioutil.ReadFile(l.blobPath(h))
+}
+
+func (l Path) blobPath(h v1.Hash) string {
+	return l.path("blobs", h.Algorithm, h.Hex)
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/doc.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package layout provides facilities for reading/writing artifacts from/to
+// an OCI image layout on disk, see:
+//
+// https://github.com/opencontainers/image-spec/blob/master/image-layout.md
+package layout

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/image.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/image.go
@@ -1,0 +1,131 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type layoutImage struct {
+	path         Path
+	desc         v1.Descriptor
+	manifestLock sync.Mutex // Protects rawManifest
+	rawManifest  []byte
+}
+
+var _ partial.CompressedImageCore = (*layoutImage)(nil)
+
+// Image reads a v1.Image with digest h from the Path.
+func (l Path) Image(h v1.Hash) (v1.Image, error) {
+	ii, err := l.ImageIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	return ii.Image(h)
+}
+
+func (li *layoutImage) MediaType() (types.MediaType, error) {
+	return li.desc.MediaType, nil
+}
+
+// Implements WithManifest for partial.Blobset.
+func (li *layoutImage) Manifest() (*v1.Manifest, error) {
+	return partial.Manifest(li)
+}
+
+func (li *layoutImage) RawManifest() ([]byte, error) {
+	li.manifestLock.Lock()
+	defer li.manifestLock.Unlock()
+	if li.rawManifest != nil {
+		return li.rawManifest, nil
+	}
+
+	b, err := li.path.Bytes(li.desc.Digest)
+	if err != nil {
+		return nil, err
+	}
+
+	li.rawManifest = b
+	return li.rawManifest, nil
+}
+
+func (li *layoutImage) RawConfigFile() ([]byte, error) {
+	manifest, err := li.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	return li.path.Bytes(manifest.Config.Digest)
+}
+
+func (li *layoutImage) LayerByDigest(h v1.Hash) (partial.CompressedLayer, error) {
+	manifest, err := li.Manifest()
+	if err != nil {
+		return nil, err
+	}
+
+	if h == manifest.Config.Digest {
+		return partial.CompressedLayer(&compressedBlob{
+			path: li.path,
+			desc: manifest.Config,
+		}), nil
+	}
+
+	for _, desc := range manifest.Layers {
+		if h == desc.Digest {
+			switch desc.MediaType {
+			case types.OCILayer, types.DockerLayer:
+				return partial.CompressedToLayer(&compressedBlob{
+					path: li.path,
+					desc: desc,
+				})
+			default:
+				// TODO: We assume everything is a compressed blob, but that might not be true.
+				// TODO: Handle foreign layers.
+				return nil, fmt.Errorf("unexpected media type: %v for layer: %v", desc.MediaType, desc.Digest)
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("could not find layer in image: %s", h)
+}
+
+type compressedBlob struct {
+	path Path
+	desc v1.Descriptor
+}
+
+func (b *compressedBlob) Digest() (v1.Hash, error) {
+	return b.desc.Digest, nil
+}
+
+func (b *compressedBlob) Compressed() (io.ReadCloser, error) {
+	return b.path.Blob(b.desc.Digest)
+}
+
+func (b *compressedBlob) Size() (int64, error) {
+	return b.desc.Size, nil
+}
+
+func (b *compressedBlob) MediaType() (types.MediaType, error) {
+	return b.desc.MediaType, nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/index.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/index.go
@@ -1,0 +1,161 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+var _ v1.ImageIndex = (*layoutIndex)(nil)
+
+type layoutIndex struct {
+	mediaType types.MediaType
+	path      Path
+	rawIndex  []byte
+}
+
+// ImageIndexFromPath is a convenience function which constructs a Path and returns its v1.ImageIndex.
+func ImageIndexFromPath(path string) (v1.ImageIndex, error) {
+	lp, err := FromPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return lp.ImageIndex()
+}
+
+// ImageIndex returns a v1.ImageIndex for the Path.
+func (l Path) ImageIndex() (v1.ImageIndex, error) {
+	rawIndex, err := ioutil.ReadFile(l.path("index.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	idx := &layoutIndex{
+		mediaType: types.OCIImageIndex,
+		path:      l,
+		rawIndex:  rawIndex,
+	}
+
+	return idx, nil
+}
+
+func (i *layoutIndex) MediaType() (types.MediaType, error) {
+	return i.mediaType, nil
+}
+
+func (i *layoutIndex) Digest() (v1.Hash, error) {
+	return partial.Digest(i)
+}
+
+func (i *layoutIndex) Size() (int64, error) {
+	return partial.Size(i)
+}
+
+func (i *layoutIndex) IndexManifest() (*v1.IndexManifest, error) {
+	var index v1.IndexManifest
+	err := json.Unmarshal(i.rawIndex, &index)
+	return &index, err
+}
+
+func (i *layoutIndex) RawManifest() ([]byte, error) {
+	return i.rawIndex, nil
+}
+
+func (i *layoutIndex) Image(h v1.Hash) (v1.Image, error) {
+	// Look up the digest in our manifest first to return a better error.
+	desc, err := i.findDescriptor(h)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isExpectedMediaType(desc.MediaType, types.OCIManifestSchema1, types.DockerManifestSchema2) {
+		return nil, fmt.Errorf("unexpected media type for %v: %s", h, desc.MediaType)
+	}
+
+	img := &layoutImage{
+		path: i.path,
+		desc: *desc,
+	}
+	return partial.CompressedToImage(img)
+}
+
+func (i *layoutIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
+	// Look up the digest in our manifest first to return a better error.
+	desc, err := i.findDescriptor(h)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isExpectedMediaType(desc.MediaType, types.OCIImageIndex, types.DockerManifestList) {
+		return nil, fmt.Errorf("unexpected media type for %v: %s", h, desc.MediaType)
+	}
+
+	rawIndex, err := i.path.Bytes(h)
+	if err != nil {
+		return nil, err
+	}
+
+	return &layoutIndex{
+		mediaType: desc.MediaType,
+		path:      i.path,
+		rawIndex:  rawIndex,
+	}, nil
+}
+
+func (i *layoutIndex) Blob(h v1.Hash) (io.ReadCloser, error) {
+	return i.path.Blob(h)
+}
+
+func (i *layoutIndex) findDescriptor(h v1.Hash) (*v1.Descriptor, error) {
+	im, err := i.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+
+	if h == (v1.Hash{}) {
+		if len(im.Manifests) != 1 {
+			return nil, errors.New("oci layout must contain only a single image to be used with layout.Image")
+		}
+		return &(im.Manifests)[0], nil
+	}
+
+	for _, desc := range im.Manifests {
+		if desc.Digest == h {
+			return &desc, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not find descriptor in index: %s", h)
+}
+
+// TODO: Pull this out into methods on types.MediaType? e.g. instead, have:
+// * mt.IsIndex()
+// * mt.IsImage()
+func isExpectedMediaType(mt types.MediaType, expected ...types.MediaType) bool {
+	for _, allowed := range expected {
+		if mt == allowed {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/layoutpath.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/layoutpath.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The original author or authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import "path/filepath"
+
+// Path represents an OCI image layout rooted in a file system path
+type Path string
+
+func (l Path) path(elem ...string) string {
+	complete := []string{string(l)}
+	return filepath.Join(append(complete, elem...)...)
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/options.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/options.go
@@ -1,0 +1,42 @@
+package layout
+
+import v1 "github.com/google/go-containerregistry/pkg/v1"
+
+// Option is a functional option for Layout.
+//
+// TODO: We'll need to change this signature to support Sparse/Thin images.
+// Or, alternatively, wrap it in a sparse.Image that returns an empty list for layers?
+type Option func(*v1.Descriptor) error
+
+// WithAnnotations adds annotations to the artifact descriptor.
+func WithAnnotations(annotations map[string]string) Option {
+	return func(desc *v1.Descriptor) error {
+		if desc.Annotations == nil {
+			desc.Annotations = make(map[string]string)
+		}
+		for k, v := range annotations {
+			desc.Annotations[k] = v
+		}
+
+		return nil
+	}
+}
+
+// WithURLs adds urls to the artifact descriptor.
+func WithURLs(urls []string) Option {
+	return func(desc *v1.Descriptor) error {
+		if desc.URLs == nil {
+			desc.URLs = []string{}
+		}
+		desc.URLs = append(desc.URLs, urls...)
+		return nil
+	}
+}
+
+// WithPlatform sets the platform of the artifact descriptor.
+func WithPlatform(platform v1.Platform) Option {
+	return func(desc *v1.Descriptor) error {
+		desc.Platform = &platform
+		return nil
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/read.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/read.go
@@ -1,0 +1,32 @@
+// Copyright 2019 The original author or authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// FromPath reads an OCI image layout at path and constructs a layout.Path.
+func FromPath(path string) (Path, error) {
+	// TODO: check oci-layout exists
+
+	_, err := os.Stat(filepath.Join(path, "index.json"))
+	if err != nil {
+		return "", err
+	}
+
+	return Path(path), nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/layout/write.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/layout/write.go
@@ -1,0 +1,305 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package layout
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"golang.org/x/sync/errgroup"
+)
+
+var layoutFile = `{
+    "imageLayoutVersion": "1.0.0"
+}`
+
+// AppendImage writes a v1.Image to the Path and updates
+// the index.json to reference it.
+func (l Path) AppendImage(img v1.Image, options ...Option) error {
+	if err := l.writeImage(img); err != nil {
+		return err
+	}
+
+	mt, err := img.MediaType()
+	if err != nil {
+		return err
+	}
+
+	d, err := img.Digest()
+	if err != nil {
+		return err
+	}
+
+	manifest, err := img.RawManifest()
+	if err != nil {
+		return err
+	}
+
+	desc := v1.Descriptor{
+		MediaType: mt,
+		Size:      int64(len(manifest)),
+		Digest:    d,
+	}
+
+	for _, opt := range options {
+		if err := opt(&desc); err != nil {
+			return err
+		}
+	}
+
+	return l.AppendDescriptor(desc)
+}
+
+// AppendIndex writes a v1.ImageIndex to the Path and updates
+// the index.json to reference it.
+func (l Path) AppendIndex(ii v1.ImageIndex, options ...Option) error {
+	if err := l.writeIndex(ii); err != nil {
+		return err
+	}
+
+	mt, err := ii.MediaType()
+	if err != nil {
+		return err
+	}
+
+	d, err := ii.Digest()
+	if err != nil {
+		return err
+	}
+
+	manifest, err := ii.RawManifest()
+	if err != nil {
+		return err
+	}
+
+	desc := v1.Descriptor{
+		MediaType: mt,
+		Size:      int64(len(manifest)),
+		Digest:    d,
+	}
+
+	for _, opt := range options {
+		if err := opt(&desc); err != nil {
+			return err
+		}
+	}
+
+	return l.AppendDescriptor(desc)
+}
+
+// AppendDescriptor adds a descriptor to the index.json of the Path.
+func (l Path) AppendDescriptor(desc v1.Descriptor) error {
+	ii, err := l.ImageIndex()
+	if err != nil {
+		return err
+	}
+
+	index, err := ii.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	index.Manifests = append(index.Manifests, desc)
+
+	rawIndex, err := json.MarshalIndent(index, "", "   ")
+	if err != nil {
+		return err
+	}
+
+	return l.WriteFile("index.json", rawIndex, os.ModePerm)
+}
+
+// WriteFile write a file with arbitrary data at an arbitrary location in a v1
+// layout. Used mostly internally to write files like "oci-layout" and
+// "index.json", also can be used to write other arbitrary files. Do *not* use
+// this to write blobs. Use only WriteBlob() for that.
+func (l Path) WriteFile(name string, data []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(l.path(), os.ModePerm); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	return ioutil.WriteFile(l.path(name), data, perm)
+
+}
+
+// WriteBlob copies a file to the blobs/ directory in the Path from the given ReadCloser at
+// blobs/{hash.Algorithm}/{hash.Hex}.
+func (l Path) WriteBlob(hash v1.Hash, r io.ReadCloser) error {
+	dir := l.path("blobs", hash.Algorithm)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	file := filepath.Join(dir, hash.Hex)
+	if _, err := os.Stat(file); err == nil {
+		// Blob already exists, that's fine.
+		return nil
+	}
+	w, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	_, err = io.Copy(w, r)
+	return err
+}
+
+// TODO: A streaming version of WriteBlob so we don't have to know the hash
+// before we write it.
+
+// TODO: For streaming layers we should write to a tmp file then Rename to the
+// final digest.
+func (l Path) writeLayer(layer v1.Layer) error {
+	d, err := layer.Digest()
+	if err != nil {
+		return err
+	}
+
+	r, err := layer.Compressed()
+	if err != nil {
+		return err
+	}
+
+	return l.WriteBlob(d, r)
+}
+
+func (l Path) writeImage(img v1.Image) error {
+	layers, err := img.Layers()
+	if err != nil {
+		return err
+	}
+
+	// Write the layers concurrently.
+	var g errgroup.Group
+	for _, layer := range layers {
+		layer := layer
+		g.Go(func() error {
+			return l.writeLayer(layer)
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Write the config.
+	cfgName, err := img.ConfigName()
+	if err != nil {
+		return err
+	}
+	cfgBlob, err := img.RawConfigFile()
+	if err != nil {
+		return err
+	}
+	if err := l.WriteBlob(cfgName, ioutil.NopCloser(bytes.NewReader(cfgBlob))); err != nil {
+		return err
+	}
+
+	// Write the img manifest.
+	d, err := img.Digest()
+	if err != nil {
+		return err
+	}
+	manifest, err := img.RawManifest()
+	if err != nil {
+		return err
+	}
+
+	return l.WriteBlob(d, ioutil.NopCloser(bytes.NewReader(manifest)))
+}
+
+func (l Path) writeIndexToFile(indexFile string, ii v1.ImageIndex) error {
+	index, err := ii.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	// Walk the descriptors and write any v1.Image or v1.ImageIndex that we find.
+	// If we come across something we don't expect, just write it as a blob.
+	for _, desc := range index.Manifests {
+		switch desc.MediaType {
+		case types.OCIImageIndex, types.DockerManifestList:
+			ii, err := ii.ImageIndex(desc.Digest)
+			if err != nil {
+				return err
+			}
+			if err := l.writeIndex(ii); err != nil {
+				return err
+			}
+		case types.OCIManifestSchema1, types.DockerManifestSchema2:
+			img, err := ii.Image(desc.Digest)
+			if err != nil {
+				return err
+			}
+			if err := l.writeImage(img); err != nil {
+				return err
+			}
+		default:
+			// TODO: The layout could reference arbitrary things, which we should
+			// probably just pass through.
+		}
+	}
+
+	rawIndex, err := ii.RawManifest()
+	if err != nil {
+		return err
+	}
+
+	return l.WriteFile(indexFile, rawIndex, os.ModePerm)
+}
+
+func (l Path) writeIndex(ii v1.ImageIndex) error {
+	// Always just write oci-layout file, since it's small.
+	if err := l.WriteFile("oci-layout", []byte(layoutFile), os.ModePerm); err != nil {
+		return err
+	}
+
+	h, err := ii.Digest()
+	if err != nil {
+		return err
+	}
+
+	indexFile := filepath.Join("blobs", h.Algorithm, h.Hex)
+	return l.writeIndexToFile(indexFile, ii)
+
+}
+
+// Write constructs a Path at path from an ImageIndex.
+//
+// The contents are written in the following format:
+// At the top level, there is:
+//   One oci-layout file containing the version of this image-layout.
+//   One index.json file listing descriptors for the contained images.
+// Under blobs/, there is, for each image:
+//   One file for each layer, named after the layer's SHA.
+//   One file for each config blob, named after its SHA.
+//   One file for each manifest blob, named after its SHA.
+func Write(path string, ii v1.ImageIndex) (Path, error) {
+	lp := Path(path)
+	// Always just write oci-layout file, since it's small.
+	if err := lp.WriteFile("oci-layout", []byte(layoutFile), os.ModePerm); err != nil {
+		return "", err
+	}
+
+	// TODO create blobs/ in case there is a blobs file which would prevent the directory from being created
+
+	return lp, lp.writeIndexToFile("index.json", ii)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -226,6 +226,7 @@ github.com/google/go-containerregistry/pkg/logs
 github.com/google/go-containerregistry/pkg/name
 github.com/google/go-containerregistry/pkg/v1
 github.com/google/go-containerregistry/pkg/v1/empty
+github.com/google/go-containerregistry/pkg/v1/layout
 github.com/google/go-containerregistry/pkg/v1/mutate
 github.com/google/go-containerregistry/pkg/v1/partial
 github.com/google/go-containerregistry/pkg/v1/remote


### PR DESCRIPTION
Currently, ctr-remote only converts images matching to the platform it running
on.
This commit allows ctr-remote to handle image index and convert images of all or
a specific platform. Based on the ability of handling index, this commit also
enables to input/output imgaes from/to the local filesystem following OCI Image
Layout.

```console
# ctr-remote i optimize --entrypoint='[ "/bin/sh", "-c" ]' --args='[ "echo hello" ]' --all-platforms ghcr.io/stargz-containers/alpine:3.10.2-org local:///tmp/alpine
WARN[0000] 2020/11/22 10:02:57 No matching credentials were found, falling back on anonymous 
INFO[0005] unpacked                                      digest="sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609" platform=linux/amd64
INFO[0005] running container "but3elopt0h6tb9qo4bg"      platform=linux/amd64
hello
INFO[0006] container "but3elopt0h6tb9qo4bg" stopped      platform=linux/amd64
INFO[0006] cleaned up successfully                       platform=linux/amd64
INFO[0007] converted                                     digest="sha256:9d48c3bd43c520dc2784e868a780e976b207cbf493eaff8c6596eb871cbd9609" platform=linux/amd64
WARN[0007] Platform mismatch or optimization disabled; converting without optimization  platform=linux/arm/v6
WARN[0010] Platform mismatch or optimization disabled; converting without optimization  platform=linux/arm/v7
WARN[0014] Platform mismatch or optimization disabled; converting without optimization  platform=linux/arm64/v8
WARN[0017] Platform mismatch or optimization disabled; converting without optimization  platform=linux/386
WARN[0020] Platform mismatch or optimization disabled; converting without optimization  platform=linux/ppc64le
WARN[0024] Platform mismatch or optimization disabled; converting without optimization  platform=linux/s390x
# tree /tmp/alpine
/tmp/alpine
|-- blobs
|   `-- sha256
|       |-- 00f75499aa08e9f519c8d9f764a2582fac506bf1de1c2c37878ddc99e506cf19
|       |-- 0a1053e006cd1b78921508479a13eb6131a3b31ce82c8fe43471fff2da5a2f91
|       |-- 359305d78b867d4743de4864d83cd550348e494877f072969597d90b1e062b64
|       |-- 3cd6da976bb602c353815734dd6020527000a11c7e97a64f5e8fbfc8006ba834
|       |-- 3e44abf2559dfe4dd181ae1814abd6e04c6b04c5e796bff51dfeb9415ba3310c
|       |-- 5133a03517d202d1f78a25e14c3eb13d174c02d623d473a1bdd6ee53801aac6c
|       |-- 51c86328b212d53de77e5ea6858c6b3c2cfc8e5188878c23e47f41c7eac2f63c
|       |-- 69387e8d0f553a2cb5dd258bbb255ffc79f7f951ab7a2b96409fb90a76470167
|       |-- 8939293798594f9f7e2ec27e1b75ca1245b20c259068475ebd86cc688b56ad05
|       |-- 98d8d4cb4eba22e682f33a98007e2e46a66e05dfc4c12ead5fa33c03875f2606
|       |-- a6a53a5c7a40c3de3d469f4c48ad1b847449154fd0e9aa838ec27fb02e66653f
|       |-- a6faf0a25b694a812258e5a9d13cd38d4cb0d2ccbe904a4b0f01af05a4e8073b
|       |-- adbeb1a65f91c1f86636a5955be27fe902172c175c967aa25b688dd53cdd5513
|       |-- ce4931c0f2325ddfe014d4138b5a86f411e4cbb74e4cc660cb43d894704b5acb
|       |-- d56cb77a16737a287801c8b0477ea476d7edf5bd73e5ac1164c778eb5832460a
|       |-- d637a5af4b87f4ed24203f72c3e3bd5b28fe248b3f0f2f92f3302ac7882c3cf4
|       |-- e12c92f71b8cad453c34d194ad42e343c58bdfa3581cef09f493f60ad247cd8f
|       |-- ec1b11e4b5d051a62db0abfd882a587a0f9c7996fa16c3c585af0b43e116aac5
|       |-- eec0c3d59c45a5ed4a7343afe3e871ce1cc99fb5db2b29af49fe67b6ad23ee62
|       |-- f06dac9a9390971f7ae49bfaf4bddd408f295fd4b7de7ee8d7d5c62af934c67f
|       `-- feb662c05599301f68cb549f5ca5d3af3f7afb419d2122b7fc4b2e05ae6ad5fd
|-- index.json
`-- oci-layout

2 directories, 23 files
# cat /tmp/alpine/index.json | jq
{
  "schemaVersion": 2,
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 560,
      "digest": "sha256:5133a03517d202d1f78a25e14c3eb13d174c02d623d473a1bdd6ee53801aac6c",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
(... omit ...)
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 560,
      "digest": "sha256:a6a53a5c7a40c3de3d469f4c48ad1b847449154fd0e9aa838ec27fb02e66653f",
      "platform": {
        "architecture": "s390x",
        "os": "linux"
      }
    }
  ]
}
```


