### PR TITLE
Support exporting metrics from `containerd-stargz-grpc`

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	AllowNoVerification bool   `toml:"allow_no_verification"`
 	DisableVerification bool   `toml:"disable_verification"`
 	MaxConcurrency      int64  `toml:"max_concurrency"`
+	NoPrometheus        bool   `toml:"no_prometheus"`
 
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob"`

--- a/fs/metrics/layer.go
+++ b/fs/metrics/layer.go
@@ -1,0 +1,52 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/containerd/stargz-snapshotter/fs/layer"
+	metrics "github.com/docker/go-metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var layerMetrics = []*metric{
+	{
+		name: "layer_fetched_size",
+		help: "Total fetched size of the layer",
+		unit: metrics.Bytes,
+		vt:   prometheus.CounterValue,
+		getValues: func(l layer.Layer) []value {
+			return []value{
+				{
+					v: float64(l.Info().FetchedSize),
+				},
+			}
+		},
+	},
+	{
+		name: "layer_size",
+		help: "Total size of the layer",
+		unit: metrics.Bytes,
+		vt:   prometheus.CounterValue,
+		getValues: func(l layer.Layer) []value {
+			return []value{
+				{
+					v: float64(l.Info().Size),
+				},
+			}
+		},
+	},
+}

--- a/fs/metrics/metrics.go
+++ b/fs/metrics/metrics.go
@@ -1,0 +1,113 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/containerd/stargz-snapshotter/fs/layer"
+	metrics "github.com/docker/go-metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func NewLayerMetrics(ns *metrics.Namespace) *Controller {
+	if ns == nil {
+		return &Controller{}
+	}
+	c := &Controller{
+		ns:    ns,
+		layer: make(map[string]layer.Layer),
+	}
+	c.metrics = append(c.metrics, layerMetrics...)
+	ns.Add(c)
+	return c
+}
+
+type Controller struct {
+	ns      *metrics.Namespace
+	metrics []*metric
+
+	layer   map[string]layer.Layer
+	layerMu sync.RWMutex
+}
+
+func (c *Controller) Describe(ch chan<- *prometheus.Desc) {
+	for _, e := range c.metrics {
+		ch <- e.desc(c.ns)
+	}
+}
+
+func (c *Controller) Collect(ch chan<- prometheus.Metric) {
+	c.layerMu.RLock()
+	wg := &sync.WaitGroup{}
+	for mp, l := range c.layer {
+		mp, l := mp, l
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for _, e := range c.metrics {
+				e.collect(mp, l, c.ns, ch)
+			}
+		}()
+	}
+	c.layerMu.RUnlock()
+	wg.Wait()
+}
+
+func (c *Controller) Add(key string, l layer.Layer) {
+	if c.ns == nil {
+		return
+	}
+	c.layerMu.Lock()
+	c.layer[key] = l
+	c.layerMu.Unlock()
+}
+
+func (c *Controller) Remove(key string) {
+	if c.ns == nil {
+		return
+	}
+	c.layerMu.Lock()
+	delete(c.layer, key)
+	c.layerMu.Unlock()
+}
+
+type value struct {
+	v float64
+	l []string
+}
+
+type metric struct {
+	name   string
+	help   string
+	unit   metrics.Unit
+	vt     prometheus.ValueType
+	labels []string
+	// getValues returns the value and labels for the data
+	getValues func(l layer.Layer) []value
+}
+
+func (m *metric) desc(ns *metrics.Namespace) *prometheus.Desc {
+	return ns.NewDesc(m.name, m.help, m.unit, append([]string{"digest", "mountpoint"}, m.labels...)...)
+}
+
+func (m *metric) collect(mountpoint string, l layer.Layer, ns *metrics.Namespace, ch chan<- prometheus.Metric) {
+	values := m.getValues(l)
+	for _, v := range values {
+		ch <- prometheus.MustNewConstMetric(m.desc(ns), m.vt, v.v, append([]string{l.Info().Digest.String(), mountpoint}, v.l...)...)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200730172259-9f28837c1d93+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
+	github.com/docker/go-metrics v0.0.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/hanwen/go-fuse/v2 v2.0.4-0.20201208195215-4a458845028b
 	github.com/hashicorp/go-multierror v1.1.0
@@ -26,6 +27,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.7.1
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/urfave/cli v1.22.2

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZo
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
@@ -77,6 +78,7 @@ github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8n
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -191,6 +193,7 @@ github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6Uezg
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
+github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -379,6 +382,7 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -455,15 +459,18 @@ github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
+github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20180110214958-89604d197083/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
+github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/script/demo/config.stargz.toml
+++ b/script/demo/config.stargz.toml
@@ -1,3 +1,4 @@
+metrics_address = "127.0.0.1:8234"
 disable_verification = true
 [[resolver.host."registry2:5000".mirrors]]
 host = "registry2:5000"


### PR DESCRIPTION
Fixes:  #271

This commit adds a metrics endpoint for exporting some useful data generated by the snapshotter.
They can be pulled by prometheus.

This commit exports the following data generated by each layer of the filesystem.
We can add more metrics if needed.

- `stargz_fs_layer_size_bytes` (counter) : The size of the layer in bytes
- `stargz_fs_layer_fetched_size_bytes` (counter) : The size of the fetched data of the layer in bytes

Each metric is labeled by the following information to distinguish each other.

- `digest` : digest of the layer
- `mountpoint` : mountpoint where the layer is mounted

## How to use

Specify the arbitrary address to export metrics by configuring `/etc/containerd-stargz-grpc/config.toml`.

```toml
metrics_address = "127.0.0.1:8234"
```

The metrics can get via `/metrics` API of that endpoint.
For example, when we execute `ctr-remote i rpull ghcr.io/stargz-containers/python:3.7-esgz`, we get the following metrics:

```
curl 127.0.0.1:8234/metrics
...(omit)...
# HELP stargz_fs_layer_fetched_size_bytes Total fetched size of the layer
# TYPE stargz_fs_layer_fetched_size_bytes counter
stargz_fs_layer_fetched_size_bytes{digest="sha256:09dcfffe1239fa012cdd72898c3ebe45c6c095f39fd106150187b896a807e982",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/9/fs"} 2.316065e+06
stargz_fs_layer_fetched_size_bytes{digest="sha256:3ef2ba902efb61d82f35b700b184bde123382462f5877451971585ae9e6b31c0",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/3/fs"} 7.199153e+06
stargz_fs_layer_fetched_size_bytes{digest="sha256:5206ddfd1f29b28bdf212e9c32f2bf2f7d53cb4535d3c36c0c009efc2cb4836c",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/7/fs"} 1.6738031e+07
stargz_fs_layer_fetched_size_bytes{digest="sha256:70ad7b0f74ab9fcc8cf624d59b069fd31e61404c4cae74cf67702b2fb1c7ddb9",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/8/fs"} 1254
stargz_fs_layer_fetched_size_bytes{digest="sha256:7999a84dec8ca5cdc77fbf9c6c4790d6cf4c869384ff33c590261704a3eb9b2d",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/2/fs"} 7.501242e+06
stargz_fs_layer_fetched_size_bytes{digest="sha256:80505726a0e2e80ef6336f4976e6a30ed3de572934224603cdc66801bbf195b9",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/1/fs"} 5.0922964e+07
stargz_fs_layer_fetched_size_bytes{digest="sha256:d50ab0bcfb98d6682d284b3863c07a8327f4a40547ba9f88e675269a39614120",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/4/fs"} 5.1242816e+07
stargz_fs_layer_fetched_size_bytes{digest="sha256:dfd38485f3518ed3f34b28bd388be806515bcf575acf8f9fdd405c2287c1af51",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/5/fs"} 1.98436384e+08
stargz_fs_layer_fetched_size_bytes{digest="sha256:e83a4f1702924b39745065c6af11af6662e87e127acee9adb327504027d127f4",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/6/fs"} 6.196871e+06
# HELP stargz_fs_layer_size_bytes Total size of the layer
# TYPE stargz_fs_layer_size_bytes counter
stargz_fs_layer_size_bytes{digest="sha256:09dcfffe1239fa012cdd72898c3ebe45c6c095f39fd106150187b896a807e982",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/9/fs"} 2.366065e+06
stargz_fs_layer_size_bytes{digest="sha256:3ef2ba902efb61d82f35b700b184bde123382462f5877451971585ae9e6b31c0",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/3/fs"} 1.0049153e+07
stargz_fs_layer_size_bytes{digest="sha256:5206ddfd1f29b28bdf212e9c32f2bf2f7d53cb4535d3c36c0c009efc2cb4836c",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/7/fs"} 1.6738031e+07
stargz_fs_layer_size_bytes{digest="sha256:70ad7b0f74ab9fcc8cf624d59b069fd31e61404c4cae74cf67702b2fb1c7ddb9",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/8/fs"} 1254
stargz_fs_layer_size_bytes{digest="sha256:7999a84dec8ca5cdc77fbf9c6c4790d6cf4c869384ff33c590261704a3eb9b2d",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/2/fs"} 7.901242e+06
stargz_fs_layer_size_bytes{digest="sha256:80505726a0e2e80ef6336f4976e6a30ed3de572934224603cdc66801bbf195b9",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/1/fs"} 5.2972964e+07
stargz_fs_layer_size_bytes{digest="sha256:d50ab0bcfb98d6682d284b3863c07a8327f4a40547ba9f88e675269a39614120",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/4/fs"} 5.4442816e+07
stargz_fs_layer_size_bytes{digest="sha256:dfd38485f3518ed3f34b28bd388be806515bcf575acf8f9fdd405c2287c1af51",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/5/fs"} 1.98436384e+08
stargz_fs_layer_size_bytes{digest="sha256:e83a4f1702924b39745065c6af11af6662e87e127acee9adb327504027d127f4",mountpoint="/var/lib/containerd-stargz-grpc/snapshotter/snapshots/6/fs"} 6.346871e+06
...(omit)...
```

Prometheus can pull metrics from this endpoint.
Make prometheus recognize that endpoint by configuring `/etc/prometheus/prometheus.yml`:

```yaml
...
# A scrape configuration containing exactly one endpoint to scrape:
# Here it's Prometheus itself.
scrape_configs:
...
  - job_name: 'stargz-snapshotter'
    static_configs:
    - targets: ['127.0.0.1:8234']
...
```

We can see the metrics on the dashboard:

![fsmetrics](https://user-images.githubusercontent.com/43872416/110919303-70a62300-835f-11eb-84d6-4cab949e3208.png)

