### PR TITLE
Replace the multierror dependency with a simple error aggregator.

### DIFF
--- a/estargz/errorutil/errors.go
+++ b/estargz/errorutil/errors.go
@@ -1,0 +1,40 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package errorutil
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Aggregate combines a list of errors into a single new error.
+func Aggregate(errs []error) error {
+	switch len(errs) {
+	case 0:
+		return nil
+	case 1:
+		return errs[0]
+	default:
+		points := make([]string, len(errs)+1)
+		points[0] = fmt.Sprintf("%d error(s) occurred:", len(errs))
+		for i, err := range errs {
+			points[i+1] = fmt.Sprintf("* %s", err)
+		}
+		return errors.New(strings.Join(points, "\n\t"))
+	}
+}

--- a/estargz/errorutil/errors_test.go
+++ b/estargz/errorutil/errors_test.go
@@ -1,0 +1,57 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package errorutil
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestNoError(t *testing.T) {
+	if err := Aggregate(nil); err != nil {
+		t.Errorf("Aggregate(nil) = %v, wanted nil", err)
+	}
+	if err := Aggregate([]error{}); err != nil {
+		t.Errorf("Aggregate(nil) = %v, wanted nil", err)
+	}
+}
+
+func TestOneError(t *testing.T) {
+	want := errors.New("this is A random Error string")
+	if got := Aggregate([]error{want}); got != want {
+		t.Errorf("Aggregate() = %v, wanted %v", got, want)
+	}
+}
+
+func TestMultipleErrors(t *testing.T) {
+	want := `3 error(s) occurred:
+	* foo
+	* bar
+	* baz`
+
+	err := Aggregate([]error{
+		errors.New("foo"),
+		errors.New("bar"),
+		errors.New("baz"),
+	})
+	if err == nil {
+		t.Errorf("Aggregate() = nil, wanted %s", want)
+	} else if got := err.Error(); got != want {
+		t.Errorf("Aggregate() = %s, wanted %s", got, want)
+	}
+}

--- a/estargz/go.mod
+++ b/estargz/go.mod
@@ -3,7 +3,6 @@ module github.com/containerd/stargz-snapshotter/estargz
 go 1.13
 
 require (
-	github.com/hashicorp/go-multierror v1.1.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pkg/errors v0.9.1
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a

--- a/estargz/go.sum
+++ b/estargz/go.sum
@@ -1,7 +1,3 @@
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
-github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
This lets functions that want to aggregate and return a collection of errors use a `[]error` to accumulate them, and `errorutil.Aggregate(list)` to turn them into a single `error`.  If the list is empty, the `error` will be nil.  If the list is a singleton, it will return the single error.  Otherwise, it will construct a new error combining the constituent error messages.

Fixes: https://github.com/containerd/stargz-snapshotter/issues/205