### PR TITLE
Update benchmark preparation script to use mount and NW

### DIFF
--- a/script/benchmark/config/config.cni.conflist
+++ b/script/benchmark/config/config.cni.conflist
@@ -1,0 +1,19 @@
+{
+  "cniVersion": "0.4.0",
+  "name": "demo",
+  "plugins" : [{
+    "type": "bridge",
+    "bridge": "optimizer0",
+    "isDefaultGateway": true,
+    "forceAddress": false,
+    "ipMasq": true,
+    "hairpinMode": true,
+    "ipam": {
+      "type": "host-local",
+      "subnet": "10.10.0.0/16"
+    }
+  },
+  {
+    "type": "loopback"
+  }]
+}

--- a/script/benchmark/hello-bench/src/hello.py
+++ b/script/benchmark/hello-bench/src/hello.py
@@ -309,7 +309,7 @@ class BenchRunner:
     def convert_echo_hello(self, repo):
         self.mode = ESTARGZ_MODE
         period=10
-        cmd = ('%s -period %s -entrypoint \'["/bin/sh", "-c"]\' -args \'["echo hello"]\' %s %s/%s' %
+        cmd = ('%s -cni -period %s -entrypoint \'["/bin/sh", "-c"]\' -args \'["echo hello"]\' %s %s/%s' %
                (self.optimizer, period, repo, self.repository, self.add_suffix(repo)))
         print cmd
         rc = os.system(cmd)
@@ -322,7 +322,7 @@ class BenchRunner:
         entry = ""
         if runargs.arg != "": # FIXME: this is naive...
             entry = '-entrypoint \'["/bin/sh", "-c"]\''
-        cmd = ('%s -period %s %s %s %s %s/%s' %
+        cmd = ('%s -cni -period %s %s %s %s %s/%s' %
                (self.optimizer, period, entry, genargs(runargs.arg), repo, self.repository, self.add_suffix(repo)))
         print cmd
         rc = os.system(cmd)
@@ -332,7 +332,7 @@ class BenchRunner:
         self.mode = ESTARGZ_MODE
         period = 90
         env = ' '.join(['-env %s=%s' % (k,v) for k,v in runargs.env.iteritems()])
-        cmd = ('%s -period %s %s %s %s %s/%s' %
+        cmd = ('%s -cni -period %s %s %s %s %s/%s' %
                (self.optimizer, period, env, genargs(runargs.arg), repo, self.repository, self.add_suffix(repo)))
         print cmd
         rc = os.system(cmd)
@@ -340,9 +340,14 @@ class BenchRunner:
 
     def convert_cmd_stdin(self, repo, runargs):
         self.mode = ESTARGZ_MODE
+        mounts = ''
+        for a,b in runargs.mount:
+            a = os.path.join(os.path.dirname(os.path.abspath(__file__)), a)
+            a = tmp_copy(a)
+            mounts += '--mount type=bind,src=%s,dst=%s,options=rbind ' % (a,b)
         period = 60
-        cmd = ('%s -period %s -entrypoint \'["/bin/sh", "-c"]\' %s %s %s/%s' %
-               (self.optimizer, period, genargs(runargs.stdin_sh), repo, self.repository, self.add_suffix(repo)))
+        cmd = ('%s -cni -period %s %s -entrypoint \'["/bin/sh", "-c"]\' %s %s %s/%s' %
+               (self.optimizer, period, mounts, genargs(runargs.stdin_sh), repo, self.repository, self.add_suffix(repo)))
         print cmd
         p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         print runargs.stdin

--- a/script/benchmark/test.sh
+++ b/script/benchmark/test.sh
@@ -23,6 +23,7 @@ BENCHMARKING_BASE_IMAGE_NAME="benchmark-image-base"
 BENCHMARKING_NODE_IMAGE_NAME="benchmark-image-test"
 BENCHMARKING_NODE=hello-bench
 BENCHMARKING_CONTAINER=hello-bench-container
+BENCHMARKING_CNI_PLUGIN_URL="https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz"
 
 if [ "${BENCHMARKING_NO_RECREATE:-}" != "true" ] ; then
     echo "Preparing node image..."
@@ -46,7 +47,9 @@ cat <<EOF > "${TMP_CONTEXT}/Dockerfile"
 FROM ${BENCHMARKING_BASE_IMAGE_NAME}
 
 RUN apt-get update -y && \
-    apt-get --no-install-recommends install -y python jq && \
+    apt-get --no-install-recommends install -y python jq iptables && \
+    update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    mkdir -p /opt/cni/bin && curl -Ls "${BENCHMARKING_CNI_PLUGIN_URL}" | tar xzv -C /opt/cni/bin && \
     git clone https://github.com/google/go-containerregistry \
               \${GOPATH}/src/github.com/google/go-containerregistry && \
     cd \${GOPATH}/src/github.com/google/go-containerregistry && \
@@ -55,6 +58,7 @@ RUN apt-get update -y && \
 
 COPY ./config/config.containerd.toml /etc/containerd/config.toml
 COPY ./config/config.stargz.toml /etc/containerd-stargz-grpc/config.toml
+COPY ./config/config.cni.conflist /etc/cni/net.d/optimizer.conflist
 
 ENV CONTAINERD_SNAPSHOTTER=""
 


### PR DESCRIPTION
Recently, we added mount & NW support for `ctr-remote` (https://github.com/containerd/stargz-snapshotter/blob/master/docs/ctr-remote.md). Let's enable these functionality for creating pre-converted images used in the benchmark.