### PR TITLE
Reduce the use of unnecessary buffers around cache

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -20,12 +20,14 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/containerd/stargz-snapshotter/util/lrucache"
 	"github.com/containerd/stargz-snapshotter/util/namedmutex"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
 
@@ -61,12 +63,29 @@ type DirectoryCacheConfig struct {
 
 // TODO: contents validation.
 
+// BlobCache represents a cache for bytes data
 type BlobCache interface {
-	// Add adds the passed data to the cache
-	Add(key string, p []byte, opts ...Option)
+	// Add returns a writer to add contents to cache
+	Add(key string, opts ...Option) (Writer, error)
 
-	// FetchAt fetches the specified range of data from the cache
-	FetchAt(key string, offset int64, p []byte, opts ...Option) (n int, err error)
+	// Get returns a reader to read the specified contents
+	// from cache
+	Get(key string, opts ...Option) (Reader, error)
+}
+
+// Reader provides the data cached.
+type Reader interface {
+	io.ReaderAt
+	Close() error
+}
+
+// Writer enables the client to cache byte data. Commit() must be
+// called after data is fully written to Write(). To abort the written
+// data, Abort() must be called.
+type Writer interface {
+	io.WriteCloser
+	Commit() error
+	Abort() error
 }
 
 type cacheOpt struct {
@@ -123,12 +142,17 @@ func NewDirectoryCache(directory string, config DirectoryCacheConfig) (BlobCache
 	if err := os.MkdirAll(directory, 0700); err != nil {
 		return nil, err
 	}
+	wipdir := filepath.Join(directory, "wip")
+	if err := os.MkdirAll(wipdir, 0700); err != nil {
+		return nil, err
+	}
 	dc := &directoryCache{
-		cache:     dataCache,
-		fileCache: fdCache,
-		wipLock:   new(namedmutex.NamedMutex),
-		directory: directory,
-		bufPool:   bufPool,
+		cache:        dataCache,
+		fileCache:    fdCache,
+		wipLock:      new(namedmutex.NamedMutex),
+		directory:    directory,
+		wipDirectory: wipdir,
+		bufPool:      bufPool,
 	}
 	dc.syncAdd = config.SyncAdd
 	return dc, nil
@@ -136,17 +160,18 @@ func NewDirectoryCache(directory string, config DirectoryCacheConfig) (BlobCache
 
 // directoryCache is a cache implementation which backend is a directory.
 type directoryCache struct {
-	cache     *lrucache.Cache
-	fileCache *lrucache.Cache
-	directory string
-	wipLock   *namedmutex.NamedMutex
+	cache        *lrucache.Cache
+	fileCache    *lrucache.Cache
+	wipDirectory string
+	directory    string
+	wipLock      *namedmutex.NamedMutex
 
 	bufPool *sync.Pool
 
 	syncAdd bool
 }
 
-func (dc *directoryCache) FetchAt(key string, offset int64, p []byte, opts ...Option) (n int, err error) {
+func (dc *directoryCache) Get(key string, opts ...Option) (Reader, error) {
 	opt := &cacheOpt{}
 	for _, o := range opts {
 		opt = o(opt)
@@ -155,19 +180,24 @@ func (dc *directoryCache) FetchAt(key string, offset int64, p []byte, opts ...Op
 	if !opt.direct {
 		// Get data from memory
 		if b, done, ok := dc.cache.Get(key); ok {
-			defer done()
-			data := b.(*bytes.Buffer).Bytes()
-			if int64(len(data)) < offset {
-				return 0, fmt.Errorf("invalid offset %d exceeds chunk size %d",
-					offset, len(data))
-			}
-			return copy(p, data[offset:]), nil
+			return &reader{
+				ReaderAt: bytes.NewReader(b.(*bytes.Buffer).Bytes()),
+				closeFunc: func() error {
+					done()
+					return nil
+				},
+			}, nil
 		}
 
 		// Get data from disk. If the file is already opened, use it.
 		if f, done, ok := dc.fileCache.Get(key); ok {
-			defer done()
-			return f.(*os.File).ReadAt(p, offset)
+			return &reader{
+				ReaderAt: f.(*os.File),
+				closeFunc: func() error {
+					done() // file will be closed when it's evicted from the cache
+					return nil
+				},
+			}, nil
 		}
 	}
 
@@ -176,168 +206,184 @@ func (dc *directoryCache) FetchAt(key string, offset int64, p []byte, opts ...Op
 	//       or simply report the cache miss?
 	file, err := os.Open(dc.cachePath(key))
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed to open blob file for %q", key)
-	}
-	if n, err = file.ReadAt(p, offset); err == io.EOF {
-		err = nil
+		return nil, errors.Wrapf(err, "failed to open blob file for %q", key)
 	}
 
-	// Cache the opened file for future use. If "direct" option is specified, this
-	// won't be done. This option is useful for preventing file cache from being
-	// polluted by data that won't be accessed immediately.
+	// If "direct" option is specified, do not cache the file on memory.
+	// This option is useful for preventing memory cache from being polluted by data
+	// that won't be accessed immediately.
 	if opt.direct {
-		file.Close()
-	} else {
-		_, done, added := dc.fileCache.Add(key, file)
-		if !added {
-			file.Close() // file already exists in the cache. discard it.
-		}
-		done() // Release this immediately. This will be removed on eviction in lru cache.
+		return &reader{
+			ReaderAt:  file,
+			closeFunc: func() error { return file.Close() },
+		}, nil
 	}
 
 	// TODO: should we cache the entire file data on memory?
 	//       but making I/O (possibly huge) on every fetching
 	//       might be costly.
-
-	return n, err
+	return &reader{
+		ReaderAt: file,
+		closeFunc: func() error {
+			_, done, added := dc.fileCache.Add(key, file)
+			defer done() // Release it immediately. Cleaned up on eviction.
+			if !added {
+				return file.Close() // file already exists in the cache. close it.
+			}
+			return nil
+		},
+	}, nil
 }
 
-func (dc *directoryCache) Add(key string, p []byte, opts ...Option) {
+func (dc *directoryCache) Add(key string, opts ...Option) (Writer, error) {
 	opt := &cacheOpt{}
 	for _, o := range opts {
 		opt = o(opt)
 	}
 
-	if !opt.direct {
-		// Cache the passed data on memory. This enables to serve this data even
-		// during writing it to the disk. If "direct" option is specified, this
-		// won't be done. This option is useful for preventing memory cache from being
-		// polluted by data that won't be accessed immediately.
-		b := dc.bufPool.Get().(*bytes.Buffer)
-		b.Reset()
-		b.Write(p)
-		_, done, added := dc.cache.Add(key, b)
-		if !added {
-			dc.bufPool.Put(b) // already exists in the cache. discard it.
-		}
-		done() // This will remain until it's evicted in lru cache.
+	wip, err := dc.wipFile(key)
+	if err != nil {
+		return nil, err
 	}
-
-	// Cache the passed data to disk.
-	b2 := dc.bufPool.Get().(*bytes.Buffer)
-	b2.Reset()
-	b2.Write(p)
-	addFunc := func() {
-		defer dc.bufPool.Put(b2)
-
-		var (
-			c   = dc.cachePath(key)
-			wip = dc.wipPath(key)
-		)
-
-		dc.wipLock.Lock(key)
-		if _, err := os.Stat(wip); err == nil {
-			dc.wipLock.Unlock(key)
-			return // Write in progress
-		}
-		if _, err := os.Stat(c); err == nil {
-			dc.wipLock.Unlock(key)
-			return // Already exists.
-		}
-
-		// Write the contents to a temporary file
-		if err := os.MkdirAll(filepath.Dir(wip), os.ModePerm); err != nil {
-			fmt.Printf("Warning: Failed to Create blob cache directory %q: %v\n", c, err)
-			dc.wipLock.Unlock(key)
-			return
-		}
-		wipfile, err := os.Create(wip)
-		if err != nil {
-			fmt.Printf("Warning: failed to prepare temp file for storing cache %q", key)
-			dc.wipLock.Unlock(key)
-			return
-		}
-		dc.wipLock.Unlock(key)
-
-		defer func() {
-			wipfile.Close()
-			os.Remove(wipfile.Name())
-		}()
-		want := b2.Len()
-		if _, err := io.CopyN(wipfile, b2, int64(want)); err != nil {
-			fmt.Printf("Warning: failed to write cache: %v\n", err)
-			return
-		}
-
-		// Commit the cache contents
-		if err := os.MkdirAll(filepath.Dir(c), os.ModePerm); err != nil {
-			fmt.Printf("Warning: Failed to Create blob cache directory %q: %v\n", c, err)
-			return
-		}
-		if err := os.Rename(wipfile.Name(), c); err != nil {
-			fmt.Printf("Warning: failed to commit cache to %q: %v\n", c, err)
-			return
-		}
-		file, err := os.Open(c)
-		if err != nil {
-			fmt.Printf("Warning: failed to open cache on %q: %v\n", c, err)
-			return
-		}
-
-		// Cache the opened file for future use. If "direct" option is specified, this
-		// won't be done. This option is useful for preventing file cache from being
-		// polluted by data that won't be accessed immediately.
-		if opt.direct {
-			file.Close()
-		} else {
-			_, done, added := dc.fileCache.Add(key, file)
-			if !added {
-				file.Close() // already exists in the cache. discard it.
+	w := &writer{
+		WriteCloser: wip,
+		commitFunc: func() error {
+			// Commit the cache contents
+			c := dc.cachePath(key)
+			if err := os.MkdirAll(filepath.Dir(c), os.ModePerm); err != nil {
+				var allErr error
+				if err := os.Remove(wip.Name()); err != nil {
+					allErr = multierror.Append(allErr, err)
+				}
+				return multierror.Append(allErr,
+					errors.Wrapf(err, "failed to create cache directory %q", c))
 			}
-			done() // This will remain until it's evicted in lru cache.
-		}
+			return os.Rename(wip.Name(), c)
+		},
+		abortFunc: func() error {
+			return os.Remove(wip.Name())
+		},
 	}
 
-	if dc.syncAdd {
-		addFunc()
-	} else {
-		go addFunc()
+	// If "direct" option is specified, do not cache the passed data on memory.
+	// This option is useful for preventing memory cache from being polluted by data
+	// that won't be accessed immediately.
+	if opt.direct {
+		return w, nil
 	}
+
+	b := dc.bufPool.Get().(*bytes.Buffer)
+	b.Reset()
+	memW := &writer{
+		WriteCloser: nopWriteCloser(io.Writer(b)),
+		commitFunc: func() error {
+			cached, done, added := dc.cache.Add(key, b)
+			if !added {
+				dc.bufPool.Put(b) // already exists in the cache. abort it.
+			}
+			commit := func() error {
+				defer done()
+				defer w.Close()
+				n, err := w.Write(cached.(*bytes.Buffer).Bytes())
+				if err != nil || n != cached.(*bytes.Buffer).Len() {
+					w.Abort()
+					return err
+				}
+				return w.Commit()
+			}
+			if dc.syncAdd {
+				return commit()
+			}
+			go func() {
+				if err := commit(); err != nil {
+					fmt.Println("failed to commit to file:", err)
+				}
+			}()
+			return nil
+		},
+		abortFunc: func() error {
+			defer w.Close()
+			defer w.Abort()
+			dc.bufPool.Put(b) // abort it.
+			return nil
+		},
+	}
+
+	return memW, nil
 }
 
 func (dc *directoryCache) cachePath(key string) string {
 	return filepath.Join(dc.directory, key[:2], key)
 }
 
-func (dc *directoryCache) wipPath(key string) string {
-	return filepath.Join(dc.directory, key[:2], "w", key)
+func (dc *directoryCache) wipFile(key string) (*os.File, error) {
+	return ioutil.TempFile(dc.wipDirectory, key+"-*")
 }
 
 func NewMemoryCache() BlobCache {
-	return &memoryCache{
-		membuf: map[string]string{},
+	return &MemoryCache{
+		Membuf: map[string]*bytes.Buffer{},
 	}
 }
 
-// memoryCache is a cache implementation which backend is a memory.
-type memoryCache struct {
-	membuf map[string]string // read-only []byte map is more ideal but we don't have it in golang...
+// MemoryCache is a cache implementation which backend is a memory.
+type MemoryCache struct {
+	Membuf map[string]*bytes.Buffer
 	mu     sync.Mutex
 }
 
-func (mc *memoryCache) FetchAt(key string, offset int64, p []byte, opts ...Option) (n int, err error) {
+func (mc *MemoryCache) Get(key string, opts ...Option) (Reader, error) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
-
-	cache, ok := mc.membuf[key]
+	b, ok := mc.Membuf[key]
 	if !ok {
-		return 0, fmt.Errorf("Missed cache: %q", key)
+		return nil, fmt.Errorf("Missed cache: %q", key)
 	}
-	return copy(p, cache[offset:]), nil
+	return &reader{bytes.NewReader(b.Bytes()), func() error { return nil }}, nil
 }
 
-func (mc *memoryCache) Add(key string, p []byte, opts ...Option) {
-	mc.mu.Lock()
-	defer mc.mu.Unlock()
-	mc.membuf[key] = string(p)
+func (mc *MemoryCache) Add(key string, opts ...Option) (Writer, error) {
+	b := new(bytes.Buffer)
+	return &writer{
+		WriteCloser: nopWriteCloser(io.Writer(b)),
+		commitFunc: func() error {
+			mc.mu.Lock()
+			defer mc.mu.Unlock()
+			mc.Membuf[key] = b
+			return nil
+		},
+		abortFunc: func() error { return nil },
+	}, nil
+}
+
+type reader struct {
+	io.ReaderAt
+	closeFunc func() error
+}
+
+func (r *reader) Close() error { return r.closeFunc() }
+
+type writer struct {
+	io.WriteCloser
+	commitFunc func() error
+	abortFunc  func() error
+}
+
+func (w *writer) Commit() error {
+	return w.commitFunc()
+}
+
+func (w *writer) Abort() error {
+	return w.abortFunc()
+}
+
+type writeCloser struct {
+	io.Writer
+	closeFunc func() error
+}
+
+func (w *writeCloser) Close() error { return w.closeFunc() }
+
+func nopWriteCloser(w io.Writer) io.WriteCloser {
+	return &writeCloser{w, func() error { return nil }}
 }

--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -23,7 +23,6 @@
 package remote
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -136,9 +135,10 @@ func (b *blob) Cache(offset int64, size int64, opts ...Option) error {
 	fetchReg := region{floor(offset, b.chunkSize), ceil(offset+size-1, b.chunkSize) - 1}
 	discard := make(map[region]io.Writer)
 	b.walkChunks(fetchReg, func(reg region) error {
-		if _, err := b.cache.FetchAt(fr.genID(reg), 0, nil, cacheOpts.cacheOpts...); err != nil {
-			discard[reg] = ioutil.Discard
+		if r, err := b.cache.Get(fr.genID(reg), cacheOpts.cacheOpts...); err == nil {
+			return r.Close() // nop if the cache hits
 		}
+		discard[reg] = ioutil.Discard
 		return nil
 	})
 	if err := b.fetchRange(discard, &cacheOpts); err != nil {
@@ -159,12 +159,6 @@ func (b *blob) ReadAt(p []byte, offset int64, opts ...Option) (int, error) {
 	// Make the buffer chunk aligned
 	allRegion := region{floor(offset, b.chunkSize), ceil(offset+int64(len(p))-1, b.chunkSize) - 1}
 	allData := make(map[region]io.Writer)
-	var putBufs []*bytes.Buffer
-	defer func() {
-		for _, bf := range putBufs {
-			b.resolver.bufPool.Put(bf)
-		}
-	}()
 
 	var readAtOpts options
 	for _, o := range opts {
@@ -177,7 +171,6 @@ func (b *blob) ReadAt(p []byte, offset int64, opts ...Option) (int, error) {
 	fr := b.fetcher
 	b.fetcherMu.Unlock()
 
-	var commits []func() error
 	b.walkChunks(allRegion, func(chunk region) error {
 		var (
 			base         = positive(chunk.b - offset)
@@ -187,55 +180,25 @@ func (b *blob) ReadAt(p []byte, offset int64, opts ...Option) (int, error) {
 		)
 
 		// Check if the content exists in the cache
-		n, err := b.cache.FetchAt(fr.genID(chunk), lowerUnread, p[base:base+expectedSize], readAtOpts.cacheOpts...)
-		if err == nil && n == int(expectedSize) {
-			return nil
+		r, err := b.cache.Get(fr.genID(chunk), readAtOpts.cacheOpts...)
+		if err == nil {
+			defer r.Close()
+			n, err := r.ReadAt(p[base:base+expectedSize], lowerUnread)
+			if (err == nil || err == io.EOF) && int64(n) == expectedSize {
+				return nil
+			}
 		}
 
 		// We missed cache. Take it from remote registry.
 		// We get the whole chunk here and add it to the cache so that following
 		// reads against neighboring chunks can take the data without making HTTP requests.
-		if lowerUnread == 0 && upperUnread == 0 {
-			// We can directly store the result in the given buffer
-			allData[chunk] = &byteWriter{
-				p: p[base : base+chunk.size()],
-			}
-		} else {
-			// Use temporally buffer for aligning this chunk
-			bf := b.resolver.bufPool.Get().(*bytes.Buffer)
-			putBufs = append(putBufs, bf)
-			bf.Reset()
-			bf.Grow(int(chunk.size()))
-			allData[chunk] = bf
-
-			// Function for committing the buffered chunk into the result slice.
-			commits = append(commits, func() error {
-				if int64(bf.Len()) != chunk.size() {
-					return fmt.Errorf("unexpected data size %d; want %d",
-						bf.Len(), chunk.size())
-				}
-				bb := bf.Bytes()[:chunk.size()]
-				n := copy(p[base:], bb[lowerUnread:chunk.size()-upperUnread])
-				if int64(n) != expectedSize {
-					return fmt.Errorf("invalid copied data size %d; want %d",
-						n, expectedSize)
-				}
-				return nil
-			})
-		}
+		allData[chunk] = newBytesWriter(p[base:base+expectedSize], lowerUnread)
 		return nil
 	})
 
 	// Read required data
 	if err := b.fetchRange(allData, &readAtOpts); err != nil {
 		return 0, err
-	}
-
-	// Write all data to the result buffer
-	for _, c := range commits {
-		if err := c(); err != nil {
-			return 0, err
-		}
 	}
 
 	// Adjust the buffer size according to the blob size
@@ -290,31 +253,32 @@ func (b *blob) fetchRange(allData map[region]io.Writer, opts *options) error {
 		} else if err != nil {
 			return errors.Wrapf(err, "failed to read multipart resp")
 		}
-		if err := b.walkChunks(reg, func(chunk region) error {
-
-			// Prepare the temporary buffer
-			bf := b.resolver.bufPool.Get().(*bytes.Buffer)
-			defer b.resolver.bufPool.Put(bf)
-			bf.Reset()
-			bf.Grow(int(chunk.size()))
-			w := io.Writer(bf)
+		if err := b.walkChunks(reg, func(chunk region) (retErr error) {
+			id := fr.genID(chunk)
+			cw, err := b.cache.Add(id, opts.cacheOpts...)
+			if err != nil {
+				return err
+			}
+			defer cw.Close()
+			w := io.Writer(cw)
 
 			// If this chunk is one of the targets, write the content to the
 			// passed reader too.
 			if _, ok := fetched[chunk]; ok {
-				w = io.MultiWriter(bf, allData[chunk])
+				w = io.MultiWriter(w, allData[chunk])
 			}
 
 			// Copy the target chunk
 			if _, err := io.CopyN(w, p, chunk.size()); err != nil {
+				cw.Abort()
 				return err
-			} else if int64(bf.Len()) != chunk.size() {
-				return fmt.Errorf("unexpected fetched data size %d; want %d",
-					bf.Len(), chunk.size())
 			}
 
 			// Add the target chunk to the cache
-			b.cache.Add(fr.genID(chunk), bf.Bytes()[:chunk.size()], opts.cacheOpts...)
+			if err := cw.Commit(); err != nil {
+				return err
+			}
+
 			b.fetchedRegionSetMu.Lock()
 			b.fetchedRegionSet.add(chunk)
 			b.fetchedRegionSetMu.Unlock()
@@ -360,15 +324,42 @@ func (b *blob) walkChunks(allRegion region, walkFn walkFunc) error {
 	return nil
 }
 
-type byteWriter struct {
-	p []byte
-	n int
+func newBytesWriter(dest []byte, destOff int64) io.Writer {
+	return &bytesWriter{
+		dest:    dest,
+		destOff: destOff,
+		current: 0,
+	}
 }
 
-func (w *byteWriter) Write(p []byte) (int, error) {
-	n := copy(w.p[w.n:], p)
-	w.n += n
-	return n, nil
+type bytesWriter struct {
+	dest    []byte
+	destOff int64
+	current int64
+}
+
+func (bw *bytesWriter) Write(p []byte) (int, error) {
+	defer func() { bw.current = bw.current + int64(len(p)) }()
+
+	var (
+		destBase = positive(bw.current - bw.destOff)
+		pBegin   = positive(bw.destOff - bw.current)
+		pEnd     = positive(bw.destOff + int64(len(bw.dest)) - bw.current)
+	)
+
+	if destBase > int64(len(bw.dest)) {
+		return len(p), nil
+	}
+	if pBegin >= int64(len(p)) {
+		return len(p), nil
+	}
+	if pEnd > int64(len(p)) {
+		pEnd = int64(len(p))
+	}
+
+	copy(bw.dest[destBase:], p[pBegin:pEnd])
+
+	return len(p), nil
 }
 
 func floor(n int64, unit int64) int64 {

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -23,7 +23,6 @@
 package remote
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"fmt"
@@ -68,11 +67,6 @@ func NewResolver(blobCache cache.BlobCache, cfg config.BlobConfig) *Resolver {
 	}
 
 	return &Resolver{
-		bufPool: sync.Pool{
-			New: func() interface{} {
-				return new(bytes.Buffer)
-			},
-		},
 		blobCache:  blobCache,
 		blobConfig: cfg,
 	}
@@ -81,7 +75,6 @@ func NewResolver(blobCache cache.BlobCache, cfg config.BlobConfig) *Resolver {
 type Resolver struct {
 	blobCache  cache.BlobCache
 	blobConfig config.BlobConfig
-	bufPool    sync.Pool
 }
 
 func (r *Resolver) Resolve(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (Blob, error) {


### PR DESCRIPTION
Though we currently use `bytes.Buffer`s in many places around the cache, some of these uses seem to be able to reduce.
This commit reduces the use of buffers around the cache, which leads to reduce memory usage of `containerd-stargz-grpc`.

We are currently using buffer during `cache.Add()` but we can reduce it by providing direct access to `*os.File` of each cache file to the cache client.

https://github.com/containerd/stargz-snapshotter/blob/17b648dd9cd4a4b859762c07b85d302e166c3387/cache/cache.go#L226-L229

This commit modifies the interface to provide the writer of that file directly to the client when adding contents to the cache.

```golang
type BlobCache interface {
	Add(key string, opts ...Option) (Writer, error)

// omit...
}
```

```golang
type Writer interface {
	io.WriteCloser
	Commit() error
	Abort() error
}
```

Another buffer we can reduce is the one in `blob.ReadAt()`. We are using this buffer for trimming the data got from the registry. Thus we are buffering the downloaded data first into this buffer then trimming off the unnecessary range.

https://github.com/containerd/stargz-snapshotter/blob/17b648dd9cd4a4b859762c07b85d302e166c3387/fs/remote/blob.go#L204-L209

But instead, we can remove this by just discarding the data out of the necessary range.

Both of the above buffers are on the code path of prefetch and background-fetch, where the entire layer blob is cached and loaded to/from the cache. So the above fixes reduced the memory usage, especially during `rpull`.

Memory usage during `ctr-remote i rpull ghcr.io/stargz-containers/python:3.7-esgz`

|master|PR|
|---|---|
|![](https://user-images.githubusercontent.com/43872416/112840245-12589e80-90da-11eb-8745-e7ea32babcea.png)|![](https://user-images.githubusercontent.com/43872416/112840296-1dabca00-90da-11eb-9398-4d061e94813c.png)|