### PR TITLE
add doc for deploy with systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [[📔**Browse images**]](./docs/pre-converted-images.md)
 [[☸**Quick Start (Kubernetes)**]](#quick-start-with-kubernetes)
 [[🤓**Quick Start (nerdctl)**]](https://github.com/containerd/nerdctl/blob/master/docs/stargz.md)
+[[🔆**Install**]](./docs/INSTALL.md)
 
 # Stargz Snapshotter
 
@@ -108,6 +109,8 @@ Hello World!
 ```
 
 Stargz snapshotter also supports [further configuration](/docs/overview.md) including private registry authentication, mirror registries, etc.
+
+- For more details about installing Stargz Snapshotter, refer to [Install Stargz Snapshotter](./docs/INSTALL.md).
 
 ## Creating eStargz images with optimization
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,51 @@
+# Install Stargz Snapshotter
+
+We assume that you are using containerd (> v1.4.2) as a CRI runtime.
+
+## Install Stargz Snapshotter with Systemd
+
+- Download release tarball from [the release page](https://github.com/containerd/stargz-snapshotter/releases). For example, amd64 binary of v0.5.0 is available from https://github.com/containerd/stargz-snapshotter/releases/download/v0.5.0/stargz-snapshotter-v0.5.0-linux-amd64.tar.gz.
+
+- Add the following configuration to containerd's configuration file (typically: /etc/containerd/config.toml). Please see also [an example configuration file](../script/config/etc/containerd/config.toml).
+  ```
+  version = 2
+
+  # Enable stargz snapshotter for CRI
+  [plugins."io.containerd.grpc.v1.cri".containerd]
+    snapshotter = "stargz"
+    disable_snapshot_annotations = false
+
+  # Plug stargz snapshotter into containerd
+  [proxy_plugins]
+    [proxy_plugins.stargz]
+      type = "snapshot"
+      address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+
+  ```
+
+- Install fuse
+
+  ###### centos
+  ```
+  # centos 7
+  yum install fuse
+  # centos 8
+  dnf install fuse
+
+  modprobe fuse
+  ```
+
+  ###### ubuntu
+
+  ```
+  apt-get install fuse
+  modprobe fuse
+  ```
+
+- Start stargz-snapshotter and restart containerd
+    ```
+    tar -xvf stargz-snapshotter-${version}-linux-${arch}.tar.gz -C /usr/local/bin
+    wget -O /etc/systemd/system/stargz-snapshotter.service https://raw.githubusercontent.com/containerd/stargz-snapshotter/master/script/config/etc/systemd/system/stargz-snapshotter.service
+    systemctl enable --now stargz-snapshotter
+    systemctl restart containerd
+  ```


### PR DESCRIPTION
There is systemd service config, but lacks of deployment document. 

I suggest that we can write a document to describe how to deploy stargz-snapshotter on different platforms such as Systemd, Kubernetes, AWS