### PR TITLE
Refactor filesystem and cache

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -44,7 +44,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -54,39 +53,31 @@ import (
 	"unsafe"
 
 	"github.com/containerd/containerd/log"
-	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/containerd/stargz-snapshotter/cache"
 	"github.com/containerd/stargz-snapshotter/estargz"
 	"github.com/containerd/stargz-snapshotter/fs/config"
-	"github.com/containerd/stargz-snapshotter/fs/reader"
-	"github.com/containerd/stargz-snapshotter/fs/remote"
+	"github.com/containerd/stargz-snapshotter/fs/layer"
 	"github.com/containerd/stargz-snapshotter/fs/source"
 	snbase "github.com/containerd/stargz-snapshotter/snapshot"
 	"github.com/containerd/stargz-snapshotter/task"
-	"github.com/golang/groupcache/lru"
 	fusefs "github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"golang.org/x/sync/singleflight"
 	"golang.org/x/sys/unix"
 )
 
 const (
-	blockSize                 = 4096
-	memoryCacheType           = "memory"
-	whiteoutPrefix            = ".wh."
-	whiteoutOpaqueDir         = whiteoutPrefix + whiteoutPrefix + ".opq"
-	opaqueXattr               = "trusted.overlay.opaque"
-	opaqueXattrValue          = "y"
-	stateDirName              = ".stargz-snapshotter"
-	defaultResolveResultEntry = 100
-	defaultPrefetchTimeoutSec = 10
-	defaultMaxConcurrency     = 2
-	statFileMode              = syscall.S_IFREG | 0400 // -r--------
-	stateDirMode              = syscall.S_IFDIR | 0500 // dr-x------
+	blockSize             = 4096
+	whiteoutPrefix        = ".wh."
+	whiteoutOpaqueDir     = whiteoutPrefix + whiteoutPrefix + ".opq"
+	opaqueXattr           = "trusted.overlay.opaque"
+	opaqueXattrValue      = "y"
+	stateDirName          = ".stargz-snapshotter"
+	defaultMaxConcurrency = 2
+	statFileMode          = syscall.S_IFREG | 0400 // -r--------
+	stateDirMode          = syscall.S_IFDIR | 0500 // dr-x------
 )
 
 type Option func(*options)
@@ -106,46 +97,6 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snbase.Fil
 	for _, o := range opts {
 		o(&fsOpts)
 	}
-
-	dcc := cfg.DirectoryCacheConfig
-	var httpCache cache.BlobCache
-	if cfg.HTTPCacheType == memoryCacheType {
-		httpCache = cache.NewMemoryCache()
-	} else {
-		if httpCache, err = cache.NewDirectoryCache(
-			filepath.Join(root, "http"),
-			cache.DirectoryCacheConfig{
-				MaxLRUCacheEntry: dcc.MaxLRUCacheEntry,
-				MaxCacheFds:      dcc.MaxCacheFds,
-				SyncAdd:          dcc.SyncAdd,
-			},
-		); err != nil {
-			return nil, errors.Wrap(err, "failed to prepare HTTP cache")
-		}
-	}
-	var fsCache cache.BlobCache
-	if cfg.FSCacheType == memoryCacheType {
-		fsCache = cache.NewMemoryCache()
-	} else {
-		if fsCache, err = cache.NewDirectoryCache(
-			filepath.Join(root, "fscache"),
-			cache.DirectoryCacheConfig{
-				MaxLRUCacheEntry: dcc.MaxLRUCacheEntry,
-				MaxCacheFds:      dcc.MaxCacheFds,
-				SyncAdd:          dcc.SyncAdd,
-			},
-		); err != nil {
-			return nil, errors.Wrap(err, "failed to prepare filesystem cache")
-		}
-	}
-	resolveResultEntry := cfg.ResolveResultEntry
-	if resolveResultEntry == 0 {
-		resolveResultEntry = defaultResolveResultEntry
-	}
-	prefetchTimeout := time.Duration(cfg.PrefetchTimeoutSec) * time.Second
-	if prefetchTimeout == 0 {
-		prefetchTimeout = defaultPrefetchTimeoutSec * time.Second
-	}
 	maxConcurrency := cfg.MaxConcurrency
 	if maxConcurrency == 0 {
 		maxConcurrency = defaultMaxConcurrency
@@ -155,46 +106,40 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snbase.Fil
 		getSources = source.FromDefaultLabels(
 			docker.ConfigureDefaultRegistries(docker.WithPlainHTTP(docker.MatchLocalhost)))
 	}
+	tm := task.NewBackgroundTaskManager(maxConcurrency, 5*time.Second)
+	r, err := layer.NewResolver(root, tm, cfg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to setup resolver")
+	}
 	return &filesystem{
-		resolver:              remote.NewResolver(httpCache, cfg.BlobConfig),
+		resolver:              r,
 		getSources:            getSources,
-		fsCache:               fsCache,
 		prefetchSize:          cfg.PrefetchSize,
-		prefetchTimeout:       prefetchTimeout,
 		noprefetch:            cfg.NoPrefetch,
 		noBackgroundFetch:     cfg.NoBackgroundFetch,
 		debug:                 cfg.Debug,
-		layer:                 make(map[string]*layer),
-		resolveResult:         lru.New(resolveResultEntry),
-		blobResult:            lru.New(resolveResultEntry),
-		backgroundTaskManager: task.NewBackgroundTaskManager(maxConcurrency, 5*time.Second),
+		layer:                 make(map[string]layer.Layer),
+		backgroundTaskManager: tm,
 		allowNoVerification:   cfg.AllowNoVerification,
 		disableVerification:   cfg.DisableVerification,
 	}, nil
 }
 
 type filesystem struct {
-	resolver              *remote.Resolver
-	fsCache               cache.BlobCache
+	resolver              *layer.Resolver
 	prefetchSize          int64
-	prefetchTimeout       time.Duration
 	noprefetch            bool
 	noBackgroundFetch     bool
 	debug                 bool
-	layer                 map[string]*layer
+	layer                 map[string]layer.Layer
 	layerMu               sync.Mutex
-	resolveResult         *lru.Cache
-	resolveResultMu       sync.Mutex
-	blobResult            *lru.Cache
-	blobResultMu          sync.Mutex
 	backgroundTaskManager *task.BackgroundTaskManager
 	allowNoVerification   bool
 	disableVerification   bool
 	getSources            source.GetSources
-	resolveG              singleflight.Group
 }
 
