### PR TITLE
optimize: allow dumping monitor log to a file

### DIFF
--- a/converter/optimizer/recorder/recorder.go
+++ b/converter/optimizer/recorder/recorder.go
@@ -1,0 +1,48 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package recorder provides log recorder
+package recorder
+
+import (
+	"encoding/json"
+	"io"
+	"sync"
+)
+
+type Entry struct {
+	Path           string `json:"path"`
+	ManifestDigest string `json:"manifestDigest,omitempty"`
+	LayerIndex     *int   `json:"layerIndex,omitempty"`
+}
+
+func New(w io.Writer) *Recorder {
+	return &Recorder{
+		enc: json.NewEncoder(w),
+	}
+}
+
+// Recorder is thread-safe.
+type Recorder struct {
+	enc *json.Encoder
+	mu  sync.Mutex
+}
+
+func (ll *Recorder) Record(e *Entry) error {
+	ll.mu.Lock()
+	defer ll.mu.Unlock()
+	return ll.enc.Encode(e)
+}


### PR DESCRIPTION
Now `ctr-remote image optimize` accepts `--record-out=<FILE>` flag.

This flag dumps the monitor log to a line-deliminated text file.

e.g.,
```json
{"path":"etc/passwd","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"etc/group","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"etc/passwd","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"etc/group","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/ld-2.28.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/ld-2.28.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/ld-2.28.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/ld-2.28.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/ld-2.28.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/libz.so.1.2.11","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/libz.so.1.2.11","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/libz.so.1.2.11","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/libz.so.1.2.11","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/libpthread-2.28.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
{"path":"usr/lib64/libpthread-2.28.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":0}
...
{"path":"usr/java/openjdk-15/lib/server/libjvm.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":2}
{"path":"usr/java/openjdk-15/lib/server/libjvm.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":2}
{"path":"usr/java/openjdk-15/lib/server/libjvm.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":2}
{"path":"usr/java/openjdk-15/lib/server/libjvm.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":2}
{"path":"usr/java/openjdk-15/lib/server/libjvm.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":2}
{"path":"usr/java/openjdk-15/lib/server/libjvm.so","manifestDigest":"sha256:02f6b131fbb5a7438e4d5bf8a06317b746c91c8e9d5a75be4d3cec8b69ae498a","layerIndex":2}
```


Future version of optimizer should also support consuming this text file. (`--record-in=<FILE>`)
