### PR TITLE
nativeconverter.GetDiffID: support non-unpacked blobs + fix nil panic + add test

### DIFF
--- a/nativeconverter/estargz/estargz.go
+++ b/nativeconverter/estargz/estargz.go
@@ -69,6 +69,9 @@ func LayerConvertFunc(opts ...estargz.Option) nativeconverter.ConvertFunc {
 			return nil, err
 		}
 		labels := info.Labels
+		if labels == nil {
+			labels = make(map[string]string)
+		}
 
 		uncompressedReaderAt, err := cs.ReaderAt(ctx, *uncompressedDesc)
 		if err != nil {

--- a/nativeconverter/estargz/estargz_test.go
+++ b/nativeconverter/estargz/estargz_test.go
@@ -1,0 +1,70 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package estargz
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/stargz-snapshotter/estargz"
+	"github.com/containerd/stargz-snapshotter/nativeconverter"
+	"github.com/containerd/stargz-snapshotter/util/testutil"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// TestLayerConvertFunc tests eStargz conversion.
+// TestLayerConvertFunc is a pure unit test that does not need the daemon to be running.
+func TestLayerConvertFunc(t *testing.T) {
+	ctx := context.Background()
+	desc, cs, err := testutil.EnsureHello(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lcf := LayerConvertFunc(estargz.WithPrioritizedFiles([]string{"hello"}))
+	docker2oci := true
+	platformMC := platforms.Default()
+	cf := nativeconverter.DefaultIndexConvertFunc(lcf, docker2oci, platformMC)
+
+	newDesc, err := cf(ctx, cs, *desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var tocDigests []string
+	handler := func(hCtx context.Context, hDesc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if hDesc.Annotations != nil {
+			if x, ok := hDesc.Annotations[estargz.TOCJSONDigestAnnotation]; ok && len(x) > 0 {
+				tocDigests = append(tocDigests, x)
+			}
+		}
+		return nil, nil
+	}
+	handlers := images.Handlers(
+		images.ChildrenHandler(cs),
+		images.HandlerFunc(handler),
+	)
+	if err := images.Walk(ctx, handlers, *newDesc); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tocDigests) == 0 {
+		t.Fatal("no eStargz layer was created")
+	}
+}

--- a/nativeconverter/nativeconverter.go
+++ b/nativeconverter/nativeconverter.go
@@ -235,6 +235,9 @@ func (c *defaultConverter) convertManifest(ctx context.Context, cs content.Store
 	if err != nil {
 		return nil, err
 	}
+	if labels == nil {
+		labels = make(map[string]string)
+	}
 	if IsDockerType(manifest.MediaType) && c.docker2oci {
 		manifest.MediaType = ""
 		modified = true
@@ -314,6 +317,9 @@ func (c *defaultConverter) convertIndex(ctx context.Context, cs content.Store, d
 	if err != nil {
 		return nil, err
 	}
+	if labels == nil {
+		labels = make(map[string]string)
+	}
 	if IsDockerType(index.MediaType) && c.docker2oci {
 		index.MediaType = ""
 		modified = true
@@ -385,6 +391,9 @@ func (c *defaultConverter) convertConfig(ctx context.Context, cs content.Store, 
 	labels, err := readJSON(ctx, cs, &cfg, desc)
 	if err != nil {
 		return nil, err
+	}
+	if labels == nil {
+		labels = make(map[string]string)
 	}
 	if _, err := readJSON(ctx, cs, &cfgAsOCI, desc); err != nil {
 		return nil, err

--- a/util/testutil/testutil.go
+++ b/util/testutil/testutil.go
@@ -1,0 +1,80 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testutil
+
+import (
+	"compress/gzip"
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/images/archive"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+const (
+	// HelloArchiveURL points to an OCI archive of `hello-world`.
+	// Exported from `docker.io/library/hello-world@sha256:1a523af650137b8accdaed439c17d684df61ee4d74feac151b5b337bd29e7eec` .
+	// See https://github.com/AkihiroSuda/test-oci-archives/releases/tag/v20210101
+	HelloArchiveURL = "https://github.com/AkihiroSuda/test-oci-archives/releases/download/v20210101/hello-world.tar.gz"
+	// HelloArchiveDigest is the digest of the archive.
+	HelloArchiveDigest = "sha256:5aa022621c4de0e941ab2a30d4569c403e156b4ba2de2ec32e382ae8679f40e1"
+)
+
+// EnsureHello creates a temp content store and ensures `hello-world` image from HelloArchiveURL into the store.
+func EnsureHello(ctx context.Context) (*ocispec.Descriptor, content.Store, error) {
+	// Pulling an image without the daemon is a mess, so we use OCI archive here.
+	resp, err := http.Get(HelloArchiveURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	sha256Digester := digest.SHA256.Digester()
+	sha256Hasher := sha256Digester.Hash()
+	tr := io.TeeReader(resp.Body, sha256Hasher)
+	gzReader, err := gzip.NewReader(tr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tempDir, err := ioutil.TempDir("", "test-estargz")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cs, err := local.NewStore(tempDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	desc, err := archive.ImportIndex(ctx, cs, gzReader)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp.Body.Close()
+	if d := sha256Digester.Digest().String(); d != HelloArchiveDigest {
+		err = errors.Errorf("expected digest of %q to be %q, got %q", HelloArchiveURL, HelloArchiveDigest, d)
+		return nil, nil, err
+	}
+	return &desc, cs, nil
+}


### PR DESCRIPTION
blobs without `containerd.io/uncompressed` labels were not supported
