### PR TITLE
Enable to cleaning up cache on unmount

### DIFF
--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -103,6 +103,7 @@ func (l *breakableLayer) Refresh(ctx context.Context, hosts docker.RegistryHosts
 	}
 	return nil
 }
+func (l *breakableLayer) Done() {}
 
 // Tests Read method of each file node.
 func TestNodeRead(t *testing.T) {
@@ -389,6 +390,7 @@ func (tl *testLayer) Check() error                         { return nil }
 func (tl *testLayer) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
 	return nil
 }
+func (tl *testLayer) Done() {}
 
 type chunkSizeInfo int
 

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -42,11 +43,11 @@ import (
 	"github.com/containerd/stargz-snapshotter/fs/remote"
 	"github.com/containerd/stargz-snapshotter/task"
 	"github.com/containerd/stargz-snapshotter/util/lrucache"
-	"github.com/golang/groupcache/lru"
+	"github.com/containerd/stargz-snapshotter/util/namedmutex"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
-	"golang.org/x/sync/singleflight"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -94,6 +95,10 @@ type Layer interface {
 	// Fetching contents is done as a background task.
 	// Calling this function before calling Verify or SkipVerify will fail.
 	BackgroundFetch() error
+
+	// Done releases the reference to this layer. The resources related to this layer will be
+	// discarded sooner or later. Queries after calling this function won't be serviced.
+	Done()
 }
 
 // Info is the current status of a layer.
@@ -105,15 +110,16 @@ type Info struct {
 
 // Resolver resolves the layer location and provieds the handler of that layer.
 type Resolver struct {
+	rootDir               string
 	resolver              *remote.Resolver
 	prefetchTimeout       time.Duration
-	layerCache            *lru.Cache
+	layerCache            *lrucache.Cache
 	layerCacheMu          sync.Mutex
-	blobCache             *lru.Cache
+	blobCache             *lrucache.Cache
 	blobCacheMu           sync.Mutex
 	backgroundTaskManager *task.BackgroundTaskManager
-	fsCache               cache.BlobCache
-	resolveG              singleflight.Group
+	resolveLock           *namedmutex.NamedMutex
+	config                config.Config
 }
 
 // NewResolver returns a new layer resolver.
@@ -127,27 +133,42 @@ func NewResolver(root string, backgroundTaskManager *task.BackgroundTaskManager,
 		prefetchTimeout = defaultPrefetchTimeoutSec * time.Second
 	}
 
-	// Prepare contents cache
-	fsCache, err := newCache(filepath.Join(root, "fscache"), cfg.FSCacheType, cfg)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create fs cache")
+	// layerCache caches resolved layers for future use. This is useful in a use-case where
+	// the filesystem resolves and caches all layers in an image (not only queried one) in parallel,
+	// before they are actually queried.
+	layerCache := lrucache.New(resolveResultEntry)
+	layerCache.OnEvicted = func(key string, value interface{}) {
+		if err := value.(*layer).close(); err != nil {
+			logrus.WithField("key", key).WithError(err).Warnf("failed to clean up layer")
+			return
+		}
+		logrus.WithField("key", key).Debugf("cleaned up layer")
 	}
-	httpCache, err := newCache(filepath.Join(root, "httpcache"), cfg.HTTPCacheType, cfg)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create http cache")
+
+	// blobCache caches resolved blobs for futural use. This is especially useful when a layer
+	// isn't eStargz/stargz (the *layer object won't be created/cached in this case).
+	blobCache := lrucache.New(resolveResultEntry)
+	blobCache.OnEvicted = func(key string, value interface{}) {
+		if err := value.(remote.Blob).Close(); err != nil {
+			logrus.WithField("key", key).WithError(err).Warnf("failed to clean up blob")
+			return
+		}
+		logrus.WithField("key", key).Debugf("cleaned up blob")
 	}
 
 	return &Resolver{
-		resolver:              remote.NewResolver(httpCache, cfg.BlobConfig),
-		fsCache:               fsCache,
-		layerCache:            lru.New(resolveResultEntry),
-		blobCache:             lru.New(resolveResultEntry),
+		rootDir:               root,
+		resolver:              remote.NewResolver(cfg.BlobConfig),
+		layerCache:            layerCache,
+		blobCache:             blobCache,
 		prefetchTimeout:       prefetchTimeout,
 		backgroundTaskManager: backgroundTaskManager,
+		config:                cfg,
+		resolveLock:           new(namedmutex.NamedMutex),
 	}, nil
 }
 
-func newCache(cachepath string, cacheType string, cfg config.Config) (cache.BlobCache, error) {
+func newCache(root string, cacheType string, cfg config.Config) (cache.BlobCache, error) {
 	if cacheType == memoryCacheType {
 		return cache.NewMemoryCache(), nil
 	}
@@ -174,8 +195,16 @@ func newCache(cachepath string, cacheType string, cfg config.Config) (cache.Blob
 	fCache.OnEvicted = func(key string, value interface{}) {
 		value.(*os.File).Close()
 	}
+	// create a cache on an unique directory
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return nil, err
+	}
+	cachePath, err := ioutil.TempDir(root, "")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to initialize directory cache")
+	}
 	return cache.NewDirectoryCache(
-		cachepath,
+		cachePath,
 		cache.DirectoryCacheConfig{
 			SyncAdd:   dcc.SyncAdd,
 			DataCache: dCache,
@@ -188,96 +217,139 @@ func newCache(cachepath string, cacheType string, cfg config.Config) (cache.Blob
 // Resolve resolves a layer based on the passed layer blob information.
 func (r *Resolver) Resolve(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (_ Layer, retErr error) {
 	name := refspec.String() + "/" + desc.Digest.String()
+
+	// Wait if resolving this layer is already running. The result
+	// can hopefully get from the LRU cache.
+	r.resolveLock.Lock(name)
+	defer r.resolveLock.Unlock(name)
+
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("src", name))
 
 	// First, try to retrieve this layer from the underlying LRU cache.
 	r.layerCacheMu.Lock()
-	c, ok := r.layerCache.Get(name)
+	c, done, ok := r.layerCache.Get(name)
 	r.layerCacheMu.Unlock()
-	if ok && c.(*layer).Check() == nil {
-		return c.(*layer), nil
-	}
-
-	resultChan := r.resolveG.DoChan(name, func() (interface{}, error) {
-		log.G(ctx).Debugf("resolving")
-
-		// Resolve the blob.
-		blobR, err := r.resolveBlob(ctx, hosts, refspec, desc)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to resolve the blob")
+	if ok {
+		if l := c.(*layer); l.Check() == nil {
+			log.G(ctx).Debugf("hit layer cache %q", name)
+			return &layerRef{l, done}, nil
 		}
-
-		// Get a reader for stargz archive.
-		// Each file's read operation is a prioritized task and all background tasks
-		// will be stopped during the execution so this can avoid being disturbed for
-		// NW traffic by background tasks.
-		sr := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (n int, err error) {
-			r.backgroundTaskManager.DoPrioritizedTask()
-			defer r.backgroundTaskManager.DonePrioritizedTask()
-			return blobR.ReadAt(p, offset)
-		}), 0, blobR.Size())
-		vr, root, err := reader.NewReader(sr, r.fsCache)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to read layer")
-		}
-
-		// Combine layer information together
-		l := newLayer(r, desc, blobR, vr, root)
+		// Cached layer is invalid
+		done()
 		r.layerCacheMu.Lock()
-		r.layerCache.Add(name, l)
+		r.layerCache.Remove(name)
 		r.layerCacheMu.Unlock()
-
-		log.G(ctx).Debugf("resolved")
-		return l, nil
-	})
-
-	var res singleflight.Result
-	select {
-	case res = <-resultChan:
-	case <-time.After(30 * time.Second):
-		r.resolveG.Forget(name)
-		return nil, fmt.Errorf("failed to resolve layer (timeout)")
-	}
-	if res.Err != nil || res.Val == nil {
-		return nil, fmt.Errorf("failed to resolve layer: %v", res.Err)
 	}
 
-	return res.Val.(*layer), nil
+	log.G(ctx).Debugf("resolving")
+
+	// Resolve the blob.
+	blobR, err := r.resolveBlob(ctx, hosts, refspec, desc)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve the blob")
+	}
+	defer func() {
+		if retErr != nil {
+			blobR.done()
+		}
+	}()
+
+	fsCache, err := newCache(filepath.Join(r.rootDir, "fscache"), r.config.FSCacheType, r.config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create fs cache")
+	}
+	defer func() {
+		if retErr != nil {
+			fsCache.Close()
+		}
+	}()
+
+	// Get a reader for stargz archive.
+	// Each file's read operation is a prioritized task and all background tasks
+	// will be stopped during the execution so this can avoid being disturbed for
+	// NW traffic by background tasks.
+	sr := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (n int, err error) {
+		r.backgroundTaskManager.DoPrioritizedTask()
+		defer r.backgroundTaskManager.DonePrioritizedTask()
+		return blobR.ReadAt(p, offset)
+	}), 0, blobR.Size())
+	vr, root, err := reader.NewReader(sr, fsCache)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read layer")
+	}
+
+	// Combine layer information together and cache it.
+	l := newLayer(r, desc, blobR, vr, root)
+	r.layerCacheMu.Lock()
+	cachedL, done2, added := r.layerCache.Add(name, l)
+	r.layerCacheMu.Unlock()
+	if !added {
+		l.close() // layer already exists in the cache. discrad this.
+	}
+
+	log.G(ctx).Debugf("resolved")
+	return &layerRef{cachedL.(*layer), done2}, nil
 }
 
 // resolveBlob resolves a blob based on the passed layer blob information.
