### PR TITLE
Ensure hardlink target entry comes forwarder than the source entry

### DIFF
--- a/estargz/build.go
+++ b/estargz/build.go
@@ -281,6 +281,9 @@ func moveRec(name string, in *tarFile, out *tarFile) {
 	}
 	parent, _ := path.Split(strings.TrimSuffix(name, "/"))
 	moveRec(parent, in, out)
+	if e, ok := in.get(name); ok && e.header.Typeflag == tar.TypeLink {
+		moveRec(e.header.Linkname, in, out)
+	}
 	if e, ok := in.get(name); ok {
 		out.add(e)
 		in.remove(name)

--- a/estargz/build_test.go
+++ b/estargz/build_test.go
@@ -650,6 +650,19 @@ func TestSort(t *testing.T) {
 				reg("baz.txt", "baz"),
 			),
 		},
+		{
+			name: "hardlink",
+			in: tarBlob(t,
+				reg("baz.txt", "aaaaa"),
+				link("bazlink", "baz.txt"),
+			),
+			log: []string{"bazlink"},
+			want: tarBlob(t,
+				reg("baz.txt", "aaaaa"),
+				link("bazlink", "baz.txt"),
+				prefetchLandmark(),
+			),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Currently, during optimization, if a hardlink is specified as a prioritized
file, the target file isn't included to prioritized file but only the hardlink
entry is moved forward in the tar file. However, some tar client (e.g. GNU tar)
don't allow that the hardlink entry comes forwarder than the target entry.

Signed-off-by: Kohei Tokunaga <ktokunaga.mail@gmail.com>