### PR TITLE
Add MaximumConcurrency to config.toml (for stargz-grpc)

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Debug               bool   `toml:"debug"`
 	AllowNoVerification bool   `toml:"allow_no_verification"`
 	DisableVerification bool   `toml:"disable_verification"`
+	MaxConcurrency      int64  `toml:"max_concurrency"`
 
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob"`


### PR DESCRIPTION
Increasing the number of concurrent background tasks (connections) may speed up the loading speed if the network condition is good. I propose to add a parameter to adjust the number of concurrent background tasks.

Signed-off-by: Jun Lin Chen <webmaster@mc256.com>