### PR TITLE
Move TestOpenRead to `-test.root`

### DIFF
--- a/converter/optimizer/logger/logger_test.go
+++ b/converter/optimizer/logger/logger_test.go
@@ -37,6 +37,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/pkg/testutil"
 	fusefs "github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"golang.org/x/sys/unix"
@@ -285,6 +286,7 @@ func getNode(t *testing.T, root *node, path string) (n *fusefs.Inode, err error)
 }
 
 func TestOpenRead(t *testing.T) {
+	testutil.RequiresRoot(t)
 	tests := []struct {
 		name string
 		in   []tarent


### PR DESCRIPTION
This test requires root for FUSE-related operation. We should move it to
`-test.root` for make `make test` succeed for non-root users.
(`make test-all` still requires root but can run all tests including `-test.root`)