### PR TITLE
estargz: Enable to get uncompressed digest (DiffID) from built eStargz

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -162,7 +162,7 @@ func buildEStargzLayer(uncompressed regpkg.Layer, tf *tempfiles.TempFiles) (regp
 	if err != nil {
 		return nil, "", err
 	}
-	rc, jtocDigest, err := estargz.Build(sr) // no optimization
+	rc, err := estargz.Build(sr) // no optimization
 	if err != nil {
 		return nil, "", err
 	}
@@ -171,7 +171,7 @@ func buildEStargzLayer(uncompressed regpkg.Layer, tf *tempfiles.TempFiles) (regp
 	if err != nil {
 		return nil, "", err
 	}
-	return l, jtocDigest, err
+	return l, rc.TOCDigest(), err
 }
 
 // specPlatform converts ggcr's platform struct to OCI's struct

--- a/converter/optimizer/layerconverter/layerconverter.go
+++ b/converter/optimizer/layerconverter/layerconverter.go
@@ -45,11 +45,12 @@ func FromTar(ctx context.Context, sr *io.SectionReader, mon logger.Monitor, tf *
 		log.G(ctx).Debugf("converting...")
 		defer log.G(ctx).Infof("converted")
 
-		rc, jtocDigest, err := estargz.Build(sr, estargz.WithPrioritizedFiles(mon.DumpLog()))
+		rc, err := estargz.Build(sr, estargz.WithPrioritizedFiles(mon.DumpLog()))
 		if err != nil {
 			return mutate.Addendum{}, err
 		}
 		defer rc.Close()
+		jtocDigest := rc.TOCDigest().String()
 		log.G(ctx).WithField("TOC JSON digest", jtocDigest).Debugf("calculated digest")
 		l, err := layer.NewStaticCompressedLayer(rc, tf)
 		if err != nil {
@@ -58,7 +59,7 @@ func FromTar(ctx context.Context, sr *io.SectionReader, mon logger.Monitor, tf *
 		return mutate.Addendum{
 			Layer: l,
 			Annotations: map[string]string{
-				estargz.TOCJSONDigestAnnotation: jtocDigest.String(),
+				estargz.TOCJSONDigestAnnotation: jtocDigest,
 			},
 		}, nil
 	}

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -446,7 +446,7 @@ func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionR
 		stargzData := stargzBuf.Bytes()
 		return io.NewSectionReader(bytes.NewReader(stargzData), 0, int64(len(stargzData))), ""
 	}
-	rc, dgst, err := estargz.Build(
+	rc, err := estargz.Build(
 		io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData))),
 		estargz.WithPrioritizedFiles([]string(prioritizedFiles)),
 		estargz.WithChunkSize(int(chunkSize)),
@@ -461,7 +461,7 @@ func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionR
 	}
 	vsbb := vsb.Bytes()
 
-	return io.NewSectionReader(bytes.NewReader(vsbb), 0, int64(len(vsbb))), dgst
+	return io.NewSectionReader(bytes.NewReader(vsbb), 0, int64(len(vsbb))), rc.TOCDigest()
 }
 
 type tarent struct {

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -377,7 +377,7 @@ func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionR
 
 	tarData := tarBuf.Bytes()
 
-	rc, dgst, err := estargz.Build(
+	rc, err := estargz.Build(
 		io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData))),
 		estargz.WithChunkSize(int(chunkSize)),
 	)
@@ -390,7 +390,7 @@ func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionR
 	}
 	vsbb := vsb.Bytes()
 
-	return io.NewSectionReader(bytes.NewReader(vsbb), 0, int64(len(vsbb))), dgst
+	return io.NewSectionReader(bytes.NewReader(vsbb), 0, int64(len(vsbb))), rc.TOCDigest()
 }
 
 func newReader(sr *io.SectionReader, cache cache.BlobCache, ev estargz.TOCEntryVerifier) (*reader, *estargz.TOCEntry, error) {


### PR DESCRIPTION
#204

This commit enables to get uncompressed digest (DiffID) from built eStargz by
introducing `DiffID` method to the result ReadCloser.

Signed-off-by: Kohei Tokunaga <ktokunaga.mail@gmail.com>