### PR TITLE
Add --version option to `containerd-stargz-grpc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,10 @@ CMD_DESTDIR ?= /usr/local
 GO111MODULE_VALUE=auto
 PREFIX ?= out/
 
-GO_LD_FLAGS=-ldflags "-s -w"
+PKG=github.com/containerd/stargz-snapshotter
+VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+GO_LD_FLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) $(GO_EXTRA_LDFLAGS)'
 
 CMD=containerd-stargz-grpc ctr-remote
 

--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	golog "log"
 	"net"
 	"os"
@@ -30,6 +31,7 @@ import (
 	"github.com/containerd/containerd/contrib/snapshotservice"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/stargz-snapshotter/service"
+	"github.com/containerd/stargz-snapshotter/version"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
@@ -42,10 +44,11 @@ const (
 )
 
 var (
-	address    = flag.String("address", defaultAddress, "address for the snapshotter's GRPC server")
-	configPath = flag.String("config", defaultConfigPath, "path to the configuration file")
-	logLevel   = flag.String("log-level", defaultLogLevel.String(), "set the logging level [trace, debug, info, warn, error, fatal, panic]")
-	rootDir    = flag.String("root", defaultRootDir, "path to the root directory for this snapshotter")
+	address      = flag.String("address", defaultAddress, "address for the snapshotter's GRPC server")
+	configPath   = flag.String("config", defaultConfigPath, "path to the configuration file")
+	logLevel     = flag.String("log-level", defaultLogLevel.String(), "set the logging level [trace, debug, info, warn, error, fatal, panic]")
+	rootDir      = flag.String("root", defaultRootDir, "path to the root directory for this snapshotter")
+	printVersion = flag.Bool("version", false, "print the version")
 )
 
 func main() {
@@ -53,6 +56,10 @@ func main() {
 	lvl, err := logrus.ParseLevel(*logLevel)
 	if err != nil {
 		log.L.WithError(err).Fatal("failed to prepare logger")
+	}
+	if *printVersion {
+		fmt.Println("containerd-stargz-grpc", version.Version, version.Revision)
+		return
 	}
 	logrus.SetLevel(lvl)
 	logrus.SetFormatter(&logrus.JSONFormatter{

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,25 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package version
+
+var (
+	// Version is the version number. Filled in at linking time (via Makefile).
+	Version = "<unknown>"
+
+	// Revision is the VCS (e.g. git) revision. Filled in at linking time (via Makefile).
+	Revision = "<unknown>"
+)


### PR DESCRIPTION
Fixes:   #268

```console
# containerd-stargz-grpc --version
containerd-stargz-grpc v0.4.1-3-ge550b6e e550b6ea86467949c0aaa372b88f04d173afc269
```