### PR TITLE
Make the order of directory entries deterministic

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -45,6 +45,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -706,6 +707,11 @@ func (n *node) Readdir(ctx context.Context) (fusefs.DirStream, syscall.Errno) {
 
 		}
 	}
+
+	// Avoid undeterministic order of entries on each call
+	sort.Slice(ents, func(i, j int) bool {
+		return ents[i].Name < ents[j].Name
+	})
 
 	return fusefs.NewListDirStream(ents), 0
 }


### PR DESCRIPTION
Currently, `*node.Readdir` returns directory entries in undeterministic order
*on each call*. Though the order of directory entries is up to the filesystem
implementation, undeterministic order *on each call* results in that the
filesystem clients see random file name on each call of `getdents` even to the
same seek position in that directory. This commit fixes this issue by sorting
the directory entries by the name.

repro:

```golang
package main

import (
	"fmt"
	"os"
	"syscall"
)

func printEntry(f *os.File, position int64) error {
	if _, err := syscall.Seek(int(f.Fd()), position, 0); err != nil {
		return err
	}
	buf := make([]byte, 1024)
	if _, err := syscall.Getdents(int(f.Fd()), buf); err != nil {
		return err
	}
	names := make([]string, 0, 1)
	_, c, newnames := syscall.ParseDirent(buf, 1, names)
	if c < 1 {
		return fmt.Errorf("at least one entry must be parsed")
	}
	fmt.Println(position, ":", newnames[0])
	return nil
}

func main() {
	f, err := os.Open("/usr/local/go/src/runtime")
	if err != nil {
		fmt.Println("Open", err)
		return
	}
	defer f.Close()

	if err := printEntry(f, 10); err != nil {
		panic(err)
	}
	if err := printEntry(f, 10); err != nil {
		panic(err)
	}
}
```

On the host (expected):
```
10 : defs_darwin_arm64.go
10 : defs_darwin_arm64.go
```

In the container (unexpected):
```
10 : atomic_ppc64x.s
10 : error.go
```
