### PR TITLE
estargz: Support duplicated entries during sort

### DIFF
--- a/estargz/build.go
+++ b/estargz/build.go
@@ -373,9 +373,9 @@ func importTar(in io.ReaderAt) (*tarFile, error) {
 			continue
 		}
 
-		// Add entry if not exist.
+		// Add entry. If it already exists, replace it.
 		if _, ok := tf.get(h.Name); ok {
-			return nil, fmt.Errorf("Duplicated entry(%q) is not supported", h.Name)
+			tf.remove(h.Name)
 		}
 		tf.add(&entry{
 			header:  h,

--- a/estargz/build_test.go
+++ b/estargz/build_test.go
@@ -674,6 +674,23 @@ func TestSort(t *testing.T) {
 			wantFail: true,
 		},
 		{
+			name: "duplicated_entry",
+			in: tarOf(
+				file("foo.txt", "foo"),
+				dir("bar/"),
+				file("bar/baz.txt", "baz"),
+				dir("bar/"),
+				file("bar/baz.txt", "baz2"),
+			),
+			log: []string{"bar/baz.txt"},
+			want: tarOf(
+				dir("bar/"),
+				file("bar/baz.txt", "baz2"),
+				prefetchLandmark(),
+				file("foo.txt", "foo"),
+			),
+		},
+		{
 			name: "hardlink",
 			in: tarOf(
 				file("baz.txt", "aaaaa"),


### PR DESCRIPTION
https://github.com/containerd/stargz-snapshotter/issues/217#issuecomment-748710444

`estargz.Build` currently doesn't support duplicated entries in the input tar.
But there are images that contain duplicated entries in a layer and we currently
cannot optimize these layers.

GNU tar supports duplicated entries by replacing the former entry with the later
one. (https://www.gnu.org/software/tar/manual/html_node/multiple.html) This
commit takes the simillar approach for supporting duplicated entries.
