### PR TITLE
Make sure the snapshotter is up-and-running during test

### DIFF
--- a/script/integration/containerd/entrypoint.sh
+++ b/script/integration/containerd/entrypoint.sh
@@ -111,7 +111,10 @@ function reboot_containerd {
     fi
     retry ls "${REMOTE_SNAPSHOTTER_SOCKET}"
     containerd --log-level debug --config=/etc/containerd/config.toml &
-    retry ctr version
+
+    # Makes sure containerd and containerd-stargz-grpc are up-and-running.
+    UNIQUE_SUFFIX=$(date +%s%N | shasum | base64 | fold -w 10 | head -1)
+    retry ctr snapshots --snapshotter="${PLUGIN}" prepare "connectiontest-dummy-${UNIQUE_SUFFIX}" ""
 }
 
 echo "Logging into the registry..."


### PR DESCRIPTION
Recently `Integration` test is flaky and sometimes fails with the following error:

```
failed to prepare extraction snapshot "extract-888733096-M1HL sha256:645c926ab234a37fce3b0d3f9de28718b25fdfe19537e6f58c01e25561116ccf": connection error: desc = "transport: Error while dialing dial unix /run/containerd-stargz-grpc/containerd-stargz-grpc.sock: connect: connection refused": unavailable
```

This seems because tests sometimes access to stargz snapshotter before it becomes up-and-running.
This commit fixes this issue.
