### PR TITLE
Fix benchmark to use non-optimized eStargz instead of stargz

### DIFF
--- a/script/benchmark/config/config.stargz.toml
+++ b/script/benchmark/config/config.stargz.toml
@@ -1,2 +1,1 @@
 noprefetch = true
-allow_no_verification = true

--- a/script/benchmark/hello-bench/run.sh
+++ b/script/benchmark/hello-bench/run.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 LEGACY_MODE="legacy"
-STARGZ_MODE="stargz"
+ESTARGZ_NOOPT_MODE="estargz-noopt"
 ESTARGZ_MODE="estargz"
 
 CONTEXT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/"
@@ -91,7 +91,7 @@ for SAMPLE_NO in $(seq ${NUM_OF_SAMPLES}) ; do
     echo -n "" > "${WORKLOADS_LIST}"
     # Randomize workloads
     for IMAGE in ${TARGET_IMAGES} ; do
-        for MODE in ${LEGACY_MODE} ${STARGZ_MODE} ${ESTARGZ_MODE} ; do
+        for MODE in ${LEGACY_MODE} ${ESTARGZ_NOOPT_MODE} ${ESTARGZ_MODE} ; do
             echo "${IMAGE},${MODE}" >> "${WORKLOADS_LIST}"
         done
     done
@@ -113,11 +113,11 @@ for SAMPLE_NO in $(seq ${NUM_OF_SAMPLES}) ; do
             measure "--mode=legacy" ${TARGET_REPOSITORY} ${IMAGE}
         fi
 
-        if [ "${MODE}" == "${STARGZ_MODE}" ] ; then
+        if [ "${MODE}" == "${ESTARGZ_NOOPT_MODE}" ] ; then
             echo -n "" > "${TMP_LOG_FILE}"
             set_noprefetch "true" # disable prefetch
             LOG_FILE="${TMP_LOG_FILE}" "${REBOOT_CONTAINERD_SCRIPT}"
-            measure "--mode=stargz" ${TARGET_REPOSITORY} ${IMAGE}
+            measure "--mode=estargz-noopt" ${TARGET_REPOSITORY} ${IMAGE}
             check_remote_snapshots "${TMP_LOG_FILE}"
         fi
 

--- a/script/benchmark/hello-bench/src/hello.py
+++ b/script/benchmark/hello-bench/src/hello.py
@@ -40,7 +40,7 @@ import os, sys, subprocess, select, random, urllib2, time, json, tempfile, shuti
 
 TMP_DIR = tempfile.mkdtemp()
 LEGACY_MODE = "legacy"
-STARGZ_MODE = "stargz"
+ESTARGZ_NOOPT_MODE = "estargz-noopt"
 ESTARGZ_MODE = "estargz"
 DEFAULT_OPTIMIZER = "ctr-remote image optimize"
 BENCHMARKOUT_MARK = "BENCHMARK_OUTPUT: "
@@ -137,7 +137,7 @@ class BenchRunner:
         self.optimizer = optimizer
 
     def lazypull(self):
-        if self.mode == STARGZ_MODE or self.mode == ESTARGZ_MODE:
+        if self.mode == ESTARGZ_NOOPT_MODE or self.mode == ESTARGZ_MODE:
             return True
         else:
             return False
@@ -169,14 +169,14 @@ class BenchRunner:
     def add_suffix(self, repo):
         if self.mode == ESTARGZ_MODE:
             return "%s-esgz" % repo
-        elif self.mode == STARGZ_MODE:
-            return "%s-sgz" % repo
+        elif self.mode == ESTARGZ_NOOPT_MODE:
+            return "%s-esgz-noopt" % repo
         else:
             return "%s-org" % repo
 
     def pull_subcmd(self):
         if self.lazypull():
-            return "rpull --skip-content-verify"
+            return "rpull"
         else:
             return "pull"
         
@@ -362,8 +362,8 @@ class BenchRunner:
         print cmd
         rc = os.system(cmd)
         assert(rc == 0)
-        self.mode = STARGZ_MODE
-        cmd = '%s --stargz-only %s %s/%s' % (self.optimizer, repo, self.repository, self.add_suffix(repo))
+        self.mode = ESTARGZ_NOOPT_MODE
+        cmd = '%s --no-optimize %s %s/%s' % (self.optimizer, repo, self.repository, self.add_suffix(repo))
         print cmd
         rc = os.system(cmd)
         assert(rc == 0)
@@ -403,7 +403,7 @@ def main():
         print '--list-json'
         print '--experiments'
         print '--op=(prepare|run)'
-        print '--mode=(%s|%s|%s)' % (LEGACY_MODE, STARGZ_MODE, ESTARGZ_MODE)
+        print '--mode=(%s|%s|%s)' % (LEGACY_MODE, ESTARGZ_NOOPT_MODE, ESTARGZ_MODE)
         exit(1)
 
     benches = []

--- a/script/benchmark/tools/csv.sh
+++ b/script/benchmark/tools/csv.sh
@@ -24,7 +24,7 @@ source "${CONTEXT}/util.sh"
 
 MODES=( ${TARGET_MODES:-} )
 if [ ${#MODES[@]} -eq 0 ] ; then
-    MODES=("legacy" "stargz" "estargz")
+    MODES=("legacy" "estargz-noopt" "estargz")
 fi
 
 IMAGES=( ${TARGET_IMAGES:-} )

--- a/script/benchmark/tools/percentiles.sh
+++ b/script/benchmark/tools/percentiles.sh
@@ -32,7 +32,7 @@ echo "output into: ${DATADIR}"
 
 MODES=( ${TARGET_MODES:-} )
 if [ ${#MODES[@]} -eq 0 ] ; then
-    MODES=("legacy" "stargz" "estargz")
+    MODES=("legacy" "estargz-noopt" "estargz")
 fi
 
 IMAGES=( ${TARGET_IMAGES:-} )

--- a/script/benchmark/tools/plot.sh
+++ b/script/benchmark/tools/plot.sh
@@ -32,7 +32,7 @@ echo "output into: ${DATADIR}"
 
 MODES=( ${TARGET_MODES:-} )
 if [ ${#MODES[@]} -eq 0 ] ; then
-    MODES=("legacy" "stargz" "estargz")
+    MODES=("legacy" "estargz-noopt" "estargz")
 fi
 
 IMAGES=( ${TARGET_IMAGES:-} )
@@ -68,7 +68,7 @@ set ylabel 'time[sec]'
 set lmargin 10
 set rmargin 5
 set tmargin 5
-set bmargin 5
+set bmargin 7
 plot \\
 EOF
 

--- a/script/benchmark/tools/table.sh
+++ b/script/benchmark/tools/table.sh
@@ -24,7 +24,7 @@ source "${CONTEXT}/util.sh"
 
 MODES=( ${TARGET_MODES:-} )
 if [ ${#MODES[@]} -eq 0 ] ; then
-    MODES=("legacy" "stargz" "estargz")
+    MODES=("legacy" "estargz-noopt" "estargz")
 fi
 
 IMAGES=( ${TARGET_IMAGES:-} )


### PR DESCRIPTION
Related: #184

This fixes benchmarking scripts for using eStargz (without optization) instead
of stargz. The non-optimized images are built by `--no-optimize` option of
`ctr-remote image optimize`.

Signed-off-by: Kohei Tokunaga <ktokunaga.mail@gmail.com>

From: https://github.com/ktock/stargz-snapshotter/actions/runs/398452630

![result](https://user-images.githubusercontent.com/43872416/101027599-8ca96400-35bb-11eb-80b5-58b012357b6d.png)
