### PR TITLE
Add an option to ignore context canceled.

### DIFF
--- a/cmd/ctr-remote/commands/optimize.go
+++ b/cmd/ctr-remote/commands/optimize.go
@@ -85,6 +85,10 @@ var OptimizeCommand = cli.Command{
 			Name:  "terminal,t",
 			Usage: "enable terminal for sample container",
 		},
+		cli.BoolFlag{
+			Name:  "wait-on-signal",
+			Usage: "ignore context cancel and keep the container running until it receives signal (Ctrl + C) sent manually",
+		},
 		cli.IntFlag{
 			Name:  "period",
 			Usage: "time period to monitor access log",
@@ -264,6 +268,9 @@ func parseArgs(clicontext *cli.Context) (opts []sampler.Option, err error) {
 	}
 	if clicontext.Bool("terminal") {
 		opts = append(opts, sampler.WithTerminal())
+	}
+	if clicontext.Bool("wait-on-signal") {
+		opts = append(opts, sampler.WithWaitOnSignal())
 	}
 	if nameservers := clicontext.String("dns-nameservers"); nameservers != "" {
 		fields, err := csv.NewReader(strings.NewReader(nameservers)).Read()

--- a/cmd/ctr-remote/sampler/options.go
+++ b/cmd/ctr-remote/sampler/options.go
@@ -25,6 +25,7 @@ type options struct {
 	user             string
 	workingDir       string
 	terminal         bool
+	waitOnSignal     bool
 	mounts           []string
 	dnsNameservers   []string
 	dnsSearchDomains []string
@@ -74,6 +75,12 @@ func WithWorkingDir(workingDir string) Option {
 func WithTerminal() Option {
 	return func(opts *options) {
 		opts.terminal = true
+	}
+}
+
+func WithWaitOnSignal() Option {
+	return func(opts *options) {
+		opts.waitOnSignal = true
 	}
 }
 


### PR DESCRIPTION
So I want to run the container a bit longer until it finishes all the
work for optimization. This option allows the container to wait until a
keyboard signal (`Ctrl-C`) or a signal from other programs.


Added this option to `ctr-remote i optimize` command:
```
 --wait-on-signal             ignore context cancel and keep the container running until it receives signal (Ctrl + C) sent manually
```



Signed-off-by: Jun Lin Chen webmaster@mc256.com
