### PR TITLE
nativeconverter: Enable to resume conversion

### DIFF
--- a/nativeconverter/estargz/estargz.go
+++ b/nativeconverter/estargz/estargz.go
@@ -90,6 +90,14 @@ func LayerConvertFunc(opts ...estargz.Option) nativeconverter.ConvertFunc {
 			return nil, err
 		}
 		defer w.Close()
+
+		// Reset the writing position
+		// Old writer possibly remains without aborted
+		// (e.g. conversion interrupted by a signal)
+		if err := w.Truncate(0); err != nil {
+			return nil, err
+		}
+
 		n, err := io.Copy(w, blob)
 		if err != nil {
 			return nil, err

--- a/nativeconverter/uncompress/uncompress.go
+++ b/nativeconverter/uncompress/uncompress.go
@@ -57,6 +57,14 @@ func LayerConvertFunc(ctx context.Context, cs content.Store, desc ocispec.Descri
 		return nil, err
 	}
 	defer w.Close()
+
+	// Reset the writing position
+	// Old writer possibly remains without aborted
+	// (e.g. conversion interrupted by a signal)
+	if err := w.Truncate(0); err != nil {
+		return nil, err
+	}
+
 	n, err := io.Copy(w, newR)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`nativeconverter` doesn't support to resume conversion after the previous
conversion is stopped by a signal, etc.

```console
ctr-remote image convert --oci --estargz ghcr.io/stargz-containers/python:3.7-org dummy:1
C-c

ctr-remote image convert --oci --estargz ghcr.io/stargz-containers/python:3.7-org dummy:2
ctr: commit failed: "convert-estargz-from-sha256:5f37a0a41b6b03489dd7de0aa2a79e369fd8b219bbc36b52f3f9790dc128e74b" failed size validation: 16739617 != 10049153: failed precondition
```


 This commit fixes this.
