### PR TITLE
Make timeout for fetching chunks configurable

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -53,9 +53,10 @@ type Config struct {
 }
 
 type BlobConfig struct {
-	ValidInterval int64 `toml:"valid_interval"`
-	CheckAlways   bool  `toml:"check_always"`
-	ChunkSize     int64 `toml:"chunk_size"`
+	ValidInterval   int64 `toml:"valid_interval"`
+	CheckAlways     bool  `toml:"check_always"`
+	ChunkSize       int64 `toml:"chunk_size"`
+	FetchTimeoutSec int64 `toml:"fetching_timeout_sec"`
 }
 
 type DirectoryCacheConfig struct {

--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -60,6 +60,7 @@ type blob struct {
 	lastCheck     time.Time
 	lastCheckMu   sync.Mutex
 	checkInterval time.Duration
+	fetchTimeout  time.Duration
 
 	fetchedRegionSet   regionSet
 	fetchedRegionSetMu sync.Mutex
@@ -267,7 +268,7 @@ func (b *blob) fetchRange(allData map[region]io.Writer, opts *options) error {
 		req = append(req, reg)
 		fetched[reg] = false
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), b.fetchTimeout)
 	defer cancel()
 	mr, err := fr.fetch(ctx, req, true, opts)
 	if err != nil {

--- a/fs/remote/blob_test.go
+++ b/fs/remote/blob_test.go
@@ -289,6 +289,7 @@ func makeBlob(t *testing.T, size int64, chunkSize int64, fn RoundTripFunc) *blob
 				},
 			},
 		},
+		fetchTimeout: time.Duration(defaultFetchTimeoutSec) * time.Second,
 	}
 }
 

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -51,6 +51,7 @@ import (
 const (
 	defaultChunkSize        = 50000
 	defaultValidIntervalSec = 60
+	defaultFetchTimeoutSec  = 300
 )
 
 func NewResolver(cache cache.BlobCache, cfg config.BlobConfig) *Resolver {
@@ -62,6 +63,9 @@ func NewResolver(cache cache.BlobCache, cfg config.BlobConfig) *Resolver {
 	}
 	if cfg.CheckAlways {
 		cfg.ValidInterval = 0
+	}
+	if cfg.FetchTimeoutSec == 0 {
+		cfg.FetchTimeoutSec = defaultFetchTimeoutSec
 	}
 
 	return &Resolver{
@@ -94,6 +98,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts docker.RegistryHosts, refs
 		lastCheck:     time.Now(),
 		checkInterval: time.Duration(r.blobConfig.ValidInterval) * time.Second,
 		resolver:      r,
+		fetchTimeout:  time.Duration(r.blobConfig.FetchTimeoutSec) * time.Second,
 	}, nil
 }
 


### PR DESCRIPTION
Resolves: #226

Currently, the timeout for fethcing chunks is 30s but this is too short on some
environments.
This commit make this configurable on `config.toml` (with `fetching_timeout`
option) and extended the default timeout (300s).

cc: @mattmoor 