### PR TITLE
estargz: Clean entry names when read and unmarshal blob

### DIFF
--- a/estargz/estargz.go
+++ b/estargz/estargz.go
@@ -36,6 +36,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -63,6 +64,8 @@ type Reader struct {
 }
 
 // Open opens a stargz file for reading.
+//
+// Note that each entry name is normalized as the path that is relative to root.
 func Open(sr *io.SectionReader) (*Reader, error) {
 	tocOff, footerSize, err := OpenFooter(sr)
 	if err != nil {
@@ -124,7 +127,7 @@ func (r *Reader) initFields() error {
 	gname := map[int]string{}
 	var lastRegEnt *TOCEntry
 	for _, ent := range r.toc.Entries {
-		ent.Name = trimNamePrefix(ent.Name)
+		ent.Name = cleanEntryName(ent.Name)
 		if ent.Type == "reg" {
 			lastRegEnt = ent
 		}
@@ -152,10 +155,8 @@ func (r *Reader) initFields() error {
 
 			if ent.Type == "dir" {
 				ent.NumLink++ // Parent dir links to this directory
-				r.m[strings.TrimSuffix(ent.Name, "/")] = ent
-			} else {
-				r.m[ent.Name] = ent
 			}
+			r.m[ent.Name] = ent
 		}
 		if ent.Type == "reg" && ent.ChunkSize > 0 && ent.ChunkSize < ent.Size {
 			r.chunks[ent.Name] = make([]*TOCEntry, 0, ent.Size/ent.ChunkSize+1)
@@ -185,9 +186,6 @@ func (r *Reader) initFields() error {
 		//    add "f.txt" child to "e"
 
 		name := ent.Name
-		if ent.Type == "dir" {
-			name = strings.TrimSuffix(name, "/")
-		}
 		pdirName := parentDir(name)
 		if name == pdirName {
 			// This entry and its parent are the same.
@@ -199,7 +197,7 @@ func (r *Reader) initFields() error {
 		pdir := r.getOrCreateDir(pdirName)
 		ent.NumLink++ // at least one name(ent.Name) references this entry.
 		if ent.Type == "hardlink" {
-			if org, ok := r.m[trimNamePrefix(ent.LinkName)]; ok {
+			if org, ok := r.m[cleanEntryName(ent.LinkName)]; ok {
 				org.NumLink++ // original entry is referenced by this ent.Name.
 				ent = org
 			} else {
@@ -305,7 +303,9 @@ func (v *verifier) Verifier(ce *TOCEntry) (digest.Verifier, error) {
 
 // ChunkEntryForOffset returns the TOCEntry containing the byte of the
 // named file at the given offset within the file.
+// Name must be absolute path or one that is relative to root.
 func (r *Reader) ChunkEntryForOffset(name string, offset int64) (e *TOCEntry, ok bool) {
+	name = cleanEntryName(name)
 	e, ok = r.Lookup(name)
 	if !ok || !e.isDataType() {
 		return nil, false
@@ -330,7 +330,9 @@ func (r *Reader) ChunkEntryForOffset(name string, offset int64) (e *TOCEntry, ok
 // Lookup returns the Table of Contents entry for the given path.
 //
 // To get the root directory, use the empty string.
+// Path must be absolute path or one that is relative to root.
 func (r *Reader) Lookup(path string) (e *TOCEntry, ok bool) {
+	path = cleanEntryName(path)
 	if r == nil {
 		return
 	}
@@ -341,7 +343,11 @@ func (r *Reader) Lookup(path string) (e *TOCEntry, ok bool) {
 	return
 }
 
+// OpenFile returns the reader of the specified file payload.
+//
+// Name must be absolute path or one that is relative to root.
 func (r *Reader) OpenFile(name string) (*io.SectionReader, error) {
+	name = cleanEntryName(name)
 	ent, ok := r.Lookup(name)
 	if !ok {
 		// TODO: come up with some error plan. This is lazy:
@@ -813,9 +819,8 @@ func formatModtime(t time.Time) string {
 	return t.UTC().Round(time.Second).Format(time.RFC3339)
 }
 
-func trimNamePrefix(name string) string {
-	// We don't use filepath.Clean here to preserve "/" suffix for directory entry.
-	return strings.TrimPrefix(name, "./")
+func cleanEntryName(name string) string {
+	return strings.TrimPrefix(filepath.Clean("/"+name), "/")
 }
 
 // countWriter counts how many bytes have been written to its wrapped


### PR DESCRIPTION
https://github.com/containerd/stargz-snapshotter/issues/217#issuecomment-748710444

Currently, when estargz lib reads an eStargz, it normalizes the entry by
trimming the prefix "./".

But this isn't enough because there are a lot of exceptions including
"/foo/bar", "../foo/bar", etc. From the library client's perspective
(e.g. snapshotter), it's complex to take care of all these differences when
interacting with unmarshaled eStargz blob with `estargz.Reader`.

For example, when the client gets a TOCEntry from `estargz.Reader.Lookup(path
string)`, it needs to prefix the path to be lexically equal to the corresponding
tar entry (so it needs to prefix that path with "/" if the corresponding tar
entry is prefixed by "/"). Additionally, when the client gets a TOCEntry
(e.g. by `estargz.TOCEntry.ForeachChild()`), the names are possibly prefixed
with "/", "./", "../", "", etc and it needs to handle all of these cases
properly.

This commit solves this by fixing estargz lib to handle entry paths with
cleaning them internally when it provides an unmarshaled view of an eStargz blob
through `estargz.Reader`. They are cleaned as relative to root, and estargz lib
APIs (e.g. `estargz.Reader.Lookup()`) also clean paths passed by the
client. This enables the client to read each TOCEntry.Name as a clean path and
enables to query TOCEntry without thinking about the differences of prefixes in
the marshalled TOC.

Note that paths are cleaned only in the `estargz.Reader` but not in
`estargz.Writer`. So TOC JSON created by estargz.Writer still contains
TOCEntry.Name identical to tar entry name (possibly prefixed with "/", "../",
"./" etc).

This commit also fixed tests to run for each prefix patterns in "", "./", "/"
and "../".
