### PR TITLE
Garbage collect the content cache on Unmount()

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -24,7 +24,8 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/golang/groupcache/lru"
+	"github.com/containerd/stargz-snapshotter/util/lrucache"
+	"github.com/containerd/stargz-snapshotter/util/namedmutex"
 	"github.com/pkg/errors"
 )
 
@@ -34,16 +35,41 @@ const (
 )
 
 type DirectoryCacheConfig struct {
+
+	// Number of entries of LRU cache (default: 10).
+	// This won't be used when DataCache is specified.
 	MaxLRUCacheEntry int
-	MaxCacheFds      int
-	SyncAdd          bool
+
+	// Number of file descriptors to cache (default: 10).
+	// This won't be used when FdCache is specified.
+	MaxCacheFds int
+
+	// On Add, wait until the data is fully written to the cache directory.
+	SyncAdd bool
+
+	// DataCache is an on-memory cache of the data.
+	// OnEvicted will be overridden and replaced for internal use.
+	DataCache *lrucache.Cache
+
+	// FdCache is a cache for opened file descriptors.
+	// OnEvicted will be overridden and replaced for internal use.
+	FdCache *lrucache.Cache
+
+	// BufPool will be used for pooling bytes.Buffer.
+	BufPool *sync.Pool
 }
 
 // TODO: contents validation.
 
 type BlobCache interface {
+	// Add adds the passed data to the cache
 	Add(key string, p []byte, opts ...Option)
+
+	// FetchAt fetches the specified range of data from the cache
 	FetchAt(key string, offset int64, p []byte, opts ...Option) (n int, err error)
+
+	// Close closes the cache. Queries after this won't be served.
+	Close() error
 }
 
 type cacheOpt struct {
@@ -64,33 +90,48 @@ func Direct() Option {
 }
 
 func NewDirectoryCache(directory string, config DirectoryCacheConfig) (BlobCache, error) {
-	maxEntry := config.MaxLRUCacheEntry
-	if maxEntry == 0 {
-		maxEntry = defaultMaxLRUCacheEntry
+	if !filepath.IsAbs(directory) {
+		return nil, fmt.Errorf("dir cache path must be an absolute path; got %q", directory)
 	}
-	maxFds := config.MaxCacheFds
-	if maxFds == 0 {
-		maxFds = defaultMaxCacheFds
-	}
-	if err := os.MkdirAll(directory, os.ModePerm); err != nil {
-		return nil, err
-	}
-	dc := &directoryCache{
-		cache:     newObjectCache(maxEntry),
-		fileCache: newObjectCache(maxFds),
-		wipLock:   &namedLock{},
-		directory: directory,
-		bufPool: sync.Pool{
+	bufPool := config.BufPool
+	if bufPool == nil {
+		bufPool = &sync.Pool{
 			New: func() interface{} {
 				return new(bytes.Buffer)
 			},
-		},
+		}
 	}
-	dc.cache.finalize = func(value interface{}) {
-		dc.bufPool.Put(value)
+	dataCache := config.DataCache
+	if dataCache == nil {
+		maxEntry := config.MaxLRUCacheEntry
+		if maxEntry == 0 {
+			maxEntry = defaultMaxLRUCacheEntry
+		}
+		dataCache = lrucache.New(maxEntry)
+		dataCache.OnEvicted = func(key string, value interface{}) {
+			bufPool.Put(value)
+		}
 	}
-	dc.fileCache.finalize = func(value interface{}) {
-		value.(*os.File).Close()
+	fdCache := config.FdCache
+	if fdCache == nil {
+		maxEntry := config.MaxCacheFds
+		if maxEntry == 0 {
+			maxEntry = defaultMaxCacheFds
+		}
+		fdCache = lrucache.New(maxEntry)
+		fdCache.OnEvicted = func(key string, value interface{}) {
+			value.(*os.File).Close()
+		}
+	}
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		return nil, err
+	}
+	dc := &directoryCache{
+		cache:     dataCache,
+		fileCache: fdCache,
+		wipLock:   new(namedmutex.NamedMutex),
+		directory: directory,
+		bufPool:   bufPool,
 	}
 	dc.syncAdd = config.SyncAdd
 	return dc, nil
@@ -98,17 +139,26 @@ func NewDirectoryCache(directory string, config DirectoryCacheConfig) (BlobCache
 
 // directoryCache is a cache implementation which backend is a directory.
 type directoryCache struct {
-	cache     *objectCache
-	fileCache *objectCache
+	cache     *lrucache.Cache
+	fileCache *lrucache.Cache
 	directory string
-	wipLock   *namedLock
+	wipLock   *namedmutex.NamedMutex
 
-	bufPool sync.Pool
+	bufPool *sync.Pool
 
 	syncAdd bool
+
+	closed   bool
+	closedMu sync.RWMutex
 }
 
 func (dc *directoryCache) FetchAt(key string, offset int64, p []byte, opts ...Option) (n int, err error) {
+	dc.closedMu.RLock()
+	defer dc.closedMu.RUnlock()
+	if dc.closed {
+		return 0, fmt.Errorf("cache already closed")
+	}
+
 	opt := &cacheOpt{}
 	for _, o := range opts {
 		opt = o(opt)
@@ -116,7 +166,7 @@ func (dc *directoryCache) FetchAt(key string, offset int64, p []byte, opts ...Op
 
 	if !opt.direct {
 		// Get data from memory
-		if b, done, ok := dc.cache.get(key); ok {
+		if b, done, ok := dc.cache.Get(key); ok {
 			defer done()
 			data := b.(*bytes.Buffer).Bytes()
 			if int64(len(data)) < offset {
@@ -127,7 +177,7 @@ func (dc *directoryCache) FetchAt(key string, offset int64, p []byte, opts ...Op
 		}
 
 		// Get data from disk. If the file is already opened, use it.
-		if f, done, ok := dc.fileCache.get(key); ok {
+		if f, done, ok := dc.fileCache.Get(key); ok {
 			defer done()
 			return f.(*os.File).ReadAt(p, offset)
 		}
@@ -147,8 +197,14 @@ func (dc *directoryCache) FetchAt(key string, offset int64, p []byte, opts ...Op
 	// Cache the opened file for future use. If "direct" option is specified, this
 	// won't be done. This option is useful for preventing file cache from being
 	// polluted by data that won't be accessed immediately.
-	if opt.direct || !dc.fileCache.add(key, file) {
+	if opt.direct {
 		file.Close()
+	} else {
+		_, done, added := dc.fileCache.Add(key, file)
+		if !added {
+			file.Close() // file already exists in the cache. discard it.
+		}
+		done() // Release this immediately. This will be removed on eviction in lru cache.
 	}
 
 	// TODO: should we cache the entire file data on memory?
@@ -172,9 +228,11 @@ func (dc *directoryCache) Add(key string, p []byte, opts ...Option) {
 		b := dc.bufPool.Get().(*bytes.Buffer)
 		b.Reset()
 		b.Write(p)
-		if !dc.cache.add(key, b) {
-			dc.bufPool.Put(b) // Already exists. No need to cache.
+		_, done, added := dc.cache.Add(key, b)
+		if !added {
+			dc.bufPool.Put(b) // already exists in the cache. discard it.
 		}
+		done() // This will remain until it's evicted in lru cache.
 	}
 
 	// Cache the passed data to disk.
@@ -182,6 +240,12 @@ func (dc *directoryCache) Add(key string, p []byte, opts ...Option) {
 	b2.Reset()
 	b2.Write(p)
 	addFunc := func() {
+		dc.closedMu.RLock()
+		defer dc.closedMu.RUnlock()
+		if dc.closed {
+			return
+		}
+
 		defer dc.bufPool.Put(b2)
 
 		var (
@@ -189,29 +253,29 @@ func (dc *directoryCache) Add(key string, p []byte, opts ...Option) {
 			wip = dc.wipPath(key)
 		)
 
-		dc.wipLock.lock(key)
+		dc.wipLock.Lock(key)
 		if _, err := os.Stat(wip); err == nil {
-			dc.wipLock.unlock(key)
+			dc.wipLock.Unlock(key)
 			return // Write in progress
 		}
 		if _, err := os.Stat(c); err == nil {
-			dc.wipLock.unlock(key)
+			dc.wipLock.Unlock(key)
 			return // Already exists.
 		}
 
 		// Write the contents to a temporary file
 		if err := os.MkdirAll(filepath.Dir(wip), os.ModePerm); err != nil {
 			fmt.Printf("Warning: Failed to Create blob cache directory %q: %v\n", c, err)
-			dc.wipLock.unlock(key)
+			dc.wipLock.Unlock(key)
 			return
 		}
 		wipfile, err := os.Create(wip)
 		if err != nil {
 			fmt.Printf("Warning: failed to prepare temp file for storing cache %q", key)
-			dc.wipLock.unlock(key)
+			dc.wipLock.Unlock(key)
 			return
 		}
-		dc.wipLock.unlock(key)
+		dc.wipLock.Unlock(key)
 
 		defer func() {
 			wipfile.Close()
@@ -241,8 +305,14 @@ func (dc *directoryCache) Add(key string, p []byte, opts ...Option) {
 		// Cache the opened file for future use. If "direct" option is specified, this
 		// won't be done. This option is useful for preventing file cache from being
 		// polluted by data that won't be accessed immediately.
-		if opt.direct || !dc.fileCache.add(key, file) {
+		if opt.direct {
 			file.Close()
+		} else {
+			_, done, added := dc.fileCache.Add(key, file)
+			if !added {
+				file.Close() // already exists in the cache. discard it.
+			}
+			done() // This will remain until it's evicted in lru cache.
 		}
 	}
 
@@ -253,115 +323,25 @@ func (dc *directoryCache) Add(key string, p []byte, opts ...Option) {
 	}
 }
 
+func (dc *directoryCache) Close() error {
+	dc.closedMu.Lock()
+	defer dc.closedMu.Unlock()
+	if dc.closed {
+		return nil
+	}
+	dc.closed = true
+	if err := os.RemoveAll(dc.directory); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (dc *directoryCache) cachePath(key string) string {
 	return filepath.Join(dc.directory, key[:2], key)
 }
 
 func (dc *directoryCache) wipPath(key string) string {
 	return filepath.Join(dc.directory, key[:2], "w", key)
-}
-
-type namedLock struct {
-	muMap  map[string]*sync.Mutex
-	refMap map[string]int
-
-	mu sync.Mutex
-}
-
-func (nl *namedLock) lock(name string) {
-	nl.mu.Lock()
-	if nl.muMap == nil {
-		nl.muMap = make(map[string]*sync.Mutex)
-	}
-	if nl.refMap == nil {
-		nl.refMap = make(map[string]int)
-	}
-	if _, ok := nl.muMap[name]; !ok {
-		nl.muMap[name] = &sync.Mutex{}
-	}
-	mu := nl.muMap[name]
-	nl.refMap[name]++
-	nl.mu.Unlock()
-	mu.Lock()
-}
-
-func (nl *namedLock) unlock(name string) {
-	nl.mu.Lock()
-	mu := nl.muMap[name]
-	nl.refMap[name]--
-	if nl.refMap[name] <= 0 {
-		delete(nl.muMap, name)
-		delete(nl.refMap, name)
-	}
-	nl.mu.Unlock()
-	mu.Unlock()
-}
-
-func newObjectCache(maxEntries int) *objectCache {
-	oc := &objectCache{
-		cache: lru.New(maxEntries),
-	}
-	oc.cache.OnEvicted = func(key lru.Key, value interface{}) {
-		value.(*object).release() // Decrease ref count incremented in add operation.
-	}
-	return oc
-}
-
-type objectCache struct {
-	cache    *lru.Cache
-	cacheMu  sync.Mutex
-	finalize func(interface{})
-}
-
-func (oc *objectCache) get(key string) (value interface{}, done func(), ok bool) {
-	oc.cacheMu.Lock()
-	defer oc.cacheMu.Unlock()
-	o, ok := oc.cache.Get(key)
-	if !ok {
-		return nil, nil, false
-	}
-	o.(*object).use()
-	return o.(*object).v, func() { o.(*object).release() }, true
-}
-
-func (oc *objectCache) add(key string, value interface{}) bool {
-	oc.cacheMu.Lock()
-	defer oc.cacheMu.Unlock()
-	if _, ok := oc.cache.Get(key); ok {
-		return false // TODO: should we swap the object?
-	}
-	o := &object{
-		v:        value,
-		finalize: oc.finalize,
-	}
-	o.use() // Keep this object having at least 1 ref count (will be decreased on eviction)
-	oc.cache.Add(key, o)
-	return true
-}
-
-type object struct {
-	v interface{}
-
-	refCounts int64
-	finalize  func(interface{})
-
-	mu sync.Mutex
-}
-
-func (o *object) use() {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	o.refCounts++
-}
-
-func (o *object) release() {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	o.refCounts--
-	if o.refCounts <= 0 && o.finalize != nil {
-		// nobody will refer this object
-		o.finalize(o.v)
-	}
 }
 
 func NewMemoryCache() BlobCache {
@@ -391,4 +371,8 @@ func (mc *memoryCache) Add(key string, p []byte, opts ...Option) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	mc.membuf[key] = string(p)
+}
+
+func (mc *memoryCache) Close() error {
+	return nil
 }

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -44,7 +44,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -54,39 +53,31 @@ import (
 	"unsafe"
 
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/containerd/stargz-snapshotter/cache"
 	"github.com/containerd/stargz-snapshotter/estargz"
 	"github.com/containerd/stargz-snapshotter/fs/config"
-	"github.com/containerd/stargz-snapshotter/fs/reader"
-	"github.com/containerd/stargz-snapshotter/fs/remote"
+	"github.com/containerd/stargz-snapshotter/fs/layer"
 	"github.com/containerd/stargz-snapshotter/fs/source"
 	snbase "github.com/containerd/stargz-snapshotter/snapshot"
 	"github.com/containerd/stargz-snapshotter/task"
-	"github.com/golang/groupcache/lru"
 	fusefs "github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"golang.org/x/sync/singleflight"
 	"golang.org/x/sys/unix"
 )
 
 const (
-	blockSize                 = 4096
-	memoryCacheType           = "memory"
-	whiteoutPrefix            = ".wh."
-	whiteoutOpaqueDir         = whiteoutPrefix + whiteoutPrefix + ".opq"
-	opaqueXattr               = "trusted.overlay.opaque"
-	opaqueXattrValue          = "y"
-	stateDirName              = ".stargz-snapshotter"
-	defaultResolveResultEntry = 100
-	defaultPrefetchTimeoutSec = 10
-	defaultMaxConcurrency     = 2
-	statFileMode              = syscall.S_IFREG | 0400 // -r--------
-	stateDirMode              = syscall.S_IFDIR | 0500 // dr-x------
+	blockSize             = 4096
+	whiteoutPrefix        = ".wh."
+	whiteoutOpaqueDir     = whiteoutPrefix + whiteoutPrefix + ".opq"
+	opaqueXattr           = "trusted.overlay.opaque"
+	opaqueXattrValue      = "y"
+	stateDirName          = ".stargz-snapshotter"
+	defaultMaxConcurrency = 2
+	statFileMode          = syscall.S_IFREG | 0400 // -r--------
+	stateDirMode          = syscall.S_IFDIR | 0500 // dr-x------
 )
 
 type Option func(*options)
@@ -106,46 +97,6 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snbase.Fil
 	for _, o := range opts {
 		o(&fsOpts)
 	}
-
-	dcc := cfg.DirectoryCacheConfig
-	var httpCache cache.BlobCache
-	if cfg.HTTPCacheType == memoryCacheType {
-		httpCache = cache.NewMemoryCache()
-	} else {
-		if httpCache, err = cache.NewDirectoryCache(
-			filepath.Join(root, "http"),
-			cache.DirectoryCacheConfig{
-				MaxLRUCacheEntry: dcc.MaxLRUCacheEntry,
-				MaxCacheFds:      dcc.MaxCacheFds,
-				SyncAdd:          dcc.SyncAdd,
-			},
-		); err != nil {
-			return nil, errors.Wrap(err, "failed to prepare HTTP cache")
-		}
-	}
-	var fsCache cache.BlobCache
-	if cfg.FSCacheType == memoryCacheType {
-		fsCache = cache.NewMemoryCache()
-	} else {
-		if fsCache, err = cache.NewDirectoryCache(
-			filepath.Join(root, "fscache"),
-			cache.DirectoryCacheConfig{
-				MaxLRUCacheEntry: dcc.MaxLRUCacheEntry,
-				MaxCacheFds:      dcc.MaxCacheFds,
-				SyncAdd:          dcc.SyncAdd,
-			},
-		); err != nil {
-			return nil, errors.Wrap(err, "failed to prepare filesystem cache")
-		}
-	}
-	resolveResultEntry := cfg.ResolveResultEntry
-	if resolveResultEntry == 0 {
-		resolveResultEntry = defaultResolveResultEntry
-	}
-	prefetchTimeout := time.Duration(cfg.PrefetchTimeoutSec) * time.Second
-	if prefetchTimeout == 0 {
-		prefetchTimeout = defaultPrefetchTimeoutSec * time.Second
-	}
 	maxConcurrency := cfg.MaxConcurrency
 	if maxConcurrency == 0 {
 		maxConcurrency = defaultMaxConcurrency
@@ -155,46 +106,36 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snbase.Fil
 		getSources = source.FromDefaultLabels(
 			docker.ConfigureDefaultRegistries(docker.WithPlainHTTP(docker.MatchLocalhost)))
 	}
+	tm := task.NewBackgroundTaskManager(maxConcurrency, 5*time.Second)
 	return &filesystem{
-		resolver:              remote.NewResolver(httpCache, cfg.BlobConfig),
+		resolver:              layer.NewResolver(root, tm, cfg),
 		getSources:            getSources,
-		fsCache:               fsCache,
 		prefetchSize:          cfg.PrefetchSize,
-		prefetchTimeout:       prefetchTimeout,
 		noprefetch:            cfg.NoPrefetch,
 		noBackgroundFetch:     cfg.NoBackgroundFetch,
 		debug:                 cfg.Debug,
-		layer:                 make(map[string]*layer),
-		resolveResult:         lru.New(resolveResultEntry),
-		blobResult:            lru.New(resolveResultEntry),
-		backgroundTaskManager: task.NewBackgroundTaskManager(maxConcurrency, 5*time.Second),
+		layer:                 make(map[string]layer.Layer),
+		backgroundTaskManager: tm,
 		allowNoVerification:   cfg.AllowNoVerification,
 		disableVerification:   cfg.DisableVerification,
 	}, nil
 }
 
 type filesystem struct {
-	resolver              *remote.Resolver
-	fsCache               cache.BlobCache
+	resolver              *layer.Resolver
 	prefetchSize          int64
-	prefetchTimeout       time.Duration
 	noprefetch            bool
 	noBackgroundFetch     bool
 	debug                 bool
-	layer                 map[string]*layer
+	layer                 map[string]layer.Layer
 	layerMu               sync.Mutex
-	resolveResult         *lru.Cache
-	resolveResultMu       sync.Mutex
-	blobResult            *lru.Cache
-	blobResultMu          sync.Mutex
 	backgroundTaskManager *task.BackgroundTaskManager
 	allowNoVerification   bool
 	disableVerification   bool
 	getSources            source.GetSources
-	resolveG              singleflight.Group
 }
 
-func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[string]string) error {
+func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[string]string) (retErr error) {
 	// This is a prioritized task and all background tasks will be stopped
 	// execution so this can avoid being disturbed for NW traffic by background
 	// tasks.
@@ -212,13 +153,13 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 
 	// Resolve the target layer
 	var (
-		resultChan = make(chan *layer)
+		resultChan = make(chan layer.Layer)
 		errChan    = make(chan error)
 	)
 	go func() {
 		rErr := fmt.Errorf("failed to resolve target")
 		for _, s := range src {
-			l, err := fs.resolveLayer(ctx, s.Hosts, s.Name, s.Target)
+			l, err := fs.resolver.Resolve(ctx, s.Hosts, s.Name, s.Target)
 			if err == nil {
 				resultChan <- l
 				return
@@ -229,16 +170,21 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		errChan <- rErr
 	}()
 
-	// Also resolve other layers in parallel
+	// Also resolve and cache other layers in parallel
 	preResolve := src[0] // TODO: should we pre-resolve blobs in other sources as well?
-	for _, desc := range preResolve.Manifest.Layers {
-		if desc.Digest.String() != preResolve.Target.Digest.String() {
-			go fs.resolveLayer(ctx, preResolve.Hosts, preResolve.Name, desc)
-		}
+	for _, desc := range neighboringLayers(preResolve.Manifest, preResolve.Target) {
+		desc := desc
+		go func() {
+			ctx := context.Background() // prevents from get canceled
+			err := fs.resolver.Cache(ctx, preResolve.Hosts, preResolve.Name, desc)
+			if err != nil {
+				log.G(ctx).WithError(err).Debug("failed to pre-resolve")
+			}
+		}()
 	}
 
 	// Wait for resolving completion
-	var l *layer
+	var l layer.Layer
 	select {
 	case l = <-resultChan:
 	case err := <-errChan:
@@ -248,11 +194,19 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		log.G(ctx).Debug("failed to resolve layer (timeout)")
 		return fmt.Errorf("failed to resolve layer (timeout)")
 	}
+	defer func() {
+		if retErr != nil {
+			l.Done() // don't use this layer.
+		}
+	}()
 
 	// Verify layer's content
 	if fs.disableVerification {
 		// Skip if verification is disabled completely
-		l.skipVerify()
+		if err := l.SkipVerify(); err != nil {
+			log.G(ctx).WithError(err).Debugf("failed to skip verify")
+			return errors.Wrapf(err, "invalid stargz layer (failed to skip verify)")
+		}
 		log.G(ctx).Debugf("Verification forcefully skipped")
 	} else if tocDigest, ok := labels[estargz.TOCJSONDigestAnnotation]; ok {
 		// Verify this layer using the TOC JSON digest passed through label.
@@ -261,7 +215,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 			log.G(ctx).WithError(err).Debugf("failed to parse passed TOC digest %q", dgst)
 			return errors.Wrapf(err, "invalid TOC digest: %v", tocDigest)
 		}
-		if err := l.verify(dgst); err != nil {
+		if err := l.Verify(dgst); err != nil {
 			log.G(ctx).WithError(err).Debugf("invalid layer")
 			return errors.Wrapf(err, "invalid stargz layer")
 		}
@@ -270,16 +224,14 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		// If unverified layer is allowed, use it with warning.
 		// This mode is for legacy stargz archives which don't contain digests
 		// necessary for layer verification.
-		l.skipVerify()
+		if err := l.SkipVerify(); err != nil {
+			log.G(ctx).WithError(err).Debugf("failed to skip verify")
+			return errors.Wrapf(err, "invalid stargz layer (failed to skip verify)")
+		}
 		log.G(ctx).Warningf("No verification is held for layer")
 	} else {
 		// Verification must be done. Don't mount this layer.
 		return fmt.Errorf("digest of TOC JSON must be passed")
-	}
-	layerReader, err := l.reader()
-	if err != nil {
-		log.G(ctx).WithError(err).Warningf("failed to get reader for layer")
-		return err
 	}
 
 	// Register the mountpoint layer
@@ -299,7 +251,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		go func() {
 			fs.backgroundTaskManager.DoPrioritizedTask()
 			defer fs.backgroundTaskManager.DonePrioritizedTask()
-			if err := l.prefetch(prefetchSize); err != nil {
+			if err := l.Prefetch(prefetchSize); err != nil {
 				log.G(ctx).WithError(err).Debug("failed to prefetched layer")
 				return
 			}
@@ -313,21 +265,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	// about NW traffic.
 	if !fs.noBackgroundFetch {
 		go func() {
-			br := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (retN int, retErr error) {
-				fs.backgroundTaskManager.InvokeBackgroundTask(func(ctx context.Context) {
-					retN, retErr = l.blob.ReadAt(
-						p,
-						offset,
-						remote.WithContext(ctx),              // Make cancellable
-						remote.WithCacheOpts(cache.Direct()), // Do not pollute mem cache
-					)
-				}, 120*time.Second)
-				return
-			}), 0, l.blob.Size())
-			if err := layerReader.Cache(
-				reader.WithReader(br),                // Read contents in background
-				reader.WithCacheOpts(cache.Direct()), // Do not pollute mem cache
-			); err != nil {
+			if err := l.BackgroundFetch(); err != nil {
 				log.G(ctx).WithError(err).Debug("failed to fetch whole layer")
 				return
 			}
@@ -340,9 +278,9 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	timeSec := time.Second
 	rawFS := fusefs.NewNodeFS(&node{
 		fs:    fs,
-		layer: layerReader,
-		e:     l.root,
-		s:     newState(l.desc.Digest.String(), l.blob),
+		layer: l,
+		e:     l.Root(),
+		s:     newState(l),
 		root:  mountpoint,
 	}, &fusefs.Options{
 		AttrTimeout:     &timeSec,
@@ -362,79 +300,6 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 
 	go server.Serve()
 	return server.WaitMount()
-}
-
-func (fs *filesystem) resolveLayer(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (*layer, error) {
-	name := refspec.String() + "/" + desc.Digest.String()
-	ctx, cancel := context.WithCancel(log.WithLogger(ctx, log.G(ctx).WithField("src", name)))
-	defer cancel()
-
-	fs.resolveResultMu.Lock()
-	c, ok := fs.resolveResult.Get(name)
-	fs.resolveResultMu.Unlock()
-	if ok && c.(*layer).blob.Check() == nil {
-		return c.(*layer), nil
-	}
-
-	resultChan := fs.resolveG.DoChan(name, func() (interface{}, error) {
-		log.G(ctx).Debugf("resolving")
-
-		// Resolve the blob. The result will be cached for future use. This is effective
-		// in some failure cases including resolving is succeeded but the blob is non-stargz.
-		var blob remote.Blob
-		fs.blobResultMu.Lock()
-		c, ok := fs.blobResult.Get(name)
-		fs.blobResultMu.Unlock()
-		if ok && c.(remote.Blob).Check() == nil {
-			blob = c.(remote.Blob)
-		} else {
-			var err error
-			blob, err = fs.resolver.Resolve(ctx, hosts, refspec, desc)
-			if err != nil {
-				log.G(ctx).WithError(err).Debugf("failed to resolve source")
-				return nil, errors.Wrap(err, "failed to resolve the source")
-			}
-			fs.blobResultMu.Lock()
-			fs.blobResult.Add(name, blob)
-			fs.blobResultMu.Unlock()
-		}
-
-		// Get a reader for stargz archive.
-		// Each file's read operation is a prioritized task and all background tasks
-		// will be stopped during the execution so this can avoid being disturbed for
-		// NW traffic by background tasks.
-		sr := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (n int, err error) {
-			fs.backgroundTaskManager.DoPrioritizedTask()
-			defer fs.backgroundTaskManager.DonePrioritizedTask()
-			return blob.ReadAt(p, offset)
-		}), 0, blob.Size())
-		vr, root, err := reader.NewReader(sr, fs.fsCache)
-		if err != nil {
-			log.G(ctx).WithError(err).Debugf("failed to resolve: layer cannot be read")
-			return nil, errors.Wrap(err, "failed to read layer")
-		}
-
-		// Combine layer information together
-		l := newLayer(desc, blob, vr, root, fs.prefetchTimeout)
-		fs.resolveResultMu.Lock()
-		fs.resolveResult.Add(name, l)
-		fs.resolveResultMu.Unlock()
-
-		log.G(ctx).Debugf("resolved")
-		return l, nil
-	})
-
-	var res singleflight.Result
-	select {
-	case res = <-resultChan:
-	case <-time.After(30 * time.Second):
-		fs.resolveG.Forget(name)
-		return nil, fmt.Errorf("failed to resolve layer (timeout)")
-	}
-	if res.Err != nil || res.Val == nil {
-		return nil, fmt.Errorf("failed to resolve layer: %v", res.Err)
-	}
-	return res.Val.(*layer), nil
 }
 
 func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[string]string) error {
@@ -462,7 +327,7 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[s
 
 	// Wait for prefetch compeletion
 	if !fs.noprefetch {
-		if err := l.waitForPrefetchCompletion(); err != nil {
+		if err := l.WaitForPrefetchCompletion(); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to sync with prefetch completion")
 		}
 	}
@@ -470,8 +335,8 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[s
 	return nil
 }
 
-func (fs *filesystem) check(ctx context.Context, l *layer, labels map[string]string) error {
-	err := l.blob.Check()
+func (fs *filesystem) check(ctx context.Context, l layer.Layer, labels map[string]string) error {
+	err := l.Check()
 	if err == nil {
 		return nil
 	}
@@ -489,7 +354,7 @@ func (fs *filesystem) check(ctx context.Context, l *layer, labels map[string]str
 	for retry := 0; retry < retrynum; retry++ {
 		log.G(ctx).Warnf("refreshing(%d)...", retry)
 		for _, s := range src {
-			err := l.blob.Refresh(ctx, s.Hosts, s.Name, s.Target)
+			err := l.Refresh(ctx, s.Hosts, s.Name, s.Target)
 			if err == nil {
 				log.G(ctx).Debug("Successfully refreshed connection")
 				return nil
@@ -506,11 +371,13 @@ func (fs *filesystem) check(ctx context.Context, l *layer, labels map[string]str
 
 func (fs *filesystem) Unmount(ctx context.Context, mountpoint string) error {
 	fs.layerMu.Lock()
-	if _, ok := fs.layer[mountpoint]; !ok {
+	l, ok := fs.layer[mountpoint]
+	if !ok {
 		fs.layerMu.Unlock()
 		return fmt.Errorf("specified path %q isn't a mountpoint", mountpoint)
 	}
 	delete(fs.layer, mountpoint) // unregisters the corresponding layer
+	l.Done()                     // Release this layer.
 	fs.layerMu.Unlock()
 	// The goroutine which serving the mountpoint possibly becomes not responding.
 	// In case of such situations, we use MNT_FORCE here and abort the connection.
@@ -520,131 +387,15 @@ func (fs *filesystem) Unmount(ctx context.Context, mountpoint string) error {
 	return syscall.Unmount(mountpoint, syscall.MNT_FORCE)
 }
 
-func newLayer(desc ocispec.Descriptor, blob remote.Blob, vr *reader.VerifiableReader, root *estargz.TOCEntry, prefetchTimeout time.Duration) *layer {
-	return &layer{
-		desc:             desc,
-		blob:             blob,
-		verifiableReader: vr,
-		root:             root,
-		prefetchWaiter:   newWaiter(),
-		prefetchTimeout:  prefetchTimeout,
+// neighboringLayers returns layer descriptors except the `target` layer in the specified manifest.
+func neighboringLayers(manifest ocispec.Manifest, target ocispec.Descriptor) (descs []ocispec.Descriptor) {
+	for _, desc := range manifest.Layers {
+		if desc.Digest.String() != target.Digest.String() {
+			descs = append(descs, desc)
+		}
 	}
-}
-
-type layer struct {
-	desc             ocispec.Descriptor
-	blob             remote.Blob
-	verifiableReader *reader.VerifiableReader
-	root             *estargz.TOCEntry
-	prefetchWaiter   *waiter
-	prefetchTimeout  time.Duration
-	r                reader.Reader
-}
-
-func (l *layer) reader() (reader.Reader, error) {
-	if l.r == nil {
-		return nil, fmt.Errorf("layer hasn't been verified yet")
-	}
-	return l.r, nil
-}
-
-func (l *layer) skipVerify() {
-	l.r = l.verifiableReader.SkipVerify()
-}
-
-func (l *layer) verify(tocDigest digest.Digest) (err error) {
-	l.r, err = l.verifiableReader.VerifyTOC(tocDigest)
 	return
 }
-
-func (l *layer) prefetch(prefetchSize int64) error {
-	defer l.prefetchWaiter.done() // Notify the completion
-
-	lr, err := l.reader()
-	if err != nil {
-		return err
-	}
-	if _, ok := lr.Lookup(estargz.NoPrefetchLandmark); ok {
-		// do not prefetch this layer
-		return nil
-	} else if e, ok := lr.Lookup(estargz.PrefetchLandmark); ok {
-		// override the prefetch size with optimized value
-		prefetchSize = e.Offset
-	} else if prefetchSize > l.blob.Size() {
-		// adjust prefetch size not to exceed the whole layer size
-		prefetchSize = l.blob.Size()
-	}
-
-	// Fetch the target range
-	if err := l.blob.Cache(0, prefetchSize); err != nil {
-		return errors.Wrap(err, "failed to prefetch layer")
-	}
-
-	// Cache uncompressed contents of the prefetched range
-	if err := lr.Cache(reader.WithFilter(func(e *estargz.TOCEntry) bool {
-		return e.Offset < prefetchSize // Cache only prefetch target
-	})); err != nil {
-		return errors.Wrap(err, "failed to cache prefetched layer")
-	}
-
-	return nil
-}
-
-func (l *layer) waitForPrefetchCompletion() error {
-	return l.prefetchWaiter.wait(l.prefetchTimeout)
-}
-
-func newWaiter() *waiter {
-	return &waiter{
-		completionCond: sync.NewCond(&sync.Mutex{}),
-	}
-}
-
-type waiter struct {
-	isDone         bool
-	isDoneMu       sync.Mutex
-	completionCond *sync.Cond
-}
-
-func (w *waiter) done() {
-	w.isDoneMu.Lock()
-	w.isDone = true
-	w.isDoneMu.Unlock()
-	w.completionCond.Broadcast()
-}
-
-func (w *waiter) wait(timeout time.Duration) error {
-	wait := func() <-chan struct{} {
-		ch := make(chan struct{})
-		go func() {
-			w.isDoneMu.Lock()
-			isDone := w.isDone
-			w.isDoneMu.Unlock()
-
-			w.completionCond.L.Lock()
-			if !isDone {
-				w.completionCond.Wait()
-			}
-			w.completionCond.L.Unlock()
-			ch <- struct{}{}
-		}()
-		return ch
-	}
-	select {
-	case <-time.After(timeout):
-		w.isDoneMu.Lock()
-		w.isDone = true
-		w.isDoneMu.Unlock()
-		w.completionCond.Broadcast()
-		return fmt.Errorf("timeout(%v)", timeout)
-	case <-wait():
-		return nil
-	}
-}
-
-type readerAtFunc func([]byte, int64) (int, error)
-
-func (f readerAtFunc) ReadAt(p []byte, offset int64) (int, error) { return f(p, offset) }
 
 type fileReader interface {
 	OpenFile(name string) (io.ReaderAt, error)
@@ -879,15 +630,16 @@ func (w *whiteout) Statfs(ctx context.Context, out *fuse.StatfsOut) syscall.Errn
 
 // newState provides new state directory node.
 // It creates statFile at the same time to give it stable inode number.
-func newState(digest string, blob remote.Blob) *state {
+func newState(layer layer.Layer) *state {
+	info := layer.Info()
 	return &state{
 		statFile: &statFile{
-			name: digest + ".json",
+			name: info.Digest.String() + ".json",
 			statJSON: statJSON{
-				Digest: digest,
-				Size:   blob.Size(),
+				Digest: info.Digest.String(),
+				Size:   info.Size,
 			},
-			blob: blob,
+			layer: layer,
 		},
 	}
 }
@@ -960,7 +712,7 @@ type statJSON struct {
 type statFile struct {
 	fusefs.Inode
 	name     string
-	blob     remote.Blob
+	layer    layer.Layer
 	statJSON statJSON
 	mu       sync.Mutex
 }
@@ -1020,7 +772,7 @@ func (sf *statFile) attr(out *fuse.Attr) (fusefs.StableAttr, syscall.Errno) {
 }
 
 func (sf *statFile) updateStatUnlocked() ([]byte, error) {
-	sf.statJSON.FetchedSize = sf.blob.FetchedSize()
+	sf.statJSON.FetchedSize = sf.layer.Info().FetchedSize
 	sf.statJSON.FetchedPercent = float64(sf.statJSON.FetchedSize) / float64(sf.statJSON.Size) * 100.0
 	j, err := json.Marshal(&sf.statJSON)
 	if err != nil {

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -1,0 +1,590 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
+*/
+
+package layer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/reference"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/stargz-snapshotter/cache"
+	"github.com/containerd/stargz-snapshotter/estargz"
+	"github.com/containerd/stargz-snapshotter/fs/config"
+	"github.com/containerd/stargz-snapshotter/fs/reader"
+	"github.com/containerd/stargz-snapshotter/fs/remote"
+	"github.com/containerd/stargz-snapshotter/task"
+	"github.com/containerd/stargz-snapshotter/util/lrucache"
+	"github.com/containerd/stargz-snapshotter/util/namedmutex"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultResolveResultEntry = 30
+	defaultMaxLRUCacheEntry   = 10
+	defaultMaxCacheFds        = 10
+	defaultPrefetchTimeoutSec = 10
+	memoryCacheType           = "memory"
+)
+
+// Layer represents a layer.
+type Layer interface {
+
+	// Info returns the information of this layer.
+	Info() Info
+
+	// Root returns the root node of this layer.
+	Root() *estargz.TOCEntry
+
+	// Check checks if the layer is still connectable.
+	Check() error
+
+	// Refresh refreshes the layer connection.
+	Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error
+
+	// Verify verifies this layer using the passed TOC Digest.
+	Verify(tocDigest digest.Digest) (err error)
+
+	// SkipVerify skips verification for this layer.
+	SkipVerify() (err error)
+
+	// OpenFile opens a file.
+	// Calling this function before calling Verify or SkipVerify will fail.
+	OpenFile(name string) (io.ReaderAt, error)
+
+	// Prefetch prefetches the specified size. If the layer is eStargz and contains landmark files,
+	// the range indicated by these files is respected.
+	// Calling this function before calling Verify or SkipVerify will fail.
+	Prefetch(prefetchSize int64) error
+
+	// WaitForPrefetchCompletion waits untils Prefetch completes.
+	WaitForPrefetchCompletion() error
+
+	// BackgroundFetch fetches the entire layer contents to the cache.
+	// Fetching contents is done as a background task.
+	// Calling this function before calling Verify or SkipVerify will fail.
+	BackgroundFetch() error
+
+	// Done releases the reference to this layer. The resources related to this layer will be
+	// discarded sooner or later. Queries after calling this function won't be serviced.
+	Done()
+}
+
+// Info is the current status of a layer.
+type Info struct {
+	Digest      digest.Digest
+	Size        int64
+	FetchedSize int64
+}
+
+// Resolver resolves the layer location and provieds the handler of that layer.
+type Resolver struct {
+	resolver              *remote.Resolver
+	prefetchTimeout       time.Duration
+	layerCache            *lrucache.Cache
+	layerCacheMu          sync.Mutex
+	blobCache             *lrucache.Cache
+	blobCacheMu           sync.Mutex
+	backgroundTaskManager *task.BackgroundTaskManager
+	fsCache               func() (cache.BlobCache, error)
+	resolveLock           *namedmutex.NamedMutex
+}
+
+// NewResolver returns a new layer resolver.
+func NewResolver(root string, backgroundTaskManager *task.BackgroundTaskManager, cfg config.Config) *Resolver {
+	resolveResultEntry := cfg.ResolveResultEntry
+	if resolveResultEntry == 0 {
+		resolveResultEntry = defaultResolveResultEntry
+	}
+	prefetchTimeout := time.Duration(cfg.PrefetchTimeoutSec) * time.Second
+	if prefetchTimeout == 0 {
+		prefetchTimeout = defaultPrefetchTimeoutSec * time.Second
+	}
+
+	// layerCache caches resolved layers for future use. This is useful in a use-case where
+	// the filesystem resolves and caches all layers in an image (not only queried one) in parallel,
+	// before they are actually queried.
+	layerCache := lrucache.New(resolveResultEntry)
+	layerCache.OnEvicted = func(key string, value interface{}) {
+		if err := value.(*layer).close(); err != nil {
+			logrus.WithField("key", key).WithError(err).Warnf("failed to clean up layer")
+			return
+		}
+		logrus.WithField("key", key).Debugf("cleaned up layer")
+	}
+
+	// blobCache caches resolved blobs for futural use. This is especially useful when a layer
+	// isn't eStargz/stargz (the *layer object won't be created/cached in this case).
+	blobCache := lrucache.New(resolveResultEntry)
+	blobCache.OnEvicted = func(key string, value interface{}) {
+		if err := value.(remote.Blob).Close(); err != nil {
+			logrus.WithField("key", key).WithError(err).Warnf("failed to clean up blob")
+			return
+		}
+		logrus.WithField("key", key).Debugf("cleaned up blob")
+	}
+
+	// Prepare the generators of contents cache.
+	httpCacheFactory := cacheFactory(filepath.Join(root, "httpcache"), cfg.HTTPCacheType, cfg)
+	fsCacheFactory := cacheFactory(filepath.Join(root, "fscache"), cfg.FSCacheType, cfg)
+
+	return &Resolver{
+		resolver:              remote.NewResolver(httpCacheFactory, cfg.BlobConfig),
+		fsCache:               fsCacheFactory,
+		layerCache:            layerCache,
+		blobCache:             blobCache,
+		prefetchTimeout:       prefetchTimeout,
+		backgroundTaskManager: backgroundTaskManager,
+		resolveLock:           new(namedmutex.NamedMutex),
+	}
+}
+
+// cacheFactory returns a callback that can be used to create a new content cache.
+func cacheFactory(root string, cacheType string, cfg config.Config) func() (cache.BlobCache, error) {
+	if cacheType == memoryCacheType {
+		return func() (cache.BlobCache, error) {
+			return cache.NewMemoryCache(), nil
+		}
+	}
+
+	dcc := cfg.DirectoryCacheConfig
+	maxDataEntry := dcc.MaxLRUCacheEntry
+	if maxDataEntry == 0 {
+		maxDataEntry = defaultMaxLRUCacheEntry
+	}
+	maxFdEntry := dcc.MaxCacheFds
+	if maxFdEntry == 0 {
+		maxFdEntry = defaultMaxCacheFds
+	}
+
+	// All directory caches share on-memory caches (pool and LRU caches).
+	bufPool := &sync.Pool{
+		New: func() interface{} {
+			return new(bytes.Buffer)
+		},
+	}
+	dCache, fCache := lrucache.New(maxDataEntry), lrucache.New(maxFdEntry)
+	dCache.OnEvicted = func(key string, value interface{}) {
+		bufPool.Put(value)
+	}
+	fCache.OnEvicted = func(key string, value interface{}) {
+		value.(*os.File).Close()
+	}
+	return func() (cache.BlobCache, error) {
+		// create a cache on an unique directory
+		if err := os.MkdirAll(root, 0700); err != nil {
+			return nil, err
+		}
+		cachePath, err := ioutil.TempDir(root, "")
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to initialize directory cache")
+		}
+		return cache.NewDirectoryCache(
+			cachePath,
+			cache.DirectoryCacheConfig{
+				SyncAdd:   dcc.SyncAdd,
+				DataCache: dCache,
+				FdCache:   fCache,
+				BufPool:   bufPool,
+			},
+		)
+	}
+}
+
+// Resolve resolves a layer based on the passed layer blob information.
+func (r *Resolver) Resolve(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (_ Layer, retErr error) {
+	name := refspec.String() + "/" + desc.Digest.String()
+
+	// Wait if resolving this layer is already running. The result
+	// can hopefully get from the LRU cache.
+	r.resolveLock.Lock(name)
+	defer r.resolveLock.Unlock(name)
+
+	ctx, cancel := context.WithCancel(log.WithLogger(ctx, log.G(ctx).WithField("src", name)))
+	defer cancel()
+
+	// First, try to retrieve this layer from the underlying LRU cache.
+	r.layerCacheMu.Lock()
+	c, done, ok := r.layerCache.Get(name)
+	r.layerCacheMu.Unlock()
+	if ok {
+		if l := c.(*layer); l.Check() == nil {
+			log.G(ctx).Debugf("hit layer cache %q", name)
+			return &layerRef{l, done}, nil
+		}
+		done()
+		r.layerCacheMu.Lock()
+		r.layerCache.Remove(name)
+		r.layerCacheMu.Unlock()
+	}
+
+	log.G(ctx).Debugf("resolving")
+
+	// Resolve the blob.
+	blobR, err := r.resolveBlob(ctx, hosts, refspec, desc)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve the blob")
+	}
+	defer func() {
+		if retErr != nil {
+			blobR.done()
+		}
+	}()
+
+	// Prepare the content cache for this layer.
+	fsCache, err := r.fsCache()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to init cache")
+	}
+	defer func() {
+		if retErr != nil {
+			fsCache.Close()
+		}
+	}()
+
+	// Get a reader for stargz archive.
+	// Each file's read operation is a prioritized task and all background tasks
+	// will be stopped during the execution so this can avoid being disturbed for
+	// NW traffic by background tasks.
+	sr := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (n int, err error) {
+		r.backgroundTaskManager.DoPrioritizedTask()
+		defer r.backgroundTaskManager.DonePrioritizedTask()
+		return blobR.ReadAt(p, offset)
+	}), 0, blobR.Size())
+	vr, root, err := reader.NewReader(sr, fsCache)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read layer")
+	}
+
+	// Combine layer information together and cache it.
+	l := newLayer(r, desc, blobR, vr, root)
+	r.layerCacheMu.Lock()
+	cachedL, done2, added := r.layerCache.Add(name, l)
+	r.layerCacheMu.Unlock()
+	if !added {
+		l.close() // layer already exists in the cache. discrad this.
+	}
+
+	log.G(ctx).Debugf("resolved")
+	return &layerRef{cachedL.(*layer), done2}, nil
+}
+
+// resolveBlob resolves a blob based on the passed layer blob information.
+func (r *Resolver) resolveBlob(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (*blobRef, error) {
+	name := refspec.String() + "/" + desc.Digest.String()
+
+	// Try to retrieve the blob from the underlying LRU cache.
+	r.blobCacheMu.Lock()
+	c, done, ok := r.blobCache.Get(name)
+	r.blobCacheMu.Unlock()
+	if ok {
+		if blob := c.(remote.Blob); blob.Check() == nil {
+			return &blobRef{blob, done}, nil
+		}
+		// invalid blob. discard this.
+		done()
+		r.blobCacheMu.Lock()
+		r.blobCache.Remove(name)
+		r.blobCacheMu.Unlock()
+	}
+
+	// Resolve the blob and cache the result.
+	b, err := r.resolver.Resolve(ctx, hosts, refspec, desc)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to resolve the source")
+	}
+	r.blobCacheMu.Lock()
+	cachedB, done, added := r.blobCache.Add(name, b)
+	r.blobCacheMu.Unlock()
+	if !added {
+		b.Close() // blob already exists in the cache. discard this.
+	}
+	return &blobRef{cachedB.(remote.Blob), done}, nil
+}
+
+// Cache is similar to Resolve but the result isn't returned. Instead, it'll be stored in the cache.
+func (r *Resolver) Cache(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
+	l, err := r.Resolve(ctx, hosts, refspec, desc)
+	if err != nil {
+		return err
+	}
+	// Release this layer. However, this will remain on the cache until eviction.
+	// Until then, the client can reuse this (already pre-resolved) layer.
+	l.Done()
+	return nil
+}
+
+// blobRef is a reference to the blob in the cache. Calling `done` decreases the reference counter
+// of this blob in the underlying cache. When nobody refers to the blob in the cache, resources bound
+// to this blob will be discarded.
+type blobRef struct {
+	remote.Blob
+	done func()
+}
+
+// layerRef is a reference to the layer in the cache. Calling `Done` or `done` decreases the
+// reference counter of this blob in the underlying cache. When nobody refers to the layer in the
+// cache, resources bound to this layer will be discarded.
+type layerRef struct {
+	*layer
+	done func()
+}
+
+func (l *layerRef) Done() {
+	l.done()
+}
+
+func newLayer(
+	resolver *Resolver,
+	desc ocispec.Descriptor,
+	blobRef *blobRef,
+	vr *reader.VerifiableReader,
+	root *estargz.TOCEntry,
+) *layer {
+	return &layer{
+		resolver:         resolver,
+		desc:             desc,
+		blobRef:          blobRef,
+		verifiableReader: vr,
+		root:             root,
+		prefetchWaiter:   newWaiter(),
+	}
+}
+
+type layer struct {
+	resolver         *Resolver
+	desc             ocispec.Descriptor
+	blobRef          *blobRef
+	verifiableReader *reader.VerifiableReader
+	root             *estargz.TOCEntry
+	prefetchWaiter   *waiter
+	closed           bool
+	closedMu         sync.Mutex
+
+	r reader.Reader
+}
+
+func (l *layer) Info() Info {
+	return Info{
+		Digest:      l.desc.Digest,
+		Size:        l.blobRef.Size(),
+		FetchedSize: l.blobRef.FetchedSize(),
+	}
+}
+
+func (l *layer) Root() *estargz.TOCEntry {
+	return l.root
+}
+
+func (l *layer) Check() error {
+	if l.isClosed() {
+		return fmt.Errorf("layer already closed")
+	}
+	return l.blobRef.Check()
+}
+
+func (l *layer) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
+	if l.isClosed() {
+		return fmt.Errorf("layer already closed")
+	}
+	return l.blobRef.Refresh(ctx, hosts, refspec, desc)
+}
+
+func (l *layer) Verify(tocDigest digest.Digest) (err error) {
+	if l.isClosed() {
+		return fmt.Errorf("layer already closed")
+	}
+	l.r, err = l.verifiableReader.VerifyTOC(tocDigest)
+	return
+}
+
+func (l *layer) SkipVerify() (err error) {
+	if l.isClosed() {
+		return fmt.Errorf("layer already closed")
+	}
+	l.r, err = l.verifiableReader.SkipVerify()
+	return
+}
+
+func (l *layer) OpenFile(name string) (io.ReaderAt, error) {
+	if l.isClosed() {
+		return nil, fmt.Errorf("layer already closed")
+	}
+	if l.r == nil {
+		return nil, fmt.Errorf("layer hasn't been verified yet")
+	}
+	return l.r.OpenFile(name)
+}
+
+func (l *layer) Prefetch(prefetchSize int64) error {
+	defer l.prefetchWaiter.done() // Notify the completion
+
+	if l.isClosed() {
+		return fmt.Errorf("layer already closed")
+	}
+	if l.r == nil {
+		return fmt.Errorf("layer hasn't been verified yet")
+	}
+	lr := l.r
+	if _, ok := lr.Lookup(estargz.NoPrefetchLandmark); ok {
+		// do not prefetch this layer
+		return nil
+	} else if e, ok := lr.Lookup(estargz.PrefetchLandmark); ok {
+		// override the prefetch size with optimized value
+		prefetchSize = e.Offset
+	} else if prefetchSize > l.blobRef.Size() {
+		// adjust prefetch size not to exceed the whole layer size
+		prefetchSize = l.blobRef.Size()
+	}
+
+	// Fetch the target range
+	if err := l.blobRef.Cache(0, prefetchSize); err != nil {
+		return errors.Wrap(err, "failed to prefetch layer")
+	}
+
+	// Cache uncompressed contents of the prefetched range
+	if err := lr.Cache(reader.WithFilter(func(e *estargz.TOCEntry) bool {
+		return e.Offset < prefetchSize // Cache only prefetch target
+	})); err != nil {
+		return errors.Wrap(err, "failed to cache prefetched layer")
+	}
+
+	return nil
+}
+
+func (l *layer) WaitForPrefetchCompletion() error {
+	if l.isClosed() {
+		return fmt.Errorf("layer already closed")
+	}
+	return l.prefetchWaiter.wait(l.resolver.prefetchTimeout)
+}
+
+func (l *layer) BackgroundFetch() error {
+	if l.isClosed() {
+		return fmt.Errorf("layer already closed")
+	}
+	if l.r == nil {
+		return fmt.Errorf("layer hasn't been verified yet")
+	}
+	lr := l.r
+	br := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (retN int, retErr error) {
+		l.resolver.backgroundTaskManager.InvokeBackgroundTask(func(ctx context.Context) {
+			retN, retErr = l.blobRef.ReadAt(
+				p,
+				offset,
+				remote.WithContext(ctx),              // Make cancellable
+				remote.WithCacheOpts(cache.Direct()), // Do not pollute mem cache
+			)
+		}, 120*time.Second)
+		return
+	}), 0, l.blobRef.Size())
+	return lr.Cache(
+		reader.WithReader(br),                // Read contents in background
+		reader.WithCacheOpts(cache.Direct()), // Do not pollute mem cache
+	)
+}
+
+func (l *layer) close() error {
+	l.closedMu.Lock()
+	defer l.closedMu.Unlock()
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+	defer l.blobRef.done() // Close reader first, then close the blob
+	l.verifiableReader.Close()
+	if l.r != nil {
+		return l.r.Close()
+	}
+	return nil
+}
+
+func (l *layer) isClosed() bool {
+	l.closedMu.Lock()
+	closed := l.closed
+	l.closedMu.Unlock()
+	return closed
+}
+
+func newWaiter() *waiter {
+	return &waiter{
+		completionCond: sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+type waiter struct {
+	isDone         bool
+	isDoneMu       sync.Mutex
+	completionCond *sync.Cond
+}
+
+func (w *waiter) done() {
+	w.isDoneMu.Lock()
+	w.isDone = true
+	w.isDoneMu.Unlock()
+	w.completionCond.Broadcast()
+}
+
+func (w *waiter) wait(timeout time.Duration) error {
+	wait := func() <-chan struct{} {
+		ch := make(chan struct{})
+		go func() {
+			w.isDoneMu.Lock()
+			isDone := w.isDone
+			w.isDoneMu.Unlock()
+
+			w.completionCond.L.Lock()
+			if !isDone {
+				w.completionCond.Wait()
+			}
+			w.completionCond.L.Unlock()
+			ch <- struct{}{}
+		}()
+		return ch
+	}
+	select {
+	case <-time.After(timeout):
+		w.isDoneMu.Lock()
+		w.isDone = true
+		w.isDoneMu.Unlock()
+		w.completionCond.Broadcast()
+		return fmt.Errorf("timeout(%v)", timeout)
+	case <-wait():
+		return nil
+	}
+}
+
+type readerAtFunc func([]byte, int64) (int, error)
+
+func (f readerAtFunc) ReadAt(p []byte, offset int64) (int, error) { return f(p, offset) }

--- a/fs/layer/layer_test.go
+++ b/fs/layer/layer_test.go
@@ -1,0 +1,344 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
+*/
+
+package layer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/reference"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/stargz-snapshotter/cache"
+	"github.com/containerd/stargz-snapshotter/estargz"
+	"github.com/containerd/stargz-snapshotter/fs/reader"
+	"github.com/containerd/stargz-snapshotter/fs/remote"
+	"github.com/containerd/stargz-snapshotter/util/testutil"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	sampleChunkSize = 3
+	sampleData1     = "0123456789"
+	sampleData2     = "abcdefghij"
+)
+
+var testStateLayerDigest = digest.FromString("dummy")
+
+// Tests prefetch method of each stargz file.
+func TestPrefetch(t *testing.T) {
+	defaultPrefetchSize := int64(10000)
+	landmarkPosition := func(t *testing.T, l *layer) int64 {
+		if l.r == nil {
+			t.Fatalf("layer hasn't been verified yet")
+		}
+		if e, ok := l.r.Lookup(estargz.PrefetchLandmark); ok {
+			return e.Offset
+		}
+		return defaultPrefetchSize
+	}
+	defaultPrefetchPosition := func(t *testing.T, l *layer) int64 {
+		return l.Info().Size
+	}
+	tests := []struct {
+		name             string
+		in               []testutil.TarEntry
+		wantNum          int      // number of chunks wanted in the cache
+		wants            []string // filenames to compare
+		prefetchSize     func(*testing.T, *layer) int64
+		prioritizedFiles []string
+		stargz           bool
+	}{
+		{
+			name: "default_prefetch",
+			in: []testutil.TarEntry{
+				testutil.File("foo.txt", sampleData1),
+			},
+			wantNum:          chunkNum(sampleData1),
+			wants:            []string{"foo.txt"},
+			prefetchSize:     defaultPrefetchPosition,
+			prioritizedFiles: nil,
+			stargz:           true,
+		},
+		{
+			name: "no_prefetch",
+			in: []testutil.TarEntry{
+				testutil.File("foo.txt", sampleData1),
+			},
+			wantNum:          0,
+			prioritizedFiles: nil,
+		},
+		{
+			name: "prefetch",
+			in: []testutil.TarEntry{
+				testutil.File("foo.txt", sampleData1),
+				testutil.File("bar.txt", sampleData2),
+			},
+			wantNum:          chunkNum(sampleData1),
+			wants:            []string{"foo.txt"},
+			prefetchSize:     landmarkPosition,
+			prioritizedFiles: []string{"foo.txt"},
+		},
+		{
+			name: "with_dir",
+			in: []testutil.TarEntry{
+				testutil.Dir("foo/"),
+				testutil.File("foo/bar.txt", sampleData1),
+				testutil.Dir("buz/"),
+				testutil.File("buz/buzbuz.txt", sampleData2),
+			},
+			wantNum:          chunkNum(sampleData1),
+			wants:            []string{"foo/bar.txt"},
+			prefetchSize:     landmarkPosition,
+			prioritizedFiles: []string{"foo/", "foo/bar.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sr, dgst := buildStargz(t, tt.in,
+				chunkSizeInfo(sampleChunkSize),
+				prioritizedFilesInfo(tt.prioritizedFiles),
+				stargzOnlyInfo(tt.stargz))
+			blob := newBlob(sr)
+			cache := &testCache{membuf: map[string]string{}, t: t}
+			vr, _, err := reader.NewReader(sr, cache)
+			if err != nil {
+				t.Fatalf("failed to make stargz reader: %v", err)
+			}
+			l := newLayer(
+				&Resolver{
+					prefetchTimeout: time.Second,
+				},
+				ocispec.Descriptor{Digest: testStateLayerDigest},
+				&blobRef{blob, func() {}},
+				vr,
+				nil,
+			)
+			if tt.stargz {
+				l.SkipVerify()
+			} else if err := l.Verify(dgst); err != nil {
+				t.Errorf("failed to verify reader: %v", err)
+				return
+			}
+			prefetchSize := int64(0)
+			if tt.prefetchSize != nil {
+				prefetchSize = tt.prefetchSize(t, l)
+			}
+			if err := l.Prefetch(defaultPrefetchSize); err != nil {
+				t.Errorf("failed to prefetch: %v", err)
+				return
+			}
+			if blob.calledPrefetchOffset != 0 {
+				t.Errorf("invalid prefetch offset %d; want %d",
+					blob.calledPrefetchOffset, 0)
+			}
+			if blob.calledPrefetchSize != prefetchSize {
+				t.Errorf("invalid prefetch size %d; want %d",
+					blob.calledPrefetchSize, prefetchSize)
+			}
+			if tt.wantNum != len(cache.membuf) {
+				t.Errorf("number of chunks in the cache %d; want %d: %v", len(cache.membuf), tt.wantNum, err)
+				return
+			}
+
+			lr := l.r
+			if lr == nil {
+				t.Fatalf("failed to get reader from layer: %v", err)
+			}
+			for _, file := range tt.wants {
+				e, ok := lr.Lookup(file)
+				if !ok {
+					t.Fatalf("failed to lookup %q", file)
+				}
+				wantFile, err := lr.OpenFile(file)
+				if err != nil {
+					t.Fatalf("failed to open file %q", file)
+				}
+				blob.readCalled = false
+				if _, err := io.Copy(ioutil.Discard, io.NewSectionReader(wantFile, 0, e.Size)); err != nil {
+					t.Fatalf("failed to read file %q", file)
+				}
+				if blob.readCalled {
+					t.Errorf("chunks of file %q aren't cached", file)
+					return
+				}
+			}
+		})
+	}
+}
+
+func chunkNum(data string) int {
+	return (len(data)-1)/sampleChunkSize + 1
+}
+
+func newBlob(sr *io.SectionReader) *sampleBlob {
+	return &sampleBlob{
+		r: sr,
+	}
+}
+
+type sampleBlob struct {
+	r                    *io.SectionReader
+	readCalled           bool
+	calledPrefetchOffset int64
+	calledPrefetchSize   int64
+}
+
+func (sb *sampleBlob) Close() error                                          { return nil }
+func (sb *sampleBlob) Authn(tr http.RoundTripper) (http.RoundTripper, error) { return nil, nil }
+func (sb *sampleBlob) Check() error                                          { return nil }
+func (sb *sampleBlob) Size() int64                                           { return sb.r.Size() }
+func (sb *sampleBlob) FetchedSize() int64                                    { return 0 }
+func (sb *sampleBlob) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, error) {
+	sb.readCalled = true
+	return sb.r.ReadAt(p, offset)
+}
+func (sb *sampleBlob) Cache(offset int64, size int64, option ...remote.Option) error {
+	sb.calledPrefetchOffset = offset
+	sb.calledPrefetchSize = size
+	return nil
+}
+func (sb *sampleBlob) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
+	return nil
+}
+
+type testCache struct {
+	membuf map[string]string
+	t      *testing.T
+	mu     sync.Mutex
+}
+
+func (tc *testCache) FetchAt(key string, offset int64, p []byte, opts ...cache.Option) (int, error) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	cache, ok := tc.membuf[key]
+	if !ok {
+		return 0, fmt.Errorf("Missed cache: %q", key)
+	}
+	return copy(p, cache[offset:]), nil
+}
+
+func (tc *testCache) Add(key string, p []byte, opts ...cache.Option) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	tc.membuf[key] = string(p)
+	tc.t.Logf("  cached [%s...]: %q", key[:8], string(p))
+}
+func (tc *testCache) Close() error {
+	return nil
+}
+
+func TestWaiter(t *testing.T) {
+	var (
+		w         = newWaiter()
+		waitTime  = time.Second
+		startTime = time.Now()
+		doneTime  time.Time
+		done      = make(chan struct{})
+	)
+
+	go func() {
+		defer close(done)
+		if err := w.wait(10 * time.Second); err != nil {
+			t.Errorf("failed to wait: %v", err)
+			return
+		}
+		doneTime = time.Now()
+	}()
+
+	time.Sleep(waitTime)
+	w.done()
+	<-done
+
+	if doneTime.Sub(startTime) < waitTime {
+		t.Errorf("wait time is too short: %v; want %v", doneTime.Sub(startTime), waitTime)
+	}
+}
+
+type chunkSizeInfo int
+type prioritizedFilesInfo []string
+type stargzOnlyInfo bool
+
+func buildStargz(t *testing.T, ents []testutil.TarEntry, opts ...interface{}) (*io.SectionReader, digest.Digest) {
+	var chunkSize chunkSizeInfo
+	var prioritizedFiles prioritizedFilesInfo
+	var stargzOnly bool
+	for _, opt := range opts {
+		if v, ok := opt.(chunkSizeInfo); ok {
+			chunkSize = v
+		} else if v, ok := opt.(prioritizedFilesInfo); ok {
+			prioritizedFiles = v
+		} else if v, ok := opt.(stargzOnlyInfo); ok {
+			stargzOnly = bool(v)
+		} else {
+			t.Fatalf("unsupported opt")
+		}
+	}
+
+	tarBuf := new(bytes.Buffer)
+	if _, err := io.Copy(tarBuf, testutil.BuildTar(ents)); err != nil {
+		t.Fatalf("failed to build tar: %v", err)
+	}
+	tarData := tarBuf.Bytes()
+
+	if stargzOnly {
+		stargzBuf := new(bytes.Buffer)
+		w := estargz.NewWriter(stargzBuf)
+		if chunkSize > 0 {
+			w.ChunkSize = int(chunkSize)
+		}
+		if err := w.AppendTar(bytes.NewReader(tarData)); err != nil {
+			t.Fatalf("failed to append tar file to stargz: %q", err)
+		}
+		if _, err := w.Close(); err != nil {
+			t.Fatalf("failed to close stargz writer: %q", err)
+		}
+		stargzData := stargzBuf.Bytes()
+		return io.NewSectionReader(bytes.NewReader(stargzData), 0, int64(len(stargzData))), ""
+	}
+	rc, err := estargz.Build(
+		io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData))),
+		estargz.WithPrioritizedFiles([]string(prioritizedFiles)),
+		estargz.WithChunkSize(int(chunkSize)),
+	)
+	if err != nil {
+		t.Fatalf("failed to build verifiable stargz: %v", err)
+	}
+	defer rc.Close()
+	vsb := new(bytes.Buffer)
+	if _, err := io.Copy(vsb, rc); err != nil {
+		t.Fatalf("failed to copy built stargz blob: %v", err)
+	}
+	vsbb := vsb.Bytes()
+
+	return io.NewSectionReader(bytes.NewReader(vsbb), 0, int64(len(vsbb))), rc.TOCDigest()
+}

--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -48,6 +48,7 @@ type Blob interface {
 	ReadAt(p []byte, offset int64, opts ...Option) (int, error)
 	Cache(offset int64, size int64, opts ...Option) error
 	Refresh(ctx context.Context, host docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error
+	Close() error
 }
 
 type blob struct {
@@ -66,9 +67,33 @@ type blob struct {
 	fetchedRegionSetMu sync.Mutex
 
 	resolver *Resolver
+
+	closed   bool
+	closedMu sync.Mutex
+}
+
+func (b *blob) Close() error {
+	b.closedMu.Lock()
+	defer b.closedMu.Unlock()
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+	return b.cache.Close()
+}
+
+func (b *blob) isClosed() bool {
+	b.closedMu.Lock()
+	closed := b.closed
+	b.closedMu.Unlock()
+	return closed
 }
 
 func (b *blob) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
+	if b.isClosed() {
+		return fmt.Errorf("blob already closed")
+	}
+
 	// refresh the fetcher
 	new, newSize, err := newFetcher(ctx, hosts, refspec, desc)
 	if err != nil {
@@ -89,6 +114,10 @@ func (b *blob) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec 
 }
 
 func (b *blob) Check() error {
+	if b.isClosed() {
+		return fmt.Errorf("blob already closed")
+	}
+
 	now := time.Now()
 	b.lastCheckMu.Lock()
 	lastCheck := b.lastCheck
@@ -124,6 +153,10 @@ func (b *blob) FetchedSize() int64 {
 }
 
 func (b *blob) Cache(offset int64, size int64, opts ...Option) error {
+	if b.isClosed() {
+		return fmt.Errorf("blob already closed")
+	}
+
 	var cacheOpts options
 	for _, o := range opts {
 		o(&cacheOpts)
@@ -152,6 +185,10 @@ func (b *blob) Cache(offset int64, size int64, opts ...Option) error {
 // It tries to fetch as many chunks as possible from local cache.
 // We can configure this function with options.
 func (b *blob) ReadAt(p []byte, offset int64, opts ...Option) (int, error) {
+	if b.isClosed() {
+		return 0, fmt.Errorf("blob already closed")
+	}
+
 	if len(p) == 0 || offset > b.size {
 		return 0, nil
 	}
@@ -251,6 +288,10 @@ func (b *blob) ReadAt(p []byte, offset int64, opts ...Option) (int, error) {
 
 // fetchRange fetches all specified chunks from local cache and remote blob.
 func (b *blob) fetchRange(allData map[region]io.Writer, opts *options) error {
+	if b.isClosed() {
+		return fmt.Errorf("blob already closed")
+	}
+
 	if len(allData) == 0 {
 		return nil
 	}

--- a/fs/remote/blob_test.go
+++ b/fs/remote/blob_test.go
@@ -317,6 +317,8 @@ func (tc *testCache) Add(key string, p []byte, opts ...cache.Option) {
 	tc.t.Logf("  cached [%s...]: %q", key[:8], string(p))
 }
 
+func (tc *testCache) Close() error { return nil }
+
 func TestCheckInterval(t *testing.T) {
 	var (
 		tr        = &calledRoundTripper{}

--- a/util/lrucache/lrucache.go
+++ b/util/lrucache/lrucache.go
@@ -1,0 +1,141 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package lrucache provides reference-count-aware lru cache.
+package lrucache
+
+import (
+	"sync"
+
+	"github.com/golang/groupcache/lru"
+)
+
+// Cache is "groupcache/lru"-like cache. The difference is that "groupcache/lru" immediately
+// finalizes theevicted contents using OnEvicted callback but our version strictly tracks the
+// reference counts of contents and calls OnEvicted when nobody refers to the evicted contents.
+type Cache struct {
+	cache *lru.Cache
+	mu    sync.Mutex
+
+	// OnEvicted optionally specifies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key string, value interface{})
+}
+
+// New creates new cache.
+func New(maxEntries int) *Cache {
+	inner := lru.New(maxEntries)
+	inner.OnEvicted = func(key lru.Key, value interface{}) {
+		// Decrease the ref count incremented in Add().
+		// When nobody refers to this value, this value will be finalized via refCounter.
+		value.(*refCounter).finalize()
+	}
+	return &Cache{
+		cache: inner,
+	}
+}
+
+// Get retrieves the specified object from the cache and increments the reference counter of the
+// target content. Client must call `done` callback to decrease the reference count when the value
+// will no longer be used.
+func (c *Cache) Get(key string) (value interface{}, done func(), ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	o, ok := c.cache.Get(key)
+	if !ok {
+		return nil, nil, false
+	}
+	rc := o.(*refCounter)
+	rc.inc()
+	return rc.v, c.decreaseOnceFunc(rc), true
+}
+
+// Add adds object to the cache and returns the cached contents with incrementing the reference count.
+// If the specified content already exists in the cache, this sets `added` to false and returns
+// "already cached" content (i.e. doesn't replace the content with the new one). Client must call
+// `done` callback to decrease the counter when the value will no longer be used.
+func (c *Cache) Add(key string, value interface{}) (cachedValue interface{}, done func(), added bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if o, ok := c.cache.Get(key); ok {
+		rc := o.(*refCounter)
+		rc.inc()
+		return rc.v, c.decreaseOnceFunc(rc), false
+	}
+	rc := &refCounter{
+		key:       key,
+		v:         value,
+		onEvicted: c.OnEvicted,
+	}
+	rc.initialize() // Keep this object having at least 1 ref count (will be decreased in OnEviction)
+	rc.inc()        // The client references this object (will be decreased on "done")
+	c.cache.Add(key, rc)
+	return rc.v, c.decreaseOnceFunc(rc), true
+}
+
+// Remove removes the specified contents from the cache. OnEvicted callback will be called when
+// nobody refers to the removed content.
+func (c *Cache) Remove(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache.Remove(key)
+}
+
+func (c *Cache) decreaseOnceFunc(rc *refCounter) func() {
+	var once sync.Once
+	return func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		once.Do(func() { rc.dec() })
+	}
+}
+
+type refCounter struct {
+	onEvicted func(key string, value interface{})
+
+	key       string
+	v         interface{}
+	refCounts int64
+
+	mu sync.Mutex
+
+	initializeOnce sync.Once
+	finalizeOnce   sync.Once
+}
+
+func (r *refCounter) inc() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refCounts++
+}
+
+func (r *refCounter) dec() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refCounts--
+	if r.refCounts <= 0 && r.onEvicted != nil {
+		// nobody will refer this object
+		r.onEvicted(r.key, r.v)
+	}
+}
+
+func (r *refCounter) initialize() {
+	r.initializeOnce.Do(func() { r.inc() })
+}
+
+func (r *refCounter) finalize() {
+	r.finalizeOnce.Do(func() { r.dec() })
+}

--- a/util/lrucache/lrucache_test.go
+++ b/util/lrucache/lrucache_test.go
@@ -1,0 +1,152 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lrucache
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAdd(t *testing.T) {
+	c := New(10)
+
+	key, value := "key1", "abcd"
+	v, _, added := c.Add(key, value)
+	if !added {
+		t.Errorf("failed to add %q", key)
+		return
+	} else if v.(string) != value {
+		t.Errorf("returned different object for %q; want %q; got %q", key, value, v.(string))
+		return
+	}
+
+	key, newvalue := "key1", "dummy"
+	v, _, added = c.Add(key, newvalue)
+	if added || v.(string) != value {
+		t.Errorf("%q must be originally stored one; want %q; got %q (added:%v)",
+			key, value, v.(string), added)
+	}
+}
+
+func TestGet(t *testing.T) {
+	c := New(10)
+
+	key, value := "key1", "abcd"
+	v, _, added := c.Add(key, value)
+	if !added {
+		t.Errorf("failed to add %q", key)
+		return
+	} else if v.(string) != value {
+		t.Errorf("returned different object for %q; want %q; got %q", key, value, v.(string))
+		return
+	}
+
+	v, _, ok := c.Get(key)
+	if !ok {
+		t.Errorf("failed to get obj %q (%q)", key, value)
+		return
+	} else if v.(string) != value {
+		t.Errorf("unexpected object for %q; want %q; got %q", key, value, v.(string))
+		return
+	}
+}
+
+func TestRemove(t *testing.T) {
+	var evicted []string
+	c := New(2)
+	c.OnEvicted = func(key string, value interface{}) {
+		evicted = append(evicted, key)
+	}
+	key1, value1 := "key1", "abcd1"
+	_, done1, _ := c.Add(key1, value1)
+	_, done12, _ := c.Get(key1)
+
+	c.Remove(key1)
+	if len(evicted) != 0 {
+		t.Errorf("no content must be evicted after remove")
+		return
+	}
+
+	done1()
+	if len(evicted) != 0 {
+		t.Errorf("no content must be evicted until all reference are discarded")
+		return
+	}
+
+	done12()
+	if len(evicted) != 1 {
+		t.Errorf("content must be evicted")
+		return
+	}
+	if evicted[0] != key1 {
+		t.Errorf("1st content %q must be evicted but got %q", key1, evicted[0])
+		return
+	}
+}
+
+func TestEviction(t *testing.T) {
+	var evicted []string
+	c := New(2)
+	c.OnEvicted = func(key string, value interface{}) {
+		evicted = append(evicted, key)
+	}
+	key1, value1 := "key1", "abcd1"
+	key2, value2 := "key2", "abcd2"
+	_, done1, _ := c.Add(key1, value1)
+	_, done2, _ := c.Add(key2, value2)
+	_, done22, _ := c.Get(key2)
+
+	if len(evicted) != 0 {
+		t.Errorf("no content must be evicted after addition")
+		return
+	}
+	for i := 0; i < 2; i++ {
+		c.Add(fmt.Sprintf("key-add-%d", i), fmt.Sprintf("abcd-add-%d", i))
+	}
+	if len(evicted) != 0 {
+		t.Errorf("no content must be evicted after overflow")
+		return
+	}
+
+	done1()
+	if len(evicted) != 1 {
+		t.Errorf("1 content must be evicted")
+		return
+	}
+	if evicted[0] != key1 {
+		t.Errorf("1st content %q must be evicted but got %q", key1, evicted[0])
+		return
+	}
+
+	done2() // effective
+	done2() // ignored
+	done2() // ignored
+	if len(evicted) != 1 {
+		t.Errorf("only 1 content must be evicted")
+		return
+	}
+
+	done22()
+	if len(evicted) != 2 {
+		t.Errorf("2 contents must be evicted")
+		return
+	}
+	if evicted[1] != key2 {
+		t.Errorf("2nd content %q must be evicted but got %q", key2, evicted[1])
+		return
+	}
+}

--- a/util/namedmutex/namedmutex.go
+++ b/util/namedmutex/namedmutex.go
@@ -1,0 +1,62 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package namedmutex provides NamedMutex that wraps sync.Mutex
+// and provides namespaced mutex.
+package namedmutex
+
+import (
+	"sync"
+)
+
+// NamedMutex wraps sync.Mutex and provides namespaced mutex.
+type NamedMutex struct {
+	muMap  map[string]*sync.Mutex
+	refMap map[string]int
+
+	mu sync.Mutex
+}
+
+// Lock locks the mutex of the given name
+func (nl *NamedMutex) Lock(name string) {
+	nl.mu.Lock()
+	if nl.muMap == nil {
+		nl.muMap = make(map[string]*sync.Mutex)
+	}
+	if nl.refMap == nil {
+		nl.refMap = make(map[string]int)
+	}
+	if _, ok := nl.muMap[name]; !ok {
+		nl.muMap[name] = &sync.Mutex{}
+	}
+	mu := nl.muMap[name]
+	nl.refMap[name]++
+	nl.mu.Unlock()
+	mu.Lock()
+}
+
+// Unlock unlocks the mutex of the given name
+func (nl *NamedMutex) Unlock(name string) {
+	nl.mu.Lock()
+	mu := nl.muMap[name]
+	nl.refMap[name]--
+	if nl.refMap[name] <= 0 {
+		delete(nl.muMap, name)
+		delete(nl.refMap, name)
+	}
+	nl.mu.Unlock()
+	mu.Unlock()
+}


### PR DESCRIPTION
Currently, *content caches* (`/var/lib/containerd-stargz-grpc/stargz/fscache` used by `reader.Reader` and `/var/lib/containerd-stargz-grpc/stargz/httpcache` used by `remote.Blob`) aren't garbage collected on `FileSystem.Unmount()`.
This commit adds this functionality.

## Notable changes

- Introduces *namespaced* caches 
  - `/var/lib/containerd-stargz-grpc/stargz/fscache` is *namespaced* per instance of `reader.Reader` with unique ID. Each instance of `reader.Reader` owns a cache namespace and has the responsibility to cleanup it.
    - i.e. separated cache directories are created per `reader.Reader` instance. (No relationship with Linux namespace)
    - e.g. `/var/lib/containerd-stargz-grpc/stargz/fscache/267141615` for instance A, `/var/lib/containerd-stargz-grpc/stargz/fscache/555130582` for instance B, ...
  - Similarlly, `/var/lib/containerd-stargz-grpc/stargz/httpcache` is namespaced per instance of `remote.Blob`. Each instance of `remote.Blob` owns a cache namespace and has the responsibility to cleanup it.
- Introduces `github.com/containerd/stargz-snapshotter/fs/layer.Layer` that represents a layer. This wraps and manages `reader.Reader` and `remote.Blob`.
- Both of `layer.Layer` and `remote.Blob` are cached to the *LRU cache* for future use once they are created. So they are referenced by the LRU cache itself as well as by multiple cache clients. This means we need to make sure that they clean up their content cache only when nobody references them. For achieving this, this commit adds `github.com/containerd/stargz-snapshotter/util/lrucache` that is a wrapper of `groupcache/lru` but comes with reference management.

## Logic overview

On the first `Mount()` of a layer, `FileSystem` resolves the image source information.
During  resolving,

- a new namespace of the content cache is created for each `remote.Blob` and `reader.Reader`.
- `remote.Blob` and `reader.Reader` are created.
- `remote.Blob` is cached to the LRU cache for future use.

Once resolved, `layer.Layer` which refers to them (i.e. `remote.Blob` and `reader.Reader`) is created and cached to the LRU cache. Then the mountpoint of `FileSystem` holds the reference to this `layer.Layer` and mounts filesystem using it.

At this moment, there are the following reference relationships between them.

```
FileSystem(mountpoint)
    | 1
    V 1     1 1
layer.Layer --> reader.Reader
    | 1
    V 1
remote.Blob
```

- This diagram means:
  - `FileSystem`(mountpoint) refers to a single `layer.Layer`
  - A single`layer.Layer` refers to a single `blob.Blob`
  - A single `layer.Layer` refers to a single `reader.Reader`

Later on, other mountpoints possibly reuse the cached `layers.Layer` and `remote.Blob` via LRU cache so the relationship will be the following:

```
FileSystem(mountpoints)
    | n
    V 1     1 1
layer.Layer --> reader.Reader
    | n
    V 1
remote.Blob
```

- This diagram means:
  - Multiple mountpoints of `FileSystem` can refer to a single `layer.Layer` via LRU cache
  - Multiple `layer.Layer` can refer to a single `blob.Blob` via LRU cache
  - A single `layer.Layer` refers to a single `reader.Reader`

Here, `layers.Layer` and `remote.Blob` are possibly evicted from LRU cache because of other new elements but the cleanup will be deferred until the reference counter of each become 0 (this logic is implemented by `github.com/containerd/stargz-snapshotter/util/lrucache`).

On `Unmount()`, `FileSystem` unmounts the mountpoint and discards the reference to `layer.Layer` of that mountpoint. When no other mountpoints refer to it (and it's evicted from the LRU cache), this `layer.Layer` is discarded.

When it's discarded,

- the content cache of `reader.Reader` bound to this `layer.Layer` is cleaned up, and
- `layer.Layer` also discards the reference to `remote.Blob`.

When no other `layer.Layer` refer to this `remote.Blob` (and it's evicted from the LRU cache), this `remote.Blob` will be discarded too. Here, the content cache of `remote.Blob` is cleaned up.

# Test

Set `resolve_result_entry = 3` (i.e. the LRU cache of `layer.Layer` and `remote.Blob` can cache elements up to 3).

After pulling an image (`ctr-remote i rpull ghcr.io/stargz-containers/python:3.7-esgz`)

<details>
<pre>
<code>

# ls -al /var/lib/containerd-stargz-grpc/snapshotter/snapshots /var/lib/containerd-stargz-grpc/stargz/fscache /var/lib/containerd-stargz-grpc/stargz/httpcache
/var/lib/containerd-stargz-grpc/snapshotter/snapshots:
total 44
drwx------ 11 root root 4096 Mar  1 14:42 .
drwx------  3 root root 4096 Mar  1 14:42 ..
drwx------  4 root root 4096 Mar  1 14:42 1
drwx------  4 root root 4096 Mar  1 14:42 2
drwx------  4 root root 4096 Mar  1 14:42 3
drwx------  4 root root 4096 Mar  1 14:42 4
drwx------  4 root root 4096 Mar  1 14:42 5
drwx------  4 root root 4096 Mar  1 14:42 6
drwx------  4 root root 4096 Mar  1 14:42 7
drwx------  4 root root 4096 Mar  1 14:42 8
drwx------  4 root root 4096 Mar  1 14:42 9

/var/lib/containerd-stargz-grpc/stargz/fscache:
total 44
drwx------ 11 root root 4096 Mar  1 14:42 .
drwx------  4 root root 4096 Mar  1 14:42 ..
drwx------  2 root root 4096 Mar  1 14:42 020217171
drwx------  3 root root 4096 Mar  1 14:42 162121748
drwx------  3 root root 4096 Mar  1 14:42 170356474
drwx------  2 root root 4096 Mar  1 14:42 185129678
drwx------ 22 root root 4096 Mar  1 14:42 552310851
drwx------  2 root root 4096 Mar  1 14:42 631605308
drwx------ 23 root root 4096 Mar  1 14:42 690791631
drwx------  2 root root 4096 Mar  1 14:42 715874177
drwx------  2 root root 4096 Mar  1 14:42 821655654

/var/lib/containerd-stargz-grpc/stargz/httpcache:
total 44
drwx------  11 root root 4096 Mar  1 14:42 .
drwx------   4 root root 4096 Mar  1 14:42 ..
drwx------   4 root root 4096 Mar  1 14:42 101798596
drwx------ 100 root root 4096 Mar  1 14:42 304590128
drwx------   3 root root 4096 Mar  1 14:42 501507089
drwx------   3 root root 4096 Mar  1 14:42 578988651
drwx------   5 root root 4096 Mar  1 14:42 633125959
drwx------  15 root root 4096 Mar  1 14:42 669354083
drwx------  10 root root 4096 Mar  1 14:42 704229193
drwx------  56 root root 4096 Mar  1 14:42 797705588
drwx------   3 root root 4096 Mar  1 14:42 936385578

</code>
</pre>
</details>

After removing the image (`ctr-remote i rm ghcr.io/stargz-containers/python:3.7-esgz`)

<details>
<pre>
<code>

# ls -al /var/lib/containerd-stargz-grpc/snapshotter/snapshots /var/lib/containerd-stargz-grpc/stargz/fscache /var/lib/containerd-stargz-grpc/stargz/httpcache
/var/lib/containerd-stargz-grpc/snapshotter/snapshots:
total 8
drwx------ 2 root root 4096 Mar  1 14:43 .
drwx------ 3 root root 4096 Mar  1 14:42 ..

/var/lib/containerd-stargz-grpc/stargz/fscache:
total 20
drwx------   5 root root 4096 Mar  1 14:43 .
drwx------   4 root root 4096 Mar  1 14:42 ..
drwx------ 225 root root 4096 Mar  1 14:42 170356474
drwx------   3 root root 4096 Mar  1 14:42 631605308
drwx------ 250 root root 4096 Mar  1 14:42 690791631

/var/lib/containerd-stargz-grpc/stargz/httpcache:
total 24
drwx------   6 root root 4096 Mar  1 14:43 .
drwx------   4 root root 4096 Mar  1 14:42 ..
drwx------ 200 root root 4096 Mar  1 14:42 304590128
drwx------   3 root root 4096 Mar  1 14:42 501507089
drwx------ 103 root root 4096 Mar  1 14:42 578988651
drwx------  42 root root 4096 Mar  1 14:42 633125959

</code>
</pre>
</details>

On `fscache`, only cached layers (= 3 layers) remain. On `httpcache`, cached blobs (= 3 blobs) + 1 blob referenced by a layer remain.
