### PR TITLE
Bump go to 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG CNI_PLUGINS_VERSION=v0.9.0
 # Legacy builder that doesn't support TARGETARCH should set this explicitly using --build-arg.
 # If TARGETARCH isn't supported by the builder, the default value is "amd64".
 
-FROM golang:1.13-buster AS golang-base
+FROM golang:1.15-buster AS golang-base
 
 # Build containerd
 FROM golang-base AS containerd-dev

--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	golog "log"
 	"net"
 	"net/http"
 	"os"
@@ -68,6 +69,10 @@ func main() {
 		ctx    = log.WithLogger(context.Background(), log.L)
 		config Config
 	)
+	// Streams log of standard lib (go-fuse uses this) into debug log
+	// Snapshotter should use "github.com/containerd/containerd/log" otherwize
+	// logs are always printed as "debug" mode.
+	golog.SetOutput(log.G(ctx).WriterLevel(logrus.DebugLevel))
 
 	// Get configuration from specified file
 	if _, err := toml.DecodeFile(*configPath, &config); err != nil && !(os.IsNotExist(err) && *configPath == defaultConfigPath) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/stargz-snapshotter
 
-go 1.13
+go 1.15
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/script/cri/test.sh
+++ b/script/cri/test.sh
@@ -43,7 +43,7 @@ FROM ${NODE_BASE_IMAGE_NAME}
 ENV PATH=$PATH:/usr/local/go/bin
 ENV GOPATH=/go
 RUN apt install -y --no-install-recommends git make gcc build-essential jq && \
-    curl https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz \
+    curl https://dl.google.com/go/go1.15.6.linux-amd64.tar.gz \
     | tar -C /usr/local -xz && \
     go get -u github.com/onsi/ginkgo/ginkgo && \
     git clone -b v1.19.0 https://github.com/kubernetes-sigs/cri-tools \

--- a/script/optimize/optimize/Dockerfile
+++ b/script/optimize/optimize/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.13
+FROM golang:1.15
 
 # basic tools
 # docker-ce-cli is used only to log into registry with ~/.docker/config.json

--- a/script/pullsecrets/test.sh
+++ b/script/pullsecrets/test.sh
@@ -78,7 +78,7 @@ if ! ( cd "${CONTEXT}" && \
                   -v "${AUTH_DIR}/certs/domain.crt:/usr/local/share/ca-certificates/rgst.crt:ro" \
                   -v "${DOCKERCONFIG}:/root/.docker/config.json:ro" \
                   -v "${REPO}:/go/src/github.com/containerd/stargz-snapshotter:ro" \
-                  golang:1.13-buster /bin/bash -c "apt-get update -y && \
+                  golang:1.15-buster /bin/bash -c "apt-get update -y && \
 apt-get --no-install-recommends install -y fuse && \
 update-ca-certificates && \
 cd /go/src/github.com/containerd/stargz-snapshotter && \

--- a/script/util/make.sh
+++ b/script/util/make.sh
@@ -29,7 +29,7 @@ function cleanup {
 trap 'cleanup "$?"' EXIT SIGHUP SIGINT SIGQUIT SIGTERM
 
 cat <<EOF > "${TMP_CONTEXT}/Dockerfile"
-FROM golang:1.13
+FROM golang:1.15
 RUN apt-get update -y && apt-get --no-install-recommends install -y fuse
 EOF
 docker build -t "${IMAGE_NAME}" ${DOCKER_BUILD_ARGS:-} "${TMP_CONTEXT}"


### PR DESCRIPTION
Fixes #202 

When the snapshotter is compiled with especially the recent version of go, we
sometimes (or frequently) see that go-fuse prints `Write/Writev failed` log.
Here, I quote the log with few lines of debug logs around it.

```
2021/01/19 14:09:43 rx 76: FLUSH n2 {Fh 1}
2021/01/19 14:09:43 tx 76:     OK
...
2021/01/19 14:09:43 rx 77: INTERRUPT n0 {ix 76}
2021/01/19 14:09:43 tx 77:     11=resource temporarily unavailable
2021/01/19 14:09:43 writer: Write/Writev failed, err: 2=no such file or directory. opcode: INTERRUPT
```

This warning comes when the filesystem tries to write the response to INTERRUPT
(EAGAIN, in this case) to the kernel [1].

When a filesystem operation of the client from userspace (`76: FLUSH`, in this
case) is interrupted by a signal, INTERRUPT request (`77: INTERRUPT` targetting
`76: FLUSH`, in this case) is sent to the FUSE server. In this case, there is a
race condition according to the kernel doc:

(Quoted from [2])

```
It is also possible that there's a race between processing the
original request and its INTERRUPT request.  There are two possibilities:

  1) The INTERRUPT request is processed before the original request is
     processed

  2) The INTERRUPT request is processed after the original request has
     been answered

If the filesystem cannot find the original request, it should wait for
some timeout and/or a number of new requests to arrive, after which it
should reply to the INTERRUPT request with an EAGAIN error.  In case
1) the INTERRUPT request will be requeued.  In case 2) the INTERRUPT
reply will be ignored.
```

As far as we can observe, we are currently seeing `Write/Writev failed` error on
case 2 where we writes EAGAIN to the kernel. In the above log excerpt,
`77: INTERRUPT` is processed after `76: FLUSH` is returned with `OK`. Though
there is no document about errno in this case, FUSE seems to return ENOENT if
the interrupted request is not found on its side[3].

As a conclusion, this is an expected behaviour according to the kernel doc so we
can consider this phenomenon as harmless.

P.S. Similar phenomenon is observed on the internet[4], and they also conclude
this phenomenon as harmless.

[1] https://github.com/hanwen/go-fuse/blob/09a3c381714cf1011fb2d08885f29896cd496a0c/fuse/server_linux.go#L15
[2] https://www.kernel.org/doc/Documentation/filesystems/fuse.txt
[3] https://github.com/torvalds/linux/blob/219d54332a09e8d8741c1e1982f5eae56099de85/fs/fuse/dev.c#L1858-L1866
[4] https://bugzilla.redhat.com/show_bug.cgi?id=1763208#c17
