### PR TITLE
Move prioritized files argument to option

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -162,7 +162,7 @@ func buildEStargzLayer(uncompressed regpkg.Layer, tf *tempfiles.TempFiles) (regp
 	if err != nil {
 		return nil, "", err
 	}
-	rc, jtocDigest, err := estargz.Build(sr, nil) // no optimization
+	rc, jtocDigest, err := estargz.Build(sr) // no optimization
 	if err != nil {
 		return nil, "", err
 	}

--- a/converter/optimizer/layerconverter/layerconverter.go
+++ b/converter/optimizer/layerconverter/layerconverter.go
@@ -45,7 +45,7 @@ func FromTar(ctx context.Context, sr *io.SectionReader, mon logger.Monitor, tf *
 		log.G(ctx).Debugf("converting...")
 		defer log.G(ctx).Infof("converted")
 
-		rc, jtocDigest, err := estargz.Build(sr, mon.DumpLog())
+		rc, jtocDigest, err := estargz.Build(sr, estargz.WithPrioritizedFiles(mon.DumpLog()))
 		if err != nil {
 			return mutate.Addendum{}, err
 		}

--- a/estargz/estargz.go
+++ b/estargz/estargz.go
@@ -124,7 +124,7 @@ func (r *Reader) initFields() error {
 	gname := map[int]string{}
 	var lastRegEnt *TOCEntry
 	for _, ent := range r.toc.Entries {
-		ent.Name = strings.TrimPrefix(ent.Name, "./")
+		ent.Name = trimNamePrefix(ent.Name)
 		if ent.Type == "reg" {
 			lastRegEnt = ent
 		}
@@ -191,7 +191,7 @@ func (r *Reader) initFields() error {
 		pdir := r.getOrCreateDir(parentDir(name))
 		ent.NumLink++ // at least one name(ent.Name) references this entry.
 		if ent.Type == "hardlink" {
-			if org, ok := r.m[ent.LinkName]; ok {
+			if org, ok := r.m[trimNamePrefix(ent.LinkName)]; ok {
 				org.NumLink++ // original entry is referenced by this ent.Name.
 				ent = org
 			} else {
@@ -802,6 +802,11 @@ func formatModtime(t time.Time) string {
 		return ""
 	}
 	return t.UTC().Round(time.Second).Format(time.RFC3339)
+}
+
+func trimNamePrefix(name string) string {
+	// We don't use filepath.Clean here to preserve "/" suffix for directory entry.
+	return strings.TrimPrefix(name, "./")
 }
 
 // countWriter counts how many bytes have been written to its wrapped

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -448,7 +448,7 @@ func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionR
 	}
 	rc, dgst, err := estargz.Build(
 		io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData))),
-		[]string(prioritizedFiles),
+		estargz.WithPrioritizedFiles([]string(prioritizedFiles)),
 		estargz.WithChunkSize(int(chunkSize)),
 	)
 	if err != nil {

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -379,7 +379,6 @@ func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionR
 
 	rc, dgst, err := estargz.Build(
 		io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData))),
-		nil,
 		estargz.WithChunkSize(int(chunkSize)),
 	)
 	if err != nil {


### PR DESCRIPTION
#203

This moves  prioritized files argument to option.
There are cases where input tar entiy names are prefixed with "./" (which is
still valid) but we shouldn't expose this difference in the option.
So this commit also adds a simple normalization (trimming "./" prefix).

Signed-off-by: Kohei Tokunaga <ktokunaga.mail@gmail.com>