### PR TITLE
Preparation for v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/containerd v1.5.0-beta.4
 	github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e
 	github.com/containerd/go-cni v1.0.1
-	github.com/containerd/stargz-snapshotter/estargz v0.4.1
+	github.com/containerd/stargz-snapshotter/estargz v0.5.0
 	github.com/coreos/go-systemd/v22 v22.1.0
 	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200730172259-9f28837c1d93+incompatible // indirect


### PR DESCRIPTION
### Release note draft

This release comes with enabling stargz snapshotter to be `import`-ed as a builtin plugin, supporting exporting prometheus metrics and rootless support for Ubuntu, Debian and any distro newer than Linux 5.11. For rootless setup, please refer to https://github.com/containerd/nerdctl/blob/master/docs/rootless.md.

- **Stargz Snapshotter**
  - Support importing stargz snapshotter as a builtin plugin (https://github.com/containerd/stargz-snapshotter/pull/267)
  - Support exporting prometheus metrics (https://github.com/containerd/stargz-snapshotter/pull/288)
  - Support rootless on Linux > 5.11 (support for `userxattr` overlayfs option) (https://github.com/containerd/stargz-snapshotter/pull/290), thanks @AkihiroSuda
  - Add check if snapshotter is supported during starting up of the plugin (https://github.com/containerd/stargz-snapshotter/pull/282)
  - Add `--version` option to `containerd-stargz-grpc` (https://github.com/containerd/stargz-snapshotter/pull/269)
  - Refactoring filesystem and cache (https://github.com/containerd/stargz-snapshotter/pull/283)
  - Use containerd's scope generator function (https://github.com/containerd/stargz-snapshotter/pull/278)

- **estargz library**
  - Support to parse suid/sgid/sticky bits (https://github.com/containerd/stargz-snapshotter/pull/286)

- **CI**
  - Use `nerdctl` in CI (https://github.com/containerd/stargz-snapshotter/pull/273)