-func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[string]string) error {
+func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[string]string) (retErr error) {
 	// This is a prioritized task and all background tasks will be stopped
 	// execution so this can avoid being disturbed for NW traffic by background
 	// tasks.
@@ -212,13 +157,13 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 
 	// Resolve the target layer
 	var (
-		resultChan = make(chan *layer)
+		resultChan = make(chan layer.Layer)
 		errChan    = make(chan error)
 	)
 	go func() {
 		rErr := fmt.Errorf("failed to resolve target")
 		for _, s := range src {
-			l, err := fs.resolveLayer(ctx, s.Hosts, s.Name, s.Target)
+			l, err := fs.resolver.Resolve(ctx, s.Hosts, s.Name, s.Target)
 			if err == nil {
 				resultChan <- l
 				return
@@ -229,16 +174,23 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		errChan <- rErr
 	}()
 
-	// Also resolve other layers in parallel
+	// Also resolve and cache other layers in parallel
 	preResolve := src[0] // TODO: should we pre-resolve blobs in other sources as well?
-	for _, desc := range preResolve.Manifest.Layers {
-		if desc.Digest.String() != preResolve.Target.Digest.String() {
-			go fs.resolveLayer(ctx, preResolve.Hosts, preResolve.Name, desc)
-		}
+	for _, desc := range neighboringLayers(preResolve.Manifest, preResolve.Target) {
+		desc := desc
+		go func() {
+			// Avoids to get canceled by client.
+			ctx := log.WithLogger(context.Background(),
+				log.G(ctx).WithField("mountpoint", mountpoint))
+			_, err := fs.resolver.Resolve(ctx, preResolve.Hosts, preResolve.Name, desc)
+			if err != nil {
+				log.G(ctx).WithError(err).Debug("failed to pre-resolve")
+			}
+		}()
 	}
 
 	// Wait for resolving completion
-	var l *layer
+	var l layer.Layer
 	select {
 	case l = <-resultChan:
 	case err := <-errChan:
@@ -252,7 +204,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	// Verify layer's content
 	if fs.disableVerification {
 		// Skip if verification is disabled completely
-		l.skipVerify()
+		l.SkipVerify()
 		log.G(ctx).Debugf("Verification forcefully skipped")
 	} else if tocDigest, ok := labels[estargz.TOCJSONDigestAnnotation]; ok {
 		// Verify this layer using the TOC JSON digest passed through label.
@@ -261,7 +213,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 			log.G(ctx).WithError(err).Debugf("failed to parse passed TOC digest %q", dgst)
 			return errors.Wrapf(err, "invalid TOC digest: %v", tocDigest)
 		}
-		if err := l.verify(dgst); err != nil {
+		if err := l.Verify(dgst); err != nil {
 			log.G(ctx).WithError(err).Debugf("invalid layer")
 			return errors.Wrapf(err, "invalid stargz layer")
 		}
@@ -270,16 +222,11 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		// If unverified layer is allowed, use it with warning.
 		// This mode is for legacy stargz archives which don't contain digests
 		// necessary for layer verification.
-		l.skipVerify()
+		l.SkipVerify()
 		log.G(ctx).Warningf("No verification is held for layer")
 	} else {
 		// Verification must be done. Don't mount this layer.
 		return fmt.Errorf("digest of TOC JSON must be passed")
-	}
-	layerReader, err := l.reader()
-	if err != nil {
-		log.G(ctx).WithError(err).Warningf("failed to get reader for layer")
-		return err
 	}
 
 	// Register the mountpoint layer
@@ -299,7 +246,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		go func() {
 			fs.backgroundTaskManager.DoPrioritizedTask()
 			defer fs.backgroundTaskManager.DonePrioritizedTask()
-			if err := l.prefetch(prefetchSize); err != nil {
+			if err := l.Prefetch(prefetchSize); err != nil {
 				log.G(ctx).WithError(err).Debug("failed to prefetched layer")
 				return
 			}
@@ -313,21 +260,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	// about NW traffic.
 	if !fs.noBackgroundFetch {
 		go func() {
-			br := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (retN int, retErr error) {
-				fs.backgroundTaskManager.InvokeBackgroundTask(func(ctx context.Context) {
-					retN, retErr = l.blob.ReadAt(
-						p,
-						offset,
-						remote.WithContext(ctx),              // Make cancellable
-						remote.WithCacheOpts(cache.Direct()), // Do not pollute mem cache
-					)
-				}, 120*time.Second)
-				return
-			}), 0, l.blob.Size())
-			if err := layerReader.Cache(
-				reader.WithReader(br),                // Read contents in background
-				reader.WithCacheOpts(cache.Direct()), // Do not pollute mem cache
-			); err != nil {
+			if err := l.BackgroundFetch(); err != nil {
 				log.G(ctx).WithError(err).Debug("failed to fetch whole layer")
 				return
 			}
@@ -340,9 +273,9 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	timeSec := time.Second
 	rawFS := fusefs.NewNodeFS(&node{
 		fs:    fs,
-		layer: layerReader,
-		e:     l.root,
-		s:     newState(l.desc.Digest.String(), l.blob),
+		layer: l,
+		e:     l.Root(),
+		s:     newState(l),
 		root:  mountpoint,
 	}, &fusefs.Options{
 		AttrTimeout:     &timeSec,
@@ -362,79 +295,6 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 
 	go server.Serve()
 	return server.WaitMount()
-}
-
-func (fs *filesystem) resolveLayer(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (*layer, error) {
-	name := refspec.String() + "/" + desc.Digest.String()
-	ctx, cancel := context.WithCancel(log.WithLogger(ctx, log.G(ctx).WithField("src", name)))
-	defer cancel()
-
-	fs.resolveResultMu.Lock()
-	c, ok := fs.resolveResult.Get(name)
-	fs.resolveResultMu.Unlock()
-	if ok && c.(*layer).blob.Check() == nil {
-		return c.(*layer), nil
-	}
-
-	resultChan := fs.resolveG.DoChan(name, func() (interface{}, error) {
-		log.G(ctx).Debugf("resolving")
-
-		// Resolve the blob. The result will be cached for future use. This is effective
-		// in some failure cases including resolving is succeeded but the blob is non-stargz.
-		var blob remote.Blob
-		fs.blobResultMu.Lock()
-		c, ok := fs.blobResult.Get(name)
-		fs.blobResultMu.Unlock()
-		if ok && c.(remote.Blob).Check() == nil {
-			blob = c.(remote.Blob)
-		} else {
-			var err error
-			blob, err = fs.resolver.Resolve(ctx, hosts, refspec, desc)
-			if err != nil {
-				log.G(ctx).WithError(err).Debugf("failed to resolve source")
-				return nil, errors.Wrap(err, "failed to resolve the source")
-			}
-			fs.blobResultMu.Lock()
-			fs.blobResult.Add(name, blob)
-			fs.blobResultMu.Unlock()
-		}
-
-		// Get a reader for stargz archive.
-		// Each file's read operation is a prioritized task and all background tasks
-		// will be stopped during the execution so this can avoid being disturbed for
-		// NW traffic by background tasks.
-		sr := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (n int, err error) {
-			fs.backgroundTaskManager.DoPrioritizedTask()
-			defer fs.backgroundTaskManager.DonePrioritizedTask()
-			return blob.ReadAt(p, offset)
-		}), 0, blob.Size())
-		vr, root, err := reader.NewReader(sr, fs.fsCache)
-		if err != nil {
-			log.G(ctx).WithError(err).Debugf("failed to resolve: layer cannot be read")
-			return nil, errors.Wrap(err, "failed to read layer")
-		}
-
-		// Combine layer information together
-		l := newLayer(desc, blob, vr, root, fs.prefetchTimeout)
-		fs.resolveResultMu.Lock()
-		fs.resolveResult.Add(name, l)
-		fs.resolveResultMu.Unlock()
-
-		log.G(ctx).Debugf("resolved")
-		return l, nil
-	})
-
-	var res singleflight.Result
-	select {
-	case res = <-resultChan:
-	case <-time.After(30 * time.Second):
-		fs.resolveG.Forget(name)
-		return nil, fmt.Errorf("failed to resolve layer (timeout)")
-	}
-	if res.Err != nil || res.Val == nil {
-		return nil, fmt.Errorf("failed to resolve layer: %v", res.Err)
-	}
-	return res.Val.(*layer), nil
 }
 
 func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[string]string) error {
@@ -462,7 +322,7 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[s
 
 	// Wait for prefetch compeletion
 	if !fs.noprefetch {
-		if err := l.waitForPrefetchCompletion(); err != nil {
+		if err := l.WaitForPrefetchCompletion(); err != nil {
 			log.G(ctx).WithError(err).Warn("failed to sync with prefetch completion")
 		}
 	}
@@ -470,8 +330,8 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[s
 	return nil
 }
 
-func (fs *filesystem) check(ctx context.Context, l *layer, labels map[string]string) error {
-	err := l.blob.Check()
+func (fs *filesystem) check(ctx context.Context, l layer.Layer, labels map[string]string) error {
+	err := l.Check()
 	if err == nil {
 		return nil
 	}
@@ -489,7 +349,7 @@ func (fs *filesystem) check(ctx context.Context, l *layer, labels map[string]str
 	for retry := 0; retry < retrynum; retry++ {
 		log.G(ctx).Warnf("refreshing(%d)...", retry)
 		for _, s := range src {
-			err := l.blob.Refresh(ctx, s.Hosts, s.Name, s.Target)
+			err := l.Refresh(ctx, s.Hosts, s.Name, s.Target)
 			if err == nil {
 				log.G(ctx).Debug("Successfully refreshed connection")
 				return nil
@@ -520,131 +380,15 @@ func (fs *filesystem) Unmount(ctx context.Context, mountpoint string) error {
 	return syscall.Unmount(mountpoint, syscall.MNT_FORCE)
 }
 
-func newLayer(desc ocispec.Descriptor, blob remote.Blob, vr *reader.VerifiableReader, root *estargz.TOCEntry, prefetchTimeout time.Duration) *layer {
-	return &layer{
-		desc:             desc,
-		blob:             blob,
-		verifiableReader: vr,
-		root:             root,
-		prefetchWaiter:   newWaiter(),
-		prefetchTimeout:  prefetchTimeout,
+// neighboringLayers returns layer descriptors except the `target` layer in the specified manifest.
+func neighboringLayers(manifest ocispec.Manifest, target ocispec.Descriptor) (descs []ocispec.Descriptor) {
+	for _, desc := range manifest.Layers {
+		if desc.Digest.String() != target.Digest.String() {
+			descs = append(descs, desc)
+		}
 	}
-}
-
-type layer struct {
-	desc             ocispec.Descriptor
-	blob             remote.Blob
-	verifiableReader *reader.VerifiableReader
-	root             *estargz.TOCEntry
-	prefetchWaiter   *waiter
-	prefetchTimeout  time.Duration
-	r                reader.Reader
-}
-
-func (l *layer) reader() (reader.Reader, error) {
-	if l.r == nil {
-		return nil, fmt.Errorf("layer hasn't been verified yet")
-	}
-	return l.r, nil
-}
-
-func (l *layer) skipVerify() {
-	l.r = l.verifiableReader.SkipVerify()
-}
-
-func (l *layer) verify(tocDigest digest.Digest) (err error) {
-	l.r, err = l.verifiableReader.VerifyTOC(tocDigest)
 	return
 }
-
-func (l *layer) prefetch(prefetchSize int64) error {
-	defer l.prefetchWaiter.done() // Notify the completion
-
-	lr, err := l.reader()
-	if err != nil {
-		return err
-	}
-	if _, ok := lr.Lookup(estargz.NoPrefetchLandmark); ok {
-		// do not prefetch this layer
-		return nil
-	} else if e, ok := lr.Lookup(estargz.PrefetchLandmark); ok {
-		// override the prefetch size with optimized value
-		prefetchSize = e.Offset
-	} else if prefetchSize > l.blob.Size() {
-		// adjust prefetch size not to exceed the whole layer size
-		prefetchSize = l.blob.Size()
-	}
-
-	// Fetch the target range
-	if err := l.blob.Cache(0, prefetchSize); err != nil {
-		return errors.Wrap(err, "failed to prefetch layer")
-	}
-
-	// Cache uncompressed contents of the prefetched range
-	if err := lr.Cache(reader.WithFilter(func(e *estargz.TOCEntry) bool {
-		return e.Offset < prefetchSize // Cache only prefetch target
-	})); err != nil {
-		return errors.Wrap(err, "failed to cache prefetched layer")
-	}
-
-	return nil
-}
-
-func (l *layer) waitForPrefetchCompletion() error {
-	return l.prefetchWaiter.wait(l.prefetchTimeout)
-}
-
-func newWaiter() *waiter {
-	return &waiter{
-		completionCond: sync.NewCond(&sync.Mutex{}),
-	}
-}
-
-type waiter struct {
-	isDone         bool
-	isDoneMu       sync.Mutex
-	completionCond *sync.Cond
-}
-
-func (w *waiter) done() {
-	w.isDoneMu.Lock()
-	w.isDone = true
-	w.isDoneMu.Unlock()
-	w.completionCond.Broadcast()
-}
-
-func (w *waiter) wait(timeout time.Duration) error {
-	wait := func() <-chan struct{} {
-		ch := make(chan struct{})
-		go func() {
-			w.isDoneMu.Lock()
-			isDone := w.isDone
-			w.isDoneMu.Unlock()
-
-			w.completionCond.L.Lock()
-			if !isDone {
-				w.completionCond.Wait()
-			}
-			w.completionCond.L.Unlock()
-			ch <- struct{}{}
-		}()
-		return ch
-	}
-	select {
-	case <-time.After(timeout):
-		w.isDoneMu.Lock()
-		w.isDone = true
-		w.isDoneMu.Unlock()
-		w.completionCond.Broadcast()
-		return fmt.Errorf("timeout(%v)", timeout)
-	case <-wait():
-		return nil
-	}
-}
-
-type readerAtFunc func([]byte, int64) (int, error)
-
-func (f readerAtFunc) ReadAt(p []byte, offset int64) (int, error) { return f(p, offset) }
 
 type fileReader interface {
 	OpenFile(name string) (io.ReaderAt, error)
@@ -879,15 +623,16 @@ func (w *whiteout) Statfs(ctx context.Context, out *fuse.StatfsOut) syscall.Errn
 
 // newState provides new state directory node.
 // It creates statFile at the same time to give it stable inode number.
-func newState(digest string, blob remote.Blob) *state {
+func newState(layer layer.Layer) *state {
+	info := layer.Info()
 	return &state{
 		statFile: &statFile{
-			name: digest + ".json",
+			name: info.Digest.String() + ".json",
 			statJSON: statJSON{
-				Digest: digest,
-				Size:   blob.Size(),
+				Digest: info.Digest.String(),
+				Size:   info.Size,
 			},
-			blob: blob,
+			layer: layer,
 		},
 	}
 }
@@ -960,7 +705,7 @@ type statJSON struct {
 type statFile struct {
 	fusefs.Inode
 	name     string
-	blob     remote.Blob
+	layer    layer.Layer
 	statJSON statJSON
 	mu       sync.Mutex
 }
@@ -1020,7 +765,7 @@ func (sf *statFile) attr(out *fuse.Attr) (fusefs.StableAttr, syscall.Errno) {
 }
 
 func (sf *statFile) updateStatUnlocked() ([]byte, error) {
-	sf.statJSON.FetchedSize = sf.blob.FetchedSize()
+	sf.statJSON.FetchedSize = sf.layer.Info().FetchedSize
 	sf.statJSON.FetchedPercent = float64(sf.statJSON.FetchedSize) / float64(sf.statJSON.Size) * 100.0
 	j, err := json.Marshal(&sf.statJSON)
 	if err != nil {

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -23,32 +23,27 @@
 package fs
 
 import (
-	"archive/tar"
 	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/containerd/stargz-snapshotter/cache"
 	"github.com/containerd/stargz-snapshotter/estargz"
-	"github.com/containerd/stargz-snapshotter/fs/reader"
-	"github.com/containerd/stargz-snapshotter/fs/remote"
+	"github.com/containerd/stargz-snapshotter/fs/layer"
 	"github.com/containerd/stargz-snapshotter/fs/source"
 	"github.com/containerd/stargz-snapshotter/task"
+	"github.com/containerd/stargz-snapshotter/util/testutil"
 	fusefs "github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	digest "github.com/opencontainers/go-digest"
@@ -60,60 +55,50 @@ const (
 	sampleChunkSize    = 3
 	sampleMiddleOffset = sampleChunkSize / 2
 	sampleData1        = "0123456789"
-	sampleData2        = "abcdefghij"
 	lastChunkOffset1   = sampleChunkSize * (int64(len(sampleData1)) / sampleChunkSize)
 )
 
 func TestCheck(t *testing.T) {
-	bb := &breakBlob{}
-	l := &layer{
-		blob:            bb,
-		r:               nopreader{},
-		prefetchWaiter:  newWaiter(),
-		prefetchTimeout: time.Second,
-	}
+	bl := &breakableLayer{}
 	fs := &filesystem{
-		layer: map[string]*layer{
-			"test": l,
+		layer: map[string]layer.Layer{
+			"test": bl,
 		},
 		backgroundTaskManager: task.NewBackgroundTaskManager(1, time.Millisecond),
 		getSources: source.FromDefaultLabels(
 			docker.ConfigureDefaultRegistries(docker.WithPlainHTTP(docker.MatchLocalhost))),
 	}
-	bb.success = true
+	bl.success = true
 	if err := fs.Check(context.TODO(), "test", nil); err != nil {
 		t.Errorf("connection failed; wanted to succeed: %v", err)
 	}
 
-	bb.success = false
+	bl.success = false
 	if err := fs.Check(context.TODO(), "test", nil); err == nil {
 		t.Errorf("connection succeeded; wanted to fail")
 	}
 }
 
-type nopreader struct{}
-
-func (r nopreader) OpenFile(name string) (io.ReaderAt, error)    { return nil, nil }
-func (r nopreader) Lookup(name string) (*estargz.TOCEntry, bool) { return nil, false }
-func (r nopreader) Cache(opts ...reader.CacheOption) error       { return nil }
-
-type breakBlob struct {
+type breakableLayer struct {
 	success bool
 }
 
-func (r *breakBlob) Authn(tr http.RoundTripper) (http.RoundTripper, error)         { return nil, nil }
-func (r *breakBlob) Size() int64                                                   { return 10 }
-func (r *breakBlob) FetchedSize() int64                                            { return 5 }
-func (r *breakBlob) ReadAt(p []byte, o int64, opts ...remote.Option) (int, error)  { return 0, nil }
-func (r *breakBlob) Cache(offset int64, size int64, option ...remote.Option) error { return nil }
-func (r *breakBlob) Check() error {
-	if !r.success {
+func (l *breakableLayer) Info() layer.Info                          { return layer.Info{} }
+func (l *breakableLayer) Verify(tocDigest digest.Digest) error      { return nil }
+func (l *breakableLayer) SkipVerify()                               {}
+func (l *breakableLayer) Root() *estargz.TOCEntry                   { return nil }
+func (l *breakableLayer) OpenFile(name string) (io.ReaderAt, error) { return nil, fmt.Errorf("fail") }
+func (l *breakableLayer) Prefetch(prefetchSize int64) error         { return fmt.Errorf("fail") }
+func (l *breakableLayer) WaitForPrefetchCompletion() error          { return fmt.Errorf("fail") }
+func (l *breakableLayer) BackgroundFetch() error                    { return fmt.Errorf("fail") }
+func (l *breakableLayer) Check() error {
+	if !l.success {
 		return fmt.Errorf("failed")
 	}
 	return nil
 }
-func (r *breakBlob) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
-	if !r.success {
+func (l *breakableLayer) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
+	if !l.success {
 		return fmt.Errorf("failed")
 	}
 	return nil
@@ -198,7 +183,7 @@ func TestNodeRead(t *testing.T) {
 
 func makeNodeReader(t *testing.T, contents []byte, chunkSize int64) *file {
 	testName := "test"
-	sgz, _ := buildStargz(t, []tarent{regfile(testName, string(contents))}, chunkSizeInfo(chunkSize))
+	sgz, _ := buildStargz(t, []testutil.TarEntry{testutil.File(testName, string(contents))}, chunkSizeInfo(chunkSize))
 	r, err := estargz.Open(sgz)
 	if err != nil {
 		t.Fatal("failed to make stargz")
@@ -219,15 +204,15 @@ func makeNodeReader(t *testing.T, contents []byte, chunkSize int64) *file {
 func TestExistence(t *testing.T) {
 	tests := []struct {
 		name string
-		in   []tarent
+		in   []testutil.TarEntry
 		want []check
 	}{
 		{
 			name: "1_whiteout_with_sibling",
-			in: []tarent{
-				directory("foo/"),
-				regfile("foo/bar.txt", ""),
-				regfile("foo/.wh.foo.txt", ""),
+			in: []testutil.TarEntry{
+				testutil.Dir("foo/"),
+				testutil.File("foo/bar.txt", ""),
+				testutil.File("foo/.wh.foo.txt", ""),
 			},
 			want: []check{
 				hasValidWhiteout("foo/foo.txt"),
@@ -236,10 +221,10 @@ func TestExistence(t *testing.T) {
 		},
 		{
 			name: "1_whiteout_with_duplicated_name",
-			in: []tarent{
-				directory("foo/"),
-				regfile("foo/bar.txt", "test"),
-				regfile("foo/.wh.bar.txt", ""),
+			in: []testutil.TarEntry{
+				testutil.Dir("foo/"),
+				testutil.File("foo/bar.txt", "test"),
+				testutil.File("foo/.wh.bar.txt", ""),
 			},
 			want: []check{
 				hasFileDigest("foo/bar.txt", digestFor("test")),
@@ -248,9 +233,9 @@ func TestExistence(t *testing.T) {
 		},
 		{
 			name: "1_opaque",
-			in: []tarent{
-				directory("foo/"),
-				regfile("foo/.wh..wh..opq", ""),
+			in: []testutil.TarEntry{
+				testutil.Dir("foo/"),
+				testutil.File("foo/.wh..wh..opq", ""),
 			},
 			want: []check{
 				hasNodeXattrs("foo/", opaqueXattr, opaqueXattrValue),
@@ -259,10 +244,10 @@ func TestExistence(t *testing.T) {
 		},
 		{
 			name: "1_opaque_with_sibling",
-			in: []tarent{
-				directory("foo/"),
-				regfile("foo/.wh..wh..opq", ""),
-				regfile("foo/bar.txt", "test"),
+			in: []testutil.TarEntry{
+				testutil.Dir("foo/"),
+				testutil.File("foo/.wh..wh..opq", ""),
+				testutil.File("foo/bar.txt", "test"),
 			},
 			want: []check{
 				hasNodeXattrs("foo/", opaqueXattr, opaqueXattrValue),
@@ -272,9 +257,9 @@ func TestExistence(t *testing.T) {
 		},
 		{
 			name: "1_opaque_with_xattr",
-			in: []tarent{
-				directory("foo/", xAttr{"foo": "bar"}),
-				regfile("foo/.wh..wh..opq", ""),
+			in: []testutil.TarEntry{
+				testutil.Dir("foo/", testutil.WithDirXattrs(map[string]string{"foo": "bar"})),
+				testutil.File("foo/.wh..wh..opq", ""),
 			},
 			want: []check{
 				hasNodeXattrs("foo/", opaqueXattr, opaqueXattrValue),
@@ -284,10 +269,10 @@ func TestExistence(t *testing.T) {
 		},
 		{
 			name: "prefetch_landmark",
-			in: []tarent{
-				regfile(estargz.PrefetchLandmark, "test"),
-				directory("foo/"),
-				regfile(fmt.Sprintf("foo/%s", estargz.PrefetchLandmark), "test"),
+			in: []testutil.TarEntry{
+				testutil.File(estargz.PrefetchLandmark, "test"),
+				testutil.Dir("foo/"),
+				testutil.File(fmt.Sprintf("foo/%s", estargz.PrefetchLandmark), "test"),
 			},
 			want: []check{
 				fileNotExist(estargz.PrefetchLandmark),
@@ -296,10 +281,10 @@ func TestExistence(t *testing.T) {
 		},
 		{
 			name: "no_prefetch_landmark",
-			in: []tarent{
-				regfile(estargz.NoPrefetchLandmark, "test"),
-				directory("foo/"),
-				regfile(fmt.Sprintf("foo/%s", estargz.NoPrefetchLandmark), "test"),
+			in: []testutil.TarEntry{
+				testutil.File(estargz.NoPrefetchLandmark, "test"),
+				testutil.Dir("foo/"),
+				testutil.File(fmt.Sprintf("foo/%s", estargz.NoPrefetchLandmark), "test"),
 			},
 			want: []check{
 				fileNotExist(estargz.NoPrefetchLandmark),
@@ -308,8 +293,8 @@ func TestExistence(t *testing.T) {
 		},
 		{
 			name: "state_file",
-			in: []tarent{
-				regfile("test", "test"),
+			in: []testutil.TarEntry{
+				testutil.File("test", "test"),
 			},
 			want: []check{
 				hasFileDigest("test", digestFor("test")),
@@ -318,8 +303,8 @@ func TestExistence(t *testing.T) {
 		},
 		{
 			name: "file_suid",
-			in: []tarent{
-				regfile("test", "test", os.ModeSetuid),
+			in: []testutil.TarEntry{
+				testutil.File("test", "test", testutil.WithFileMode(0644|os.ModeSetuid)),
 			},
 			want: []check{
 				hasExtraMode("test", os.ModeSetuid),
@@ -327,8 +312,8 @@ func TestExistence(t *testing.T) {
 		},
 		{
 			name: "dir_sgid",
-			in: []tarent{
-				directory("test/", os.ModeSetgid),
+			in: []testutil.TarEntry{
+				testutil.Dir("test/", testutil.WithDirMode(0755|os.ModeSetgid)),
 			},
 			want: []check{
 				hasExtraMode("test/", os.ModeSetgid),
@@ -336,8 +321,8 @@ func TestExistence(t *testing.T) {
 		},
 		{
 			name: "file_sticky",
-			in: []tarent{
-				regfile("test", "test", os.ModeSticky),
+			in: []testutil.TarEntry{
+				testutil.File("test", "test", testutil.WithFileMode(0644|os.ModeSticky)),
 			},
 			want: []check{
 				hasExtraMode("test", os.ModeSticky),
@@ -360,17 +345,16 @@ func TestExistence(t *testing.T) {
 	}
 }
 
-var testStateLayerDigest = digest.FromString("dummy")
-
 func getRootNode(t *testing.T, r *estargz.Reader) *node {
 	root, ok := r.Lookup("")
 	if !ok {
 		t.Fatalf("failed to find root in stargz")
 	}
+	l := &testLayer{r}
 	rootNode := &node{
-		layer: &testLayer{r},
+		layer: l,
 		e:     root,
-		s:     newState(testStateLayerDigest.String(), &dummyBlob{}),
+		s:     newState(l),
 	}
 	fusefs.NewNodeFS(rootNode, &fusefs.Options{})
 	return rootNode
@@ -380,75 +364,48 @@ type testLayer struct {
 	r *estargz.Reader
 }
 
+var testStateLayerDigest = digest.FromString("dummy")
+
 func (tl *testLayer) OpenFile(name string) (io.ReaderAt, error) {
 	return tl.r.OpenFile(name)
 }
-
-type dummyBlob struct{}
-
-func (db *dummyBlob) Authn(tr http.RoundTripper) (http.RoundTripper, error)             { return nil, nil }
-func (db *dummyBlob) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, error) { return 0, nil }
-func (db *dummyBlob) Size() int64                                                       { return 10 }
-func (db *dummyBlob) FetchedSize() int64                                                { return 5 }
-func (db *dummyBlob) Check() error                                                      { return nil }
-func (db *dummyBlob) Cache(offset int64, size int64, option ...remote.Option) error     { return nil }
-func (db *dummyBlob) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
+func (tl *testLayer) Info() layer.Info {
+	return layer.Info{
+		Digest:      testStateLayerDigest,
+		Size:        10,
+		FetchedSize: 5,
+	}
+}
+func (tl *testLayer) Verify(tocDigest digest.Digest) error { return nil }
+func (tl *testLayer) SkipVerify()                          {}
+func (tl *testLayer) Root() *estargz.TOCEntry              { return nil }
+func (tl *testLayer) Prefetch(prefetchSize int64) error    { return fmt.Errorf("fail") }
+func (tl *testLayer) WaitForPrefetchCompletion() error     { return fmt.Errorf("fail") }
+func (tl *testLayer) BackgroundFetch() error               { return fmt.Errorf("fail") }
+func (tl *testLayer) Check() error                         { return nil }
+func (tl *testLayer) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
 	return nil
 }
 
 type chunkSizeInfo int
-type prioritizedFilesInfo []string
-type stargzOnlyInfo bool
 
-func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionReader, digest.Digest) {
+func buildStargz(t *testing.T, ents []testutil.TarEntry, opts ...interface{}) (*io.SectionReader, digest.Digest) {
 	var chunkSize chunkSizeInfo
-	var prioritizedFiles prioritizedFilesInfo
-	var stargzOnly bool
 	for _, opt := range opts {
 		if v, ok := opt.(chunkSizeInfo); ok {
 			chunkSize = v
-		} else if v, ok := opt.(prioritizedFilesInfo); ok {
-			prioritizedFiles = v
-		} else if v, ok := opt.(stargzOnlyInfo); ok {
-			stargzOnly = bool(v)
 		} else {
 			t.Fatalf("unsupported opt")
 		}
 	}
 
 	tarBuf := new(bytes.Buffer)
-	tw := tar.NewWriter(tarBuf)
-	for _, ent := range ents {
-		if err := tw.WriteHeader(ent.header); err != nil {
-			t.Fatalf("writing header to the input tar: %v", err)
-		}
-		if _, err := tw.Write(ent.contents); err != nil {
-			t.Fatalf("writing contents to the input tar: %v", err)
-		}
-	}
-	if err := tw.Close(); err != nil {
-		t.Fatalf("closing write of input tar: %v", err)
+	if _, err := io.Copy(tarBuf, testutil.BuildTar(ents)); err != nil {
+		t.Fatalf("failed to build tar: %v", err)
 	}
 	tarData := tarBuf.Bytes()
-
-	if stargzOnly {
-		stargzBuf := new(bytes.Buffer)
-		w := estargz.NewWriter(stargzBuf)
-		if chunkSize > 0 {
-			w.ChunkSize = int(chunkSize)
-		}
-		if err := w.AppendTar(bytes.NewReader(tarData)); err != nil {
-			t.Fatalf("failed to append tar file to stargz: %q", err)
-		}
-		if _, err := w.Close(); err != nil {
-			t.Fatalf("failed to close stargz writer: %q", err)
-		}
-		stargzData := stargzBuf.Bytes()
-		return io.NewSectionReader(bytes.NewReader(stargzData), 0, int64(len(stargzData))), ""
-	}
 	rc, err := estargz.Build(
 		io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData))),
-		estargz.WithPrioritizedFiles([]string(prioritizedFiles)),
 		estargz.WithChunkSize(int(chunkSize)),
 	)
 	if err != nil {
@@ -462,80 +419,6 @@ func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionR
 	vsbb := vsb.Bytes()
 
 	return io.NewSectionReader(bytes.NewReader(vsbb), 0, int64(len(vsbb))), rc.TOCDigest()
-}
-
-type tarent struct {
-	header   *tar.Header
-	contents []byte
-}
-
-// suid, guid, sticky bits for archive/tar
-// https://github.com/golang/go/blob/release-branch.go1.13/src/archive/tar/common.go#L607-L609
-const (
-	cISUID = 04000 // Set uid
-	cISGID = 02000 // Set gid
-	cISVTX = 01000 // Save text (sticky bit)
-)
-
-func extraModeToTarMode(fm os.FileMode) (tm int64) {
-	if fm&os.ModeSetuid != 0 {
-		tm |= cISUID
-	}
-	if fm&os.ModeSetgid != 0 {
-		tm |= cISGID
-	}
-	if fm&os.ModeSticky != 0 {
-		tm |= cISVTX
-	}
-	return
-}
-
-func regfile(name string, contents string, opts ...interface{}) tarent {
-	if strings.HasSuffix(name, "/") {
-		panic(fmt.Sprintf("file %q has suffix /", name))
-	}
-	var xmodes os.FileMode
-	for _, opt := range opts {
-		if v, ok := opt.(os.FileMode); ok {
-			xmodes = v
-		}
-	}
-	return tarent{
-		header: &tar.Header{
-			Typeflag: tar.TypeReg,
-			Name:     name,
-			Mode:     0644 | extraModeToTarMode(xmodes),
-			Size:     int64(len(contents)),
-		},
-		contents: []byte(contents),
-	}
-}
-
-type xAttr map[string]string
-
-func directory(name string, opts ...interface{}) tarent {
-	if !strings.HasSuffix(name, "/") {
-		panic(fmt.Sprintf("dir %q hasn't suffix /", name))
-	}
-	var (
-		xattrs xAttr
-		xmodes os.FileMode
-	)
-	for _, opt := range opts {
-		if v, ok := opt.(xAttr); ok {
-			xattrs = v
-		} else if v, ok := opt.(os.FileMode); ok {
-			xmodes = v
-		}
-	}
-	return tarent{
-		header: &tar.Header{
-			Typeflag: tar.TypeDir,
-			Name:     name,
-			Mode:     0755 | extraModeToTarMode(xmodes),
-			Xattrs:   xattrs,
-		},
-	}
 }
 
 type check func(*testing.T, *node)
@@ -812,223 +695,23 @@ func digestFor(content string) string {
 	return fmt.Sprintf("sha256:%x", sum)
 }
 
-// Tests prefetch method of each stargz file.
-func TestPrefetch(t *testing.T) {
-	defaultPrefetchSize := int64(10000)
-	landmarkPosition := func(t *testing.T, l *layer) int64 {
-		lr, err := l.reader()
-		if err != nil {
-			t.Fatalf("failed to get reader from layer: %v", err)
-		}
-		if e, ok := lr.Lookup(estargz.PrefetchLandmark); ok {
-			return e.Offset
-		}
-		return defaultPrefetchSize
+// suid, guid, sticky bits for archive/tar
+// https://github.com/golang/go/blob/release-branch.go1.13/src/archive/tar/common.go#L607-L609
+const (
+	cISUID = 04000 // Set uid
+	cISGID = 02000 // Set gid
+	cISVTX = 01000 // Save text (sticky bit)
+)
+
+func extraModeToTarMode(fm os.FileMode) (tm int64) {
+	if fm&os.ModeSetuid != 0 {
+		tm |= cISUID
 	}
-	defaultPrefetchPosition := func(t *testing.T, l *layer) int64 {
-		return l.blob.Size()
+	if fm&os.ModeSetgid != 0 {
+		tm |= cISGID
 	}
-	tests := []struct {
-		name             string
-		in               []tarent
-		wantNum          int      // number of chunks wanted in the cache
-		wants            []string // filenames to compare
-		prefetchSize     func(*testing.T, *layer) int64
-		prioritizedFiles []string
-		stargz           bool
-	}{
-		{
-			name: "default_prefetch",
-			in: []tarent{
-				regfile("foo.txt", sampleData1),
-			},
-			wantNum:          chunkNum(sampleData1),
-			wants:            []string{"foo.txt"},
-			prefetchSize:     defaultPrefetchPosition,
-			prioritizedFiles: nil,
-			stargz:           true,
-		},
-		{
-			name: "no_prefetch",
-			in: []tarent{
-				regfile("foo.txt", sampleData1),
-			},
-			wantNum:          0,
-			prioritizedFiles: nil,
-		},
-		{
-			name: "prefetch",
-			in: []tarent{
-				regfile("foo.txt", sampleData1),
-				regfile("bar.txt", sampleData2),
-			},
-			wantNum:          chunkNum(sampleData1),
-			wants:            []string{"foo.txt"},
-			prefetchSize:     landmarkPosition,
-			prioritizedFiles: []string{"foo.txt"},
-		},
-		{
-			name: "with_dir",
-			in: []tarent{
-				directory("foo/"),
-				regfile("foo/bar.txt", sampleData1),
-				directory("buz/"),
-				regfile("buz/buzbuz.txt", sampleData2),
-			},
-			wantNum:          chunkNum(sampleData1),
-			wants:            []string{"foo/bar.txt"},
-			prefetchSize:     landmarkPosition,
-			prioritizedFiles: []string{"foo/", "foo/bar.txt"},
-		},
+	if fm&os.ModeSticky != 0 {
+		tm |= cISVTX
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sr, dgst := buildStargz(t, tt.in,
-				chunkSizeInfo(sampleChunkSize),
-				prioritizedFilesInfo(tt.prioritizedFiles),
-				stargzOnlyInfo(tt.stargz))
-			blob := newBlob(sr)
-			cache := &testCache{membuf: map[string]string{}, t: t}
-			vr, _, err := reader.NewReader(sr, cache)
-			if err != nil {
-				t.Fatalf("failed to make stargz reader: %v", err)
-			}
-			l := newLayer(ocispec.Descriptor{Digest: testStateLayerDigest}, blob, vr, nil, time.Second)
-			if tt.stargz {
-				l.skipVerify()
-			} else if err := l.verify(dgst); err != nil {
-				t.Errorf("failed to verify reader: %v", err)
-				return
-			}
-			prefetchSize := int64(0)
-			if tt.prefetchSize != nil {
-				prefetchSize = tt.prefetchSize(t, l)
-			}
-			if err := l.prefetch(defaultPrefetchSize); err != nil {
-				t.Errorf("failed to prefetch: %v", err)
-				return
-			}
-			if blob.calledPrefetchOffset != 0 {
-				t.Errorf("invalid prefetch offset %d; want %d",
-					blob.calledPrefetchOffset, 0)
-			}
-			if blob.calledPrefetchSize != prefetchSize {
-				t.Errorf("invalid prefetch size %d; want %d",
-					blob.calledPrefetchSize, prefetchSize)
-			}
-			if tt.wantNum != len(cache.membuf) {
-				t.Errorf("number of chunks in the cache %d; want %d: %v", len(cache.membuf), tt.wantNum, err)
-				return
-			}
-
-			lr, err := l.reader()
-			if err != nil {
-				t.Fatalf("failed to get reader from layer: %v", err)
-			}
-			for _, file := range tt.wants {
-				e, ok := lr.Lookup(file)
-				if !ok {
-					t.Fatalf("failed to lookup %q", file)
-				}
-				wantFile, err := lr.OpenFile(file)
-				if err != nil {
-					t.Fatalf("failed to open file %q", file)
-				}
-				blob.readCalled = false
-				if _, err := io.Copy(ioutil.Discard, io.NewSectionReader(wantFile, 0, e.Size)); err != nil {
-					t.Fatalf("failed to read file %q", file)
-				}
-				if blob.readCalled {
-					t.Errorf("chunks of file %q aren't cached", file)
-					return
-				}
-			}
-		})
-	}
-}
-
-func chunkNum(data string) int {
-	return (len(data)-1)/sampleChunkSize + 1
-}
-
-func newBlob(sr *io.SectionReader) *sampleBlob {
-	return &sampleBlob{
-		r: sr,
-	}
-}
-
-type sampleBlob struct {
-	r                    *io.SectionReader
-	readCalled           bool
-	calledPrefetchOffset int64
-	calledPrefetchSize   int64
-}
-
-func (sb *sampleBlob) Authn(tr http.RoundTripper) (http.RoundTripper, error) { return nil, nil }
-func (sb *sampleBlob) Check() error                                          { return nil }
-func (sb *sampleBlob) Size() int64                                           { return sb.r.Size() }
-func (sb *sampleBlob) FetchedSize() int64                                    { return 0 }
-func (sb *sampleBlob) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, error) {
-	sb.readCalled = true
-	return sb.r.ReadAt(p, offset)
-}
-func (sb *sampleBlob) Cache(offset int64, size int64, option ...remote.Option) error {
-	sb.calledPrefetchOffset = offset
-	sb.calledPrefetchSize = size
-	return nil
-}
-func (sb *sampleBlob) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
-	return nil
-}
-
-type testCache struct {
-	membuf map[string]string
-	t      *testing.T
-	mu     sync.Mutex
-}
-
-func (tc *testCache) FetchAt(key string, offset int64, p []byte, opts ...cache.Option) (int, error) {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-
-	cache, ok := tc.membuf[key]
-	if !ok {
-		return 0, fmt.Errorf("Missed cache: %q", key)
-	}
-	return copy(p, cache[offset:]), nil
-}
-
-func (tc *testCache) Add(key string, p []byte, opts ...cache.Option) {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-	tc.membuf[key] = string(p)
-	tc.t.Logf("  cached [%s...]: %q", key[:8], string(p))
-}
-
-func TestWaiter(t *testing.T) {
-	var (
-		w         = newWaiter()
-		waitTime  = time.Second
-		startTime = time.Now()
-		doneTime  time.Time
-		done      = make(chan struct{})
-	)
-
-	go func() {
-		defer close(done)
-		if err := w.wait(10 * time.Second); err != nil {
-			t.Errorf("failed to wait: %v", err)
-			return
-		}
-		doneTime = time.Now()
-	}()
-
-	time.Sleep(waitTime)
-	w.done()
-	<-done
-
-	if doneTime.Sub(startTime) < waitTime {
-		t.Errorf("wait time is too short: %v; want %v", doneTime.Sub(startTime), waitTime)
-	}
+	return
 }

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -1,0 +1,450 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
+*/
+
+package layer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/reference"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/stargz-snapshotter/cache"
+	"github.com/containerd/stargz-snapshotter/estargz"
+	"github.com/containerd/stargz-snapshotter/fs/config"
+	"github.com/containerd/stargz-snapshotter/fs/reader"
+	"github.com/containerd/stargz-snapshotter/fs/remote"
+	"github.com/containerd/stargz-snapshotter/task"
+	"github.com/containerd/stargz-snapshotter/util/lrucache"
+	"github.com/golang/groupcache/lru"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	defaultResolveResultEntry = 30
+	defaultMaxLRUCacheEntry   = 10
+	defaultMaxCacheFds        = 10
+	defaultPrefetchTimeoutSec = 10
+	memoryCacheType           = "memory"
+)
+
+// Layer represents a layer.
+type Layer interface {
+
+	// Info returns the information of this layer.
+	Info() Info
+
+	// Root returns the root node of this layer.
+	Root() *estargz.TOCEntry
+
+	// Check checks if the layer is still connectable.
+	Check() error
+
+	// Refresh refreshes the layer connection.
+	Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error
+
+	// Verify verifies this layer using the passed TOC Digest.
+	Verify(tocDigest digest.Digest) (err error)
+
+	// SkipVerify skips verification for this layer.
+	SkipVerify()
+
+	// OpenFile opens a file.
+	// Calling this function before calling Verify or SkipVerify will fail.
+	OpenFile(name string) (io.ReaderAt, error)
+
+	// Prefetch prefetches the specified size. If the layer is eStargz and contains landmark files,
+	// the range indicated by these files is respected.
+	// Calling this function before calling Verify or SkipVerify will fail.
+	Prefetch(prefetchSize int64) error
+
+	// WaitForPrefetchCompletion waits untils Prefetch completes.
+	WaitForPrefetchCompletion() error
+
+	// BackgroundFetch fetches the entire layer contents to the cache.
+	// Fetching contents is done as a background task.
+	// Calling this function before calling Verify or SkipVerify will fail.
+	BackgroundFetch() error
+}
+
+// Info is the current status of a layer.
+type Info struct {
+	Digest      digest.Digest
+	Size        int64
+	FetchedSize int64
+}
+
+// Resolver resolves the layer location and provieds the handler of that layer.
+type Resolver struct {
+	resolver              *remote.Resolver
+	prefetchTimeout       time.Duration
+	layerCache            *lru.Cache
+	layerCacheMu          sync.Mutex
+	blobCache             *lru.Cache
+	blobCacheMu           sync.Mutex
+	backgroundTaskManager *task.BackgroundTaskManager
+	fsCache               cache.BlobCache
+	resolveG              singleflight.Group
+}
+
+// NewResolver returns a new layer resolver.
+func NewResolver(root string, backgroundTaskManager *task.BackgroundTaskManager, cfg config.Config) (*Resolver, error) {
+	resolveResultEntry := cfg.ResolveResultEntry
+	if resolveResultEntry == 0 {
+		resolveResultEntry = defaultResolveResultEntry
+	}
+	prefetchTimeout := time.Duration(cfg.PrefetchTimeoutSec) * time.Second
+	if prefetchTimeout == 0 {
+		prefetchTimeout = defaultPrefetchTimeoutSec * time.Second
+	}
+
+	// Prepare contents cache
+	fsCache, err := newCache(filepath.Join(root, "fscache"), cfg.FSCacheType, cfg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create fs cache")
+	}
+	httpCache, err := newCache(filepath.Join(root, "httpcache"), cfg.HTTPCacheType, cfg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create http cache")
+	}
+
+	return &Resolver{
+		resolver:              remote.NewResolver(httpCache, cfg.BlobConfig),
+		fsCache:               fsCache,
+		layerCache:            lru.New(resolveResultEntry),
+		blobCache:             lru.New(resolveResultEntry),
+		prefetchTimeout:       prefetchTimeout,
+		backgroundTaskManager: backgroundTaskManager,
+	}, nil
+}
+
+func newCache(cachepath string, cacheType string, cfg config.Config) (cache.BlobCache, error) {
+	if cacheType == memoryCacheType {
+		return cache.NewMemoryCache(), nil
+	}
+
+	dcc := cfg.DirectoryCacheConfig
+	maxDataEntry := dcc.MaxLRUCacheEntry
+	if maxDataEntry == 0 {
+		maxDataEntry = defaultMaxLRUCacheEntry
+	}
+	maxFdEntry := dcc.MaxCacheFds
+	if maxFdEntry == 0 {
+		maxFdEntry = defaultMaxCacheFds
+	}
+
+	bufPool := &sync.Pool{
+		New: func() interface{} {
+			return new(bytes.Buffer)
+		},
+	}
+	dCache, fCache := lrucache.New(maxDataEntry), lrucache.New(maxFdEntry)
+	dCache.OnEvicted = func(key string, value interface{}) {
+		bufPool.Put(value)
+	}
+	fCache.OnEvicted = func(key string, value interface{}) {
+		value.(*os.File).Close()
+	}
+	return cache.NewDirectoryCache(
+		cachepath,
+		cache.DirectoryCacheConfig{
+			SyncAdd:   dcc.SyncAdd,
+			DataCache: dCache,
+			FdCache:   fCache,
+			BufPool:   bufPool,
+		},
+	)
+}
+
+// Resolve resolves a layer based on the passed layer blob information.
+func (r *Resolver) Resolve(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (_ Layer, retErr error) {
+	name := refspec.String() + "/" + desc.Digest.String()
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField("src", name))
+
+	// First, try to retrieve this layer from the underlying LRU cache.
+	r.layerCacheMu.Lock()
+	c, ok := r.layerCache.Get(name)
+	r.layerCacheMu.Unlock()
+	if ok && c.(*layer).Check() == nil {
+		return c.(*layer), nil
+	}
+
+	resultChan := r.resolveG.DoChan(name, func() (interface{}, error) {
+		log.G(ctx).Debugf("resolving")
+
+		// Resolve the blob.
+		blobR, err := r.resolveBlob(ctx, hosts, refspec, desc)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to resolve the blob")
+		}
+
+		// Get a reader for stargz archive.
+		// Each file's read operation is a prioritized task and all background tasks
+		// will be stopped during the execution so this can avoid being disturbed for
+		// NW traffic by background tasks.
+		sr := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (n int, err error) {
+			r.backgroundTaskManager.DoPrioritizedTask()
+			defer r.backgroundTaskManager.DonePrioritizedTask()
+			return blobR.ReadAt(p, offset)
+		}), 0, blobR.Size())
+		vr, root, err := reader.NewReader(sr, r.fsCache)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read layer")
+		}
+
+		// Combine layer information together
+		l := newLayer(r, desc, blobR, vr, root)
+		r.layerCacheMu.Lock()
+		r.layerCache.Add(name, l)
+		r.layerCacheMu.Unlock()
+
+		log.G(ctx).Debugf("resolved")
+		return l, nil
+	})
+
+	var res singleflight.Result
+	select {
+	case res = <-resultChan:
+	case <-time.After(30 * time.Second):
+		r.resolveG.Forget(name)
+		return nil, fmt.Errorf("failed to resolve layer (timeout)")
+	}
+	if res.Err != nil || res.Val == nil {
+		return nil, fmt.Errorf("failed to resolve layer: %v", res.Err)
+	}
+
+	return res.Val.(*layer), nil
+}
+
+// resolveBlob resolves a blob based on the passed layer blob information.
+func (r *Resolver) resolveBlob(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (remote.Blob, error) {
+	name := refspec.String() + "/" + desc.Digest.String()
+
+	// Resolve the blob. The result will be cached for future use. This is effective
+	// in some failure cases including resolving is succeeded but the blob is non-stargz.
+	var blob remote.Blob
+	r.blobCacheMu.Lock()
+	c, ok := r.blobCache.Get(name)
+	r.blobCacheMu.Unlock()
+	if ok {
+		if blob := c.(remote.Blob); blob.Check() == nil {
+			return blob, nil
+		}
+	}
+
+	var err error
+	blob, err = r.resolver.Resolve(ctx, hosts, refspec, desc)
+	if err != nil {
+		log.G(ctx).WithError(err).Debugf("failed to resolve source")
+		return nil, errors.Wrap(err, "failed to resolve the source")
+	}
+	r.blobCacheMu.Lock()
+	r.blobCache.Add(name, blob)
+	r.blobCacheMu.Unlock()
+
+	return blob, nil
+}
+
+func newLayer(
+	resolver *Resolver,
+	desc ocispec.Descriptor,
+	blob remote.Blob,
+	vr *reader.VerifiableReader,
+	root *estargz.TOCEntry,
+) *layer {
+	return &layer{
+		resolver:         resolver,
+		desc:             desc,
+		blob:             blob,
+		verifiableReader: vr,
+		root:             root,
+		prefetchWaiter:   newWaiter(),
+	}
+}
+
+type layer struct {
+	resolver         *Resolver
+	desc             ocispec.Descriptor
+	blob             remote.Blob
+	verifiableReader *reader.VerifiableReader
+	root             *estargz.TOCEntry
+	prefetchWaiter   *waiter
+
+	r reader.Reader
+}
+
+func (l *layer) Info() Info {
+	return Info{
+		Digest:      l.desc.Digest,
+		Size:        l.blob.Size(),
+		FetchedSize: l.blob.FetchedSize(),
+	}
+}
+
+func (l *layer) Root() *estargz.TOCEntry {
+	return l.root
+}
+
+func (l *layer) Check() error {
+	return l.blob.Check()
+}
+
+func (l *layer) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
+	return l.blob.Refresh(ctx, hosts, refspec, desc)
+}
+
+func (l *layer) Verify(tocDigest digest.Digest) (err error) {
+	l.r, err = l.verifiableReader.VerifyTOC(tocDigest)
+	return
+}
+
+func (l *layer) SkipVerify() {
+	l.r = l.verifiableReader.SkipVerify()
+}
+
+func (l *layer) OpenFile(name string) (io.ReaderAt, error) {
+	if l.r == nil {
+		return nil, fmt.Errorf("layer hasn't been verified yet")
+	}
+	return l.r.OpenFile(name)
+}
+
+func (l *layer) Prefetch(prefetchSize int64) error {
+	defer l.prefetchWaiter.done() // Notify the completion
+
+	if l.r == nil {
+		return fmt.Errorf("layer hasn't been verified yet")
+	}
+	lr := l.r
+	if _, ok := lr.Lookup(estargz.NoPrefetchLandmark); ok {
+		// do not prefetch this layer
+		return nil
+	} else if e, ok := lr.Lookup(estargz.PrefetchLandmark); ok {
+		// override the prefetch size with optimized value
+		prefetchSize = e.Offset
+	} else if prefetchSize > l.blob.Size() {
+		// adjust prefetch size not to exceed the whole layer size
+		prefetchSize = l.blob.Size()
+	}
+
+	// Fetch the target range
+	if err := l.blob.Cache(0, prefetchSize); err != nil {
+		return errors.Wrap(err, "failed to prefetch layer")
+	}
+
+	// Cache uncompressed contents of the prefetched range
+	if err := lr.Cache(reader.WithFilter(func(e *estargz.TOCEntry) bool {
+		return e.Offset < prefetchSize // Cache only prefetch target
+	})); err != nil {
+		return errors.Wrap(err, "failed to cache prefetched layer")
+	}
+
+	return nil
+}
+
+func (l *layer) WaitForPrefetchCompletion() error {
+	return l.prefetchWaiter.wait(l.resolver.prefetchTimeout)
+}
+
+func (l *layer) BackgroundFetch() error {
+	if l.r == nil {
+		return fmt.Errorf("layer hasn't been verified yet")
+	}
+	lr := l.r
+	br := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (retN int, retErr error) {
+		l.resolver.backgroundTaskManager.InvokeBackgroundTask(func(ctx context.Context) {
+			retN, retErr = l.blob.ReadAt(
+				p,
+				offset,
+				remote.WithContext(ctx),              // Make cancellable
+				remote.WithCacheOpts(cache.Direct()), // Do not pollute mem cache
+			)
+		}, 120*time.Second)
+		return
+	}), 0, l.blob.Size())
+	return lr.Cache(
+		reader.WithReader(br),                // Read contents in background
+		reader.WithCacheOpts(cache.Direct()), // Do not pollute mem cache
+	)
+}
+
+func newWaiter() *waiter {
+	return &waiter{
+		completionCond: sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+type waiter struct {
+	isDone         bool
+	isDoneMu       sync.Mutex
+	completionCond *sync.Cond
+}
+
+func (w *waiter) done() {
+	w.isDoneMu.Lock()
+	w.isDone = true
+	w.isDoneMu.Unlock()
+	w.completionCond.Broadcast()
+}
+
+func (w *waiter) wait(timeout time.Duration) error {
+	wait := func() <-chan struct{} {
+		ch := make(chan struct{})
+		go func() {
+			w.isDoneMu.Lock()
+			isDone := w.isDone
+			w.isDoneMu.Unlock()
+
+			w.completionCond.L.Lock()
+			if !isDone {
+				w.completionCond.Wait()
+			}
+			w.completionCond.L.Unlock()
+			ch <- struct{}{}
+		}()
+		return ch
+	}
+	select {
+	case <-time.After(timeout):
+		w.isDoneMu.Lock()
+		w.isDone = true
+		w.isDoneMu.Unlock()
+		w.completionCond.Broadcast()
+		return fmt.Errorf("timeout(%v)", timeout)
+	case <-wait():
+		return nil
+	}
+}
+
+type readerAtFunc func([]byte, int64) (int, error)
+
+func (f readerAtFunc) ReadAt(p []byte, offset int64) (int, error) { return f(p, offset) }

--- a/fs/layer/layer_test.go
+++ b/fs/layer/layer_test.go
@@ -1,0 +1,340 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
+*/
+
+package layer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/reference"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/stargz-snapshotter/cache"
+	"github.com/containerd/stargz-snapshotter/estargz"
+	"github.com/containerd/stargz-snapshotter/fs/reader"
+	"github.com/containerd/stargz-snapshotter/fs/remote"
+	"github.com/containerd/stargz-snapshotter/util/testutil"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	sampleChunkSize = 3
+	sampleData1     = "0123456789"
+	sampleData2     = "abcdefghij"
+)
+
+var testStateLayerDigest = digest.FromString("dummy")
+
+// Tests prefetch method of each stargz file.
+func TestPrefetch(t *testing.T) {
+	defaultPrefetchSize := int64(10000)
+	landmarkPosition := func(t *testing.T, l *layer) int64 {
+		if l.r == nil {
+			t.Fatalf("layer hasn't been verified yet")
+		}
+		if e, ok := l.r.Lookup(estargz.PrefetchLandmark); ok {
+			return e.Offset
+		}
+		return defaultPrefetchSize
+	}
+	defaultPrefetchPosition := func(t *testing.T, l *layer) int64 {
+		return l.Info().Size
+	}
+	tests := []struct {
+		name             string
+		in               []testutil.TarEntry
+		wantNum          int      // number of chunks wanted in the cache
+		wants            []string // filenames to compare
+		prefetchSize     func(*testing.T, *layer) int64
+		prioritizedFiles []string
+		stargz           bool
+	}{
+		{
+			name: "default_prefetch",
+			in: []testutil.TarEntry{
+				testutil.File("foo.txt", sampleData1),
+			},
+			wantNum:          chunkNum(sampleData1),
+			wants:            []string{"foo.txt"},
+			prefetchSize:     defaultPrefetchPosition,
+			prioritizedFiles: nil,
+			stargz:           true,
+		},
+		{
+			name: "no_prefetch",
+			in: []testutil.TarEntry{
+				testutil.File("foo.txt", sampleData1),
+			},
+			wantNum:          0,
+			prioritizedFiles: nil,
+		},
+		{
+			name: "prefetch",
+			in: []testutil.TarEntry{
+				testutil.File("foo.txt", sampleData1),
+				testutil.File("bar.txt", sampleData2),
+			},
+			wantNum:          chunkNum(sampleData1),
+			wants:            []string{"foo.txt"},
+			prefetchSize:     landmarkPosition,
+			prioritizedFiles: []string{"foo.txt"},
+		},
+		{
+			name: "with_dir",
+			in: []testutil.TarEntry{
+				testutil.Dir("foo/"),
+				testutil.File("foo/bar.txt", sampleData1),
+				testutil.Dir("buz/"),
+				testutil.File("buz/buzbuz.txt", sampleData2),
+			},
+			wantNum:          chunkNum(sampleData1),
+			wants:            []string{"foo/bar.txt"},
+			prefetchSize:     landmarkPosition,
+			prioritizedFiles: []string{"foo/", "foo/bar.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sr, dgst := buildStargz(t, tt.in,
+				chunkSizeInfo(sampleChunkSize),
+				prioritizedFilesInfo(tt.prioritizedFiles),
+				stargzOnlyInfo(tt.stargz))
+			blob := newBlob(sr)
+			cache := &testCache{membuf: map[string]string{}, t: t}
+			vr, _, err := reader.NewReader(sr, cache)
+			if err != nil {
+				t.Fatalf("failed to make stargz reader: %v", err)
+			}
+			l := newLayer(
+				&Resolver{
+					prefetchTimeout: time.Second,
+				},
+				ocispec.Descriptor{Digest: testStateLayerDigest},
+				blob,
+				vr,
+				nil,
+			)
+			if tt.stargz {
+				l.SkipVerify()
+			} else if err := l.Verify(dgst); err != nil {
+				t.Errorf("failed to verify reader: %v", err)
+				return
+			}
+			prefetchSize := int64(0)
+			if tt.prefetchSize != nil {
+				prefetchSize = tt.prefetchSize(t, l)
+			}
+			if err := l.Prefetch(defaultPrefetchSize); err != nil {
+				t.Errorf("failed to prefetch: %v", err)
+				return
+			}
+			if blob.calledPrefetchOffset != 0 {
+				t.Errorf("invalid prefetch offset %d; want %d",
+					blob.calledPrefetchOffset, 0)
+			}
+			if blob.calledPrefetchSize != prefetchSize {
+				t.Errorf("invalid prefetch size %d; want %d",
+					blob.calledPrefetchSize, prefetchSize)
+			}
+			if tt.wantNum != len(cache.membuf) {
+				t.Errorf("number of chunks in the cache %d; want %d: %v", len(cache.membuf), tt.wantNum, err)
+				return
+			}
+
+			lr := l.r
+			if lr == nil {
+				t.Fatalf("failed to get reader from layer: %v", err)
+			}
+			for _, file := range tt.wants {
+				e, ok := lr.Lookup(file)
+				if !ok {
+					t.Fatalf("failed to lookup %q", file)
+				}
+				wantFile, err := lr.OpenFile(file)
+				if err != nil {
+					t.Fatalf("failed to open file %q", file)
+				}
+				blob.readCalled = false
+				if _, err := io.Copy(ioutil.Discard, io.NewSectionReader(wantFile, 0, e.Size)); err != nil {
+					t.Fatalf("failed to read file %q", file)
+				}
+				if blob.readCalled {
+					t.Errorf("chunks of file %q aren't cached", file)
+					return
+				}
+			}
+		})
+	}
+}
+
+func chunkNum(data string) int {
+	return (len(data)-1)/sampleChunkSize + 1
+}
+
+func newBlob(sr *io.SectionReader) *sampleBlob {
+	return &sampleBlob{
+		r: sr,
+	}
+}
+
+type sampleBlob struct {
+	r                    *io.SectionReader
+	readCalled           bool
+	calledPrefetchOffset int64
+	calledPrefetchSize   int64
+}
+
+func (sb *sampleBlob) Authn(tr http.RoundTripper) (http.RoundTripper, error) { return nil, nil }
+func (sb *sampleBlob) Check() error                                          { return nil }
+func (sb *sampleBlob) Size() int64                                           { return sb.r.Size() }
+func (sb *sampleBlob) FetchedSize() int64                                    { return 0 }
+func (sb *sampleBlob) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, error) {
+	sb.readCalled = true
+	return sb.r.ReadAt(p, offset)
+}
+func (sb *sampleBlob) Cache(offset int64, size int64, option ...remote.Option) error {
+	sb.calledPrefetchOffset = offset
+	sb.calledPrefetchSize = size
+	return nil
+}
+func (sb *sampleBlob) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
+	return nil
+}
+
+type testCache struct {
+	membuf map[string]string
+	t      *testing.T
+	mu     sync.Mutex
+}
+
+func (tc *testCache) FetchAt(key string, offset int64, p []byte, opts ...cache.Option) (int, error) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	cache, ok := tc.membuf[key]
+	if !ok {
+		return 0, fmt.Errorf("Missed cache: %q", key)
+	}
+	return copy(p, cache[offset:]), nil
+}
+
+func (tc *testCache) Add(key string, p []byte, opts ...cache.Option) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	tc.membuf[key] = string(p)
+	tc.t.Logf("  cached [%s...]: %q", key[:8], string(p))
+}
+
+func TestWaiter(t *testing.T) {
+	var (
+		w         = newWaiter()
+		waitTime  = time.Second
+		startTime = time.Now()
+		doneTime  time.Time
+		done      = make(chan struct{})
+	)
+
+	go func() {
+		defer close(done)
+		if err := w.wait(10 * time.Second); err != nil {
+			t.Errorf("failed to wait: %v", err)
+			return
+		}
+		doneTime = time.Now()
+	}()
+
+	time.Sleep(waitTime)
+	w.done()
+	<-done
+
+	if doneTime.Sub(startTime) < waitTime {
+		t.Errorf("wait time is too short: %v; want %v", doneTime.Sub(startTime), waitTime)
+	}
+}
+
+type chunkSizeInfo int
+type prioritizedFilesInfo []string
+type stargzOnlyInfo bool
+
+func buildStargz(t *testing.T, ents []testutil.TarEntry, opts ...interface{}) (*io.SectionReader, digest.Digest) {
+	var chunkSize chunkSizeInfo
+	var prioritizedFiles prioritizedFilesInfo
+	var stargzOnly bool
+	for _, opt := range opts {
+		if v, ok := opt.(chunkSizeInfo); ok {
+			chunkSize = v
+		} else if v, ok := opt.(prioritizedFilesInfo); ok {
+			prioritizedFiles = v
+		} else if v, ok := opt.(stargzOnlyInfo); ok {
+			stargzOnly = bool(v)
+		} else {
+			t.Fatalf("unsupported opt")
+		}
+	}
+
+	tarBuf := new(bytes.Buffer)
+	if _, err := io.Copy(tarBuf, testutil.BuildTar(ents)); err != nil {
+		t.Fatalf("failed to build tar: %v", err)
+	}
+	tarData := tarBuf.Bytes()
+
+	if stargzOnly {
+		stargzBuf := new(bytes.Buffer)
+		w := estargz.NewWriter(stargzBuf)
+		if chunkSize > 0 {
+			w.ChunkSize = int(chunkSize)
+		}
+		if err := w.AppendTar(bytes.NewReader(tarData)); err != nil {
+			t.Fatalf("failed to append tar file to stargz: %q", err)
+		}
+		if _, err := w.Close(); err != nil {
+			t.Fatalf("failed to close stargz writer: %q", err)
+		}
+		stargzData := stargzBuf.Bytes()
+		return io.NewSectionReader(bytes.NewReader(stargzData), 0, int64(len(stargzData))), ""
+	}
+	rc, err := estargz.Build(
+		io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData))),
+		estargz.WithPrioritizedFiles([]string(prioritizedFiles)),
+		estargz.WithChunkSize(int(chunkSize)),
+	)
+	if err != nil {
+		t.Fatalf("failed to build verifiable stargz: %v", err)
+	}
+	defer rc.Close()
+	vsb := new(bytes.Buffer)
+	if _, err := io.Copy(vsb, rc); err != nil {
+		t.Fatalf("failed to copy built stargz blob: %v", err)
+	}
+	vsbb := vsb.Bytes()
+
+	return io.NewSectionReader(bytes.NewReader(vsbb), 0, int64(len(vsbb))), rc.TOCDigest()
+}

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -23,7 +23,6 @@
 package reader
 
 import (
-	"archive/tar"
 	"bytes"
 	"fmt"
 	"io"
@@ -33,6 +32,7 @@ import (
 
 	"github.com/containerd/stargz-snapshotter/cache"
 	"github.com/containerd/stargz-snapshotter/estargz"
+	"github.com/containerd/stargz-snapshotter/util/testutil"
 	digest "github.com/opencontainers/go-digest"
 )
 
@@ -46,8 +46,8 @@ const (
 // Tests Reader for failure cases.
 func TestFailReader(t *testing.T) {
 	testFileName := "test"
-	stargzFile, _ := buildStargz(t, []tarent{
-		regfile(testFileName, sampleData1),
+	stargzFile, _ := buildStargz(t, []testutil.TarEntry{
+		testutil.File(testFileName, sampleData1),
 	}, chunkSizeInfo(sampleChunkSize))
 	br := &breakReaderAt{
 		ReaderAt: stargzFile,
@@ -301,8 +301,8 @@ func (er *exceptSectionReader) ReadAt(p []byte, offset int64) (int, error) {
 
 func makeFile(t *testing.T, contents []byte, chunkSize int64) *file {
 	testName := "test"
-	sr, dgst := buildStargz(t, []tarent{
-		regfile(testName, string(contents)),
+	sr, dgst := buildStargz(t, []testutil.TarEntry{
+		testutil.File(testName, string(contents)),
 	}, chunkSizeInfo(chunkSize))
 
 	sgz, err := estargz.Open(sr)
@@ -329,29 +329,9 @@ func makeFile(t *testing.T, contents []byte, chunkSize int64) *file {
 	return f
 }
 
-type tarent struct {
-	header   *tar.Header
-	contents []byte
-}
-
-func regfile(name string, contents string) tarent {
-	if strings.HasSuffix(name, "/") {
-		panic(fmt.Sprintf("file %q has suffix /", name))
-	}
-	return tarent{
-		header: &tar.Header{
-			Typeflag: tar.TypeReg,
-			Name:     name,
-			Mode:     0644,
-			Size:     int64(len(contents)),
-		},
-		contents: []byte(contents),
-	}
-}
-
 type chunkSizeInfo int
 
-func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionReader, digest.Digest) {
+func buildStargz(t *testing.T, ents []testutil.TarEntry, opts ...interface{}) (*io.SectionReader, digest.Digest) {
 	var chunkSize chunkSizeInfo
 	for _, opt := range opts {
 		if v, ok := opt.(chunkSizeInfo); ok {
@@ -362,21 +342,10 @@ func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionR
 	}
 
 	tarBuf := new(bytes.Buffer)
-	tw := tar.NewWriter(tarBuf)
-	for _, ent := range ents {
-		if err := tw.WriteHeader(ent.header); err != nil {
-			t.Fatalf("writing header to the input tar: %v", err)
-		}
-		if _, err := tw.Write(ent.contents); err != nil {
-			t.Fatalf("writing contents to the input tar: %v", err)
-		}
+	if _, err := io.Copy(tarBuf, testutil.BuildTar(ents)); err != nil {
+		t.Fatalf("failed to build tar: %v", err)
 	}
-	if err := tw.Close(); err != nil {
-		t.Fatalf("closing write of input tar: %v", err)
-	}
-
 	tarData := tarBuf.Bytes()
-
 	rc, err := estargz.Build(
 		io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData))),
 		estargz.WithChunkSize(int(chunkSize)),
@@ -384,6 +353,7 @@ func buildStargz(t *testing.T, ents []tarent, opts ...interface{}) (*io.SectionR
 	if err != nil {
 		t.Fatalf("failed to build verifiable stargz: %v", err)
 	}
+	defer rc.Close()
 	vsb := new(bytes.Buffer)
 	if _, err := io.Copy(vsb, rc); err != nil {
 		t.Fatalf("failed to copy built stargz blob: %v", err)

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -54,7 +54,7 @@ const (
 	defaultFetchTimeoutSec  = 300
 )
 
-func NewResolver(cache cache.BlobCache, cfg config.BlobConfig) *Resolver {
+func NewResolver(blobCache cache.BlobCache, cfg config.BlobConfig) *Resolver {
 	if cfg.ChunkSize == 0 { // zero means "use default chunk size"
 		cfg.ChunkSize = defaultChunkSize
 	}
@@ -74,7 +74,7 @@ func NewResolver(cache cache.BlobCache, cfg config.BlobConfig) *Resolver {
 				return new(bytes.Buffer)
 			},
 		},
-		blobCache:  cache,
+		blobCache:  blobCache,
 		blobConfig: cfg,
 	}
 }

--- a/util/lrucache/lrucache.go
+++ b/util/lrucache/lrucache.go
@@ -1,0 +1,141 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package lrucache provides reference-count-aware lru cache.
+package lrucache
+
+import (
+	"sync"
+
+	"github.com/golang/groupcache/lru"
+)
+
+// Cache is "groupcache/lru"-like cache. The difference is that "groupcache/lru" immediately
+// finalizes theevicted contents using OnEvicted callback but our version strictly tracks the
+// reference counts of contents and calls OnEvicted when nobody refers to the evicted contents.
+type Cache struct {
+	cache *lru.Cache
+	mu    sync.Mutex
+
+	// OnEvicted optionally specifies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key string, value interface{})
+}
+
+// New creates new cache.
+func New(maxEntries int) *Cache {
+	inner := lru.New(maxEntries)
+	inner.OnEvicted = func(key lru.Key, value interface{}) {
+		// Decrease the ref count incremented in Add().
+		// When nobody refers to this value, this value will be finalized via refCounter.
+		value.(*refCounter).finalize()
+	}
+	return &Cache{
+		cache: inner,
+	}
+}
+
+// Get retrieves the specified object from the cache and increments the reference counter of the
+// target content. Client must call `done` callback to decrease the reference count when the value
+// will no longer be used.
+func (c *Cache) Get(key string) (value interface{}, done func(), ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	o, ok := c.cache.Get(key)
+	if !ok {
+		return nil, nil, false
+	}
+	rc := o.(*refCounter)
+	rc.inc()
+	return rc.v, c.decreaseOnceFunc(rc), true
+}
+
+// Add adds object to the cache and returns the cached contents with incrementing the reference count.
+// If the specified content already exists in the cache, this sets `added` to false and returns
+// "already cached" content (i.e. doesn't replace the content with the new one). Client must call
+// `done` callback to decrease the counter when the value will no longer be used.
+func (c *Cache) Add(key string, value interface{}) (cachedValue interface{}, done func(), added bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if o, ok := c.cache.Get(key); ok {
+		rc := o.(*refCounter)
+		rc.inc()
+		return rc.v, c.decreaseOnceFunc(rc), false
+	}
+	rc := &refCounter{
+		key:       key,
+		v:         value,
+		onEvicted: c.OnEvicted,
+	}
+	rc.initialize() // Keep this object having at least 1 ref count (will be decreased in OnEviction)
+	rc.inc()        // The client references this object (will be decreased on "done")
+	c.cache.Add(key, rc)
+	return rc.v, c.decreaseOnceFunc(rc), true
+}
+
+// Remove removes the specified contents from the cache. OnEvicted callback will be called when
+// nobody refers to the removed content.
+func (c *Cache) Remove(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache.Remove(key)
+}
+
+func (c *Cache) decreaseOnceFunc(rc *refCounter) func() {
+	var once sync.Once
+	return func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		once.Do(func() { rc.dec() })
+	}
+}
+
+type refCounter struct {
+	onEvicted func(key string, value interface{})
+
+	key       string
+	v         interface{}
+	refCounts int64
+
+	mu sync.Mutex
+
+	initializeOnce sync.Once
+	finalizeOnce   sync.Once
+}
+
+func (r *refCounter) inc() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refCounts++
+}
+
+func (r *refCounter) dec() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refCounts--
+	if r.refCounts <= 0 && r.onEvicted != nil {
+		// nobody will refer this object
+		r.onEvicted(r.key, r.v)
+	}
+}
+
+func (r *refCounter) initialize() {
+	r.initializeOnce.Do(func() { r.inc() })
+}
+
+func (r *refCounter) finalize() {
+	r.finalizeOnce.Do(func() { r.dec() })
+}

--- a/util/lrucache/lrucache_test.go
+++ b/util/lrucache/lrucache_test.go
@@ -1,0 +1,152 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package lrucache
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAdd(t *testing.T) {
+	c := New(10)
+
+	key, value := "key1", "abcd"
+	v, _, added := c.Add(key, value)
+	if !added {
+		t.Errorf("failed to add %q", key)
+		return
+	} else if v.(string) != value {
+		t.Errorf("returned different object for %q; want %q; got %q", key, value, v.(string))
+		return
+	}
+
+	key, newvalue := "key1", "dummy"
+	v, _, added = c.Add(key, newvalue)
+	if added || v.(string) != value {
+		t.Errorf("%q must be originally stored one; want %q; got %q (added:%v)",
+			key, value, v.(string), added)
+	}
+}
+
+func TestGet(t *testing.T) {
+	c := New(10)
+
+	key, value := "key1", "abcd"
+	v, _, added := c.Add(key, value)
+	if !added {
+		t.Errorf("failed to add %q", key)
+		return
+	} else if v.(string) != value {
+		t.Errorf("returned different object for %q; want %q; got %q", key, value, v.(string))
+		return
+	}
+
+	v, _, ok := c.Get(key)
+	if !ok {
+		t.Errorf("failed to get obj %q (%q)", key, value)
+		return
+	} else if v.(string) != value {
+		t.Errorf("unexpected object for %q; want %q; got %q", key, value, v.(string))
+		return
+	}
+}
+
+func TestRemove(t *testing.T) {
+	var evicted []string
+	c := New(2)
+	c.OnEvicted = func(key string, value interface{}) {
+		evicted = append(evicted, key)
+	}
+	key1, value1 := "key1", "abcd1"
+	_, done1, _ := c.Add(key1, value1)
+	_, done12, _ := c.Get(key1)
+
+	c.Remove(key1)
+	if len(evicted) != 0 {
+		t.Errorf("no content must be evicted after remove")
+		return
+	}
+
+	done1()
+	if len(evicted) != 0 {
+		t.Errorf("no content must be evicted until all reference are discarded")
+		return
+	}
+
+	done12()
+	if len(evicted) != 1 {
+		t.Errorf("content must be evicted")
+		return
+	}
+	if evicted[0] != key1 {
+		t.Errorf("1st content %q must be evicted but got %q", key1, evicted[0])
+		return
+	}
+}
+
+func TestEviction(t *testing.T) {
+	var evicted []string
+	c := New(2)
+	c.OnEvicted = func(key string, value interface{}) {
+		evicted = append(evicted, key)
+	}
+	key1, value1 := "key1", "abcd1"
+	key2, value2 := "key2", "abcd2"
+	_, done1, _ := c.Add(key1, value1)
+	_, done2, _ := c.Add(key2, value2)
+	_, done22, _ := c.Get(key2)
+
+	if len(evicted) != 0 {
+		t.Errorf("no content must be evicted after addition")
+		return
+	}
+	for i := 0; i < 2; i++ {
+		c.Add(fmt.Sprintf("key-add-%d", i), fmt.Sprintf("abcd-add-%d", i))
+	}
+	if len(evicted) != 0 {
+		t.Errorf("no content must be evicted after overflow")
+		return
+	}
+
+	done1()
+	if len(evicted) != 1 {
+		t.Errorf("1 content must be evicted")
+		return
+	}
+	if evicted[0] != key1 {
+		t.Errorf("1st content %q must be evicted but got %q", key1, evicted[0])
+		return
+	}
+
+	done2() // effective
+	done2() // ignored
+	done2() // ignored
+	if len(evicted) != 1 {
+		t.Errorf("only 1 content must be evicted")
+		return
+	}
+
+	done22()
+	if len(evicted) != 2 {
+		t.Errorf("2 contents must be evicted")
+		return
+	}
+	if evicted[1] != key2 {
+		t.Errorf("2nd content %q must be evicted but got %q", key2, evicted[1])
+		return
+	}
+}

--- a/util/namedmutex/namedmutex.go
+++ b/util/namedmutex/namedmutex.go
@@ -1,0 +1,62 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package namedmutex provides NamedMutex that wraps sync.Mutex
+// and provides namespaced mutex.
+package namedmutex
+
+import (
+	"sync"
+)
+
+// NamedMutex wraps sync.Mutex and provides namespaced mutex.
+type NamedMutex struct {
+	muMap  map[string]*sync.Mutex
+	refMap map[string]int
+
+	mu sync.Mutex
+}
+
+// Lock locks the mutex of the given name
+func (nl *NamedMutex) Lock(name string) {
+	nl.mu.Lock()
+	if nl.muMap == nil {
+		nl.muMap = make(map[string]*sync.Mutex)
+	}
+	if nl.refMap == nil {
+		nl.refMap = make(map[string]int)
+	}
+	if _, ok := nl.muMap[name]; !ok {
+		nl.muMap[name] = &sync.Mutex{}
+	}
+	mu := nl.muMap[name]
+	nl.refMap[name]++
+	nl.mu.Unlock()
+	mu.Lock()
+}
+
+// Unlock unlocks the mutex of the given name
+func (nl *NamedMutex) Unlock(name string) {
+	nl.mu.Lock()
+	mu := nl.muMap[name]
+	nl.refMap[name]--
+	if nl.refMap[name] <= 0 {
+		delete(nl.muMap, name)
+		delete(nl.refMap, name)
+	}
+	nl.mu.Unlock()
+	mu.Unlock()
+}


### PR DESCRIPTION
This PR contains the following refactoring.

- separated out `*fs.layer` into a new pkg `layer`
- separated out
  - `*cache.namedLock` into a new pkg `namedmutex`
  - `*cache.objectCache` into a new pkg `lrucache`
- Fixed test codes to use `util/testutil`.

This PR is a subset of https://github.com/containerd/stargz-snapshotter/pull/276 but only refactoring part (doesn't add GC functionality).