-func (r *Resolver) resolveBlob(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (remote.Blob, error) {
+func (r *Resolver) resolveBlob(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (_ *blobRef, retErr error) {
 	name := refspec.String() + "/" + desc.Digest.String()
 
-	// Resolve the blob. The result will be cached for future use. This is effective
-	// in some failure cases including resolving is succeeded but the blob is non-stargz.
-	var blob remote.Blob
+	// Try to retrieve the blob from the underlying LRU cache.
 	r.blobCacheMu.Lock()
-	c, ok := r.blobCache.Get(name)
+	c, done, ok := r.blobCache.Get(name)
 	r.blobCacheMu.Unlock()
 	if ok {
 		if blob := c.(remote.Blob); blob.Check() == nil {
-			return blob, nil
+			return &blobRef{blob, done}, nil
 		}
+		// invalid blob. discard this.
+		done()
+		r.blobCacheMu.Lock()
+		r.blobCache.Remove(name)
+		r.blobCacheMu.Unlock()
 	}
 
-	var err error
-	blob, err = r.resolver.Resolve(ctx, hosts, refspec, desc)
+	httpCache, err := newCache(filepath.Join(r.rootDir, "httpcache"), r.config.HTTPCacheType, r.config)
 	if err != nil {
-		log.G(ctx).WithError(err).Debugf("failed to resolve source")
+		return nil, errors.Wrapf(err, "failed to create http cache")
+	}
+	defer func() {
+		if retErr != nil {
+			httpCache.Close()
+		}
+	}()
+
+	// Resolve the blob and cache the result.
+	b, err := r.resolver.Resolve(ctx, hosts, refspec, desc, httpCache)
+	if err != nil {
 		return nil, errors.Wrap(err, "failed to resolve the source")
 	}
 	r.blobCacheMu.Lock()
-	r.blobCache.Add(name, blob)
+	cachedB, done, added := r.blobCache.Add(name, b)
 	r.blobCacheMu.Unlock()
+	if !added {
+		b.Close() // blob already exists in the cache. discard this.
+	}
+	return &blobRef{cachedB.(remote.Blob), done}, nil
+}
 
-	return blob, nil
+// Cache is similar to Resolve but the result isn't returned. Instead, it'll be stored in the cache.
+func (r *Resolver) Cache(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
+	l, err := r.Resolve(ctx, hosts, refspec, desc)
+	if err != nil {
+		return err
+	}
+	// Release this layer. However, this will remain on the cache until eviction.
+	// Until then, the client can reuse this (already pre-resolved) layer.
+	l.Done()
+	return nil
 }
 
 func newLayer(
 	resolver *Resolver,
 	desc ocispec.Descriptor,
-	blob remote.Blob,
+	blob *blobRef,
 	vr *reader.VerifiableReader,
 	root *estargz.TOCEntry,
 ) *layer {
@@ -294,12 +366,15 @@ func newLayer(
 type layer struct {
 	resolver         *Resolver
 	desc             ocispec.Descriptor
-	blob             remote.Blob
+	blob             *blobRef
 	verifiableReader *reader.VerifiableReader
 	root             *estargz.TOCEntry
 	prefetchWaiter   *waiter
 
 	r reader.Reader
+
+	closed   bool
+	closedMu sync.Mutex
 }
 
 func (l *layer) Info() Info {
@@ -315,14 +390,23 @@ func (l *layer) Root() *estargz.TOCEntry {
 }
 
 func (l *layer) Check() error {
+	if l.isClosed() {
+		return fmt.Errorf("layer is already closed")
+	}
 	return l.blob.Check()
 }
 
 func (l *layer) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
+	if l.isClosed() {
+		return fmt.Errorf("layer is already closed")
+	}
 	return l.blob.Refresh(ctx, hosts, refspec, desc)
 }
 
 func (l *layer) Verify(tocDigest digest.Digest) (err error) {
+	if l.isClosed() {
+		return fmt.Errorf("layer is already closed")
+	}
 	l.r, err = l.verifiableReader.VerifyTOC(tocDigest)
 	return
 }
@@ -332,6 +416,9 @@ func (l *layer) SkipVerify() {
 }
 
 func (l *layer) OpenFile(name string) (io.ReaderAt, error) {
+	if l.isClosed() {
+		return nil, fmt.Errorf("layer is already closed")
+	}
 	if l.r == nil {
 		return nil, fmt.Errorf("layer hasn't been verified yet")
 	}
@@ -341,6 +428,9 @@ func (l *layer) OpenFile(name string) (io.ReaderAt, error) {
 func (l *layer) Prefetch(prefetchSize int64) error {
 	defer l.prefetchWaiter.done() // Notify the completion
 
+	if l.isClosed() {
+		return fmt.Errorf("layer is already closed")
+	}
 	if l.r == nil {
 		return fmt.Errorf("layer hasn't been verified yet")
 	}
@@ -372,10 +462,16 @@ func (l *layer) Prefetch(prefetchSize int64) error {
 }
 
 func (l *layer) WaitForPrefetchCompletion() error {
+	if l.isClosed() {
+		return fmt.Errorf("layer is already closed")
+	}
 	return l.prefetchWaiter.wait(l.resolver.prefetchTimeout)
 }
 
 func (l *layer) BackgroundFetch() error {
+	if l.isClosed() {
+		return fmt.Errorf("layer is already closed")
+	}
 	if l.r == nil {
 		return fmt.Errorf("layer hasn't been verified yet")
 	}
@@ -395,6 +491,48 @@ func (l *layer) BackgroundFetch() error {
 		reader.WithReader(br),                // Read contents in background
 		reader.WithCacheOpts(cache.Direct()), // Do not pollute mem cache
 	)
+}
+
+func (l *layer) close() error {
+	l.closedMu.Lock()
+	defer l.closedMu.Unlock()
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+	defer l.blob.done() // Close reader first, then close the blob
+	l.verifiableReader.Close()
+	if l.r != nil {
+		return l.r.Close()
+	}
+	return nil
+}
+
+func (l *layer) isClosed() bool {
+	l.closedMu.Lock()
+	closed := l.closed
+	l.closedMu.Unlock()
+	return closed
+}
+
+// blobRef is a reference to the blob in the cache. Calling `done` decreases the reference counter
+// of this blob in the underlying cache. When nobody refers to the blob in the cache, resources bound
+// to this blob will be discarded.
+type blobRef struct {
+	remote.Blob
+	done func()
+}
+
+// layerRef is a reference to the layer in the cache. Calling `Done` or `done` decreases the
+// reference counter of this blob in the underlying cache. When nobody refers to the layer in the
+// cache, resources bound to this layer will be discarded.
+type layerRef struct {
+	*layer
+	done func()
+}
+
+func (l *layerRef) Done() {
+	l.done()
 }
 
 func newWaiter() *waiter {

--- a/fs/layer/layer_test.go
+++ b/fs/layer/layer_test.go
@@ -136,7 +136,7 @@ func TestPrefetch(t *testing.T) {
 					prefetchTimeout: time.Second,
 				},
 				ocispec.Descriptor{Digest: testStateLayerDigest},
-				blob,
+				&blobRef{blob, func() {}},
 				vr,
 				nil,
 			)
@@ -226,6 +226,7 @@ func (sb *sampleBlob) Cache(offset int64, size int64, option ...remote.Option) e
 func (sb *sampleBlob) Refresh(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) error {
 	return nil
 }
+func (sb *sampleBlob) Close() error { return nil }
 
 func TestWaiter(t *testing.T) {
 	var (

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -52,7 +52,7 @@ const (
 	defaultFetchTimeoutSec  = 300
 )
 
-func NewResolver(blobCache cache.BlobCache, cfg config.BlobConfig) *Resolver {
+func NewResolver(cfg config.BlobConfig) *Resolver {
 	if cfg.ChunkSize == 0 { // zero means "use default chunk size"
 		cfg.ChunkSize = defaultChunkSize
 	}
@@ -67,17 +67,15 @@ func NewResolver(blobCache cache.BlobCache, cfg config.BlobConfig) *Resolver {
 	}
 
 	return &Resolver{
-		blobCache:  blobCache,
 		blobConfig: cfg,
 	}
 }
 
 type Resolver struct {
-	blobCache  cache.BlobCache
 	blobConfig config.BlobConfig
 }
 
-func (r *Resolver) Resolve(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (Blob, error) {
+func (r *Resolver) Resolve(ctx context.Context, hosts docker.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor, blobCache cache.BlobCache) (Blob, error) {
 	fetcher, size, err := newFetcher(ctx, hosts, refspec, desc)
 	if err != nil {
 		return nil, err
@@ -86,7 +84,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts docker.RegistryHosts, refs
 		fetcher:       fetcher,
 		size:          size,
 		chunkSize:     r.blobConfig.ChunkSize,
-		cache:         r.blobCache,
+		cache:         blobCache,
 		lastCheck:     time.Now(),
 		checkInterval: time.Duration(r.blobConfig.ValidInterval) * time.Second,
 		resolver:      r,


### PR DESCRIPTION
Resolves: #308
Related: #276

Currently, content caches (`/var/lib/containerd-stargz-grpc/stargz/fscache` and `/var/lib/containerd-stargz-grpc/stargz/httpcache`) aren't cleaned up on FileSystem.Unmount().
This commit adds this functionality.

From this commit, content caches are namespaced per layer with unique ID (e.g. `/var/lib/containerd-stargz-grpc/stargz/fscache/123456` for layer A and `/var/lib/containerd-stargz-grpc/stargz/fscache/987654` for layer B).

This commit allows snapshotter to cleanup a namespace of cache when the corresponding layer is no longer referenced (i.e. unmounted).

### Test

#### Add the following configuration to `/etc/containerd-stargz-grpc/config.toml`

- `resolve_result_entry = 3`  : at most 3 resolved layers are cached

#### Pull an image

```
ctr-remote i rpull ghcr.io/stargz-containers/python:3.9-esgz
```

#### Inspect the snapsotter's root dir

```
ls -al /var/lib/containerd-stargz-grpc/snapshotter/snapshots /var/lib/containerd-stargz-grpc/stargz/fscache
```

<details>
<summary>Click here to show the output</summary>

<p>

```
/var/lib/containerd-stargz-grpc/snapshotter/snapshots:
total 44
drwx------ 11 root root 4096 Apr 27 04:35 .
drwx------  3 root root 4096 Apr 27 04:35 ..
drwx------  4 root root 4096 Apr 27 04:35 1
drwx------  4 root root 4096 Apr 27 04:35 2
drwx------  4 root root 4096 Apr 27 04:35 3
drwx------  4 root root 4096 Apr 27 04:35 4
drwx------  4 root root 4096 Apr 27 04:35 5
drwx------  4 root root 4096 Apr 27 04:35 6
drwx------  4 root root 4096 Apr 27 04:35 7
drwx------  4 root root 4096 Apr 27 04:35 8
drwx------  4 root root 4096 Apr 27 04:35 9

/var/lib/containerd-stargz-grpc/stargz/fscache:
total 44
drwx------ 11 root root 4096 Apr 27 04:35 .
drwx------  4 root root 4096 Apr 27 04:35 ..
drwx------  3 root root 4096 Apr 27 04:35 014116486
drwx------  3 root root 4096 Apr 27 04:35 093047428
drwx------  3 root root 4096 Apr 27 04:35 388270433
drwx------ 23 root root 4096 Apr 27 04:35 631707427
drwx------  3 root root 4096 Apr 27 04:35 651487165
drwx------ 14 root root 4096 Apr 27 04:35 717597717
drwx------  3 root root 4096 Apr 27 04:35 783436066
drwx------  4 root root 4096 Apr 27 04:35 909474884
drwx------  3 root root 4096 Apr 27 04:35 972338455
```

</p>
</details>

We have 9 snapshots and cache namespaces are create for each snapshots

#### Remove the image

Snaphsots are unmountd by containerd's GC.

```
ctr-remote i rm ghcr.io/stargz-containers/python:3.9-esgz
```

#### Inspect the snapsotter's root dir again

```
ls -al /var/lib/containerd-stargz-grpc/snapshotter/snapshots /var/lib/containerd-stargz-grpc/stargz/fscache
```

<details>
<summary>Click here to show the output</summary>

<p>

```
/var/lib/containerd-stargz-grpc/snapshotter/snapshots:
total 8
drwx------ 2 root root 4096 Apr 27 04:38 .
drwx------ 3 root root 4096 Apr 27 04:35 ..

/var/lib/containerd-stargz-grpc/stargz/fscache:
total 20
drwx------   5 root root 4096 Apr 27 04:38 .
drwx------   4 root root 4096 Apr 27 04:35 ..
drwx------ 255 root root 4096 Apr 27 04:35 631707427
drwx------ 232 root root 4096 Apr 27 04:35 909474884
drwx------   4 root root 4096 Apr 27 04:35 972338455
```

</p>
</details>

We have only 3 cache namespaces that are corresponding to the 3 resolved layer cached in snapshotter. Cache namespaces corresponding to 6 evicted layers are cleaned up.

### Note about the relationship with containerd's GC

Containerd's unpacker (CRI plugin uses this) [create GC reference labels](https://github.com/containerd/containerd/blob/b0fb8a5a04eff810861d258053bdac951ccf7b78/unpacker.go#L244-L254) (`containerd.io/gc.ref.snapshot.*`) that bind the image (its config blob content, more precisely) to the corresponding snapshots. So, as long as the image isn't deleted, snapshots aren't Unmount()-ed even if containers are deleted.

