### PR TITLE
[RFC] Bump estargz lib to a vaild oldest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ root@8dab301bd68d:/# ls
 bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
 ```
 
+## Importing Stargz Snapshotter as go module
+
+Currently, Stargz Snapshotter repository contains two Go modules as the following and both of them need to be imported.
+
+- `github.com/containerd/stargz-snapshotter`
+- `github.com/containerd/stargz-snapshotter/estargz`
+
+Please make sure you import the both of them and they point to *the same commit version*.
+
 ## Project details
 
 Stargz Snapshotter is a containerd **non-core** sub-project, licensed under the [Apache 2.0 license](./LICENSE).

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/containerd v1.5.0-beta.0.0.20210122062454-5a66c2ae5cec
 	github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7
 	github.com/containerd/go-cni v1.0.1
-	github.com/containerd/stargz-snapshotter/estargz v0.0.0-00010101000000-000000000000
+	github.com/containerd/stargz-snapshotter/estargz v0.3.0
 	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200730172259-9f28837c1d93+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect


### PR DESCRIPTION
#259

This commit eliminates the need of specifying `replace` directive in the
consumer project's go.mod.

Currently, our tests and releases are done against stargz snapshotter that
imports the local (i.e. the same commit of) `estargz` library.

```
replace github.com/containerd/stargz-snapshotter/estargz => ./estargz
```

Here, we don't want to force consumer projects (and their all downstream
projects) to specify `replace` directive but `require` directive doesn't support
to specify the local directory.

For solving this issue, this commit let the consumers manually specify the
version of `github.com/containerd/stargz-snapshotter/estargz` to the same commit
as `github.com/containerd/stargz-snapshotter` in their go.mod as an [indirect
requirement](https://golang.org/ref/mod#go-mod-file-require).

This commit intensionally bumps `estargz` lib to the "oldest" version to make
sure that the build fails if the version of
`github.com/containerd/stargz-snapshotter/estargz` is not specified explicitly.
