### PR TITLE
Preparation for v0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ RUN git clone https://github.com/containers/common $GOPATH/src/github.com/contai
 # Binaries for release
 FROM scratch AS release-binaries
 COPY --from=snapshotter-dev /out/* /
+COPY --from=stargz-store-dev /out/* /
 
 # Base image which contains containerd with default snapshotter
 FROM golang-base AS containerd-base

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -28,7 +28,7 @@ To enable lazy pulling of eStargz on containerd, you need to install *Stargz Sna
 This section shows the step to install Stargz Snapshotter with systemd.
 We assume that you are using containerd (> v1.4.2) as a CRI runtime.
 
-- Download release tarball from [the release page](https://github.com/containerd/stargz-snapshotter/releases). For example, amd64 binary of v0.5.0 is available from https://github.com/containerd/stargz-snapshotter/releases/download/v0.5.0/stargz-snapshotter-v0.5.0-linux-amd64.tar.gz.
+- Download release tarball from [the release page](https://github.com/containerd/stargz-snapshotter/releases). For example, amd64 binary of v0.6.0 is available from https://github.com/containerd/stargz-snapshotter/releases/download/v0.6.0/stargz-snapshotter-v0.6.0-linux-amd64.tar.gz.
 
 - Add the following configuration to containerd's configuration file (typically: /etc/containerd/config.toml). Please see also [an example configuration file](../script/config/etc/containerd/config.toml).
   ```toml
@@ -80,7 +80,7 @@ To enable lazy pulling of eStargz on CRI-O/Podman, you need to install *Stargz S
 This section shows the step to install Stargz Store with systemd.
 We assume that you are using CRI-O newer than https://github.com/cri-o/cri-o/pull/4850 or Podman newer than https://github.com/containers/podman/pull/10214 .
 
-- Download release tarball from [the release page](https://github.com/containerd/stargz-snapshotter/releases).
+- Download release tarball from [the release page](https://github.com/containerd/stargz-snapshotter/releases). For example, amd64 binary of v0.6.0 is available from https://github.com/containerd/stargz-snapshotter/releases/download/v0.6.0/stargz-snapshotter-v0.6.0-linux-amd64.tar.gz.
 
 - Add the following configuration to the storage configuration file of CRI-O/Podman (typically: /etc/containers/storage.conf). Please see also [an example configuration file](../script/config-cri-o/etc/containers/storage.conf).
   ```toml

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containerd/containerd v1.5.0
 	github.com/containerd/continuity v0.1.0
 	github.com/containerd/go-cni v1.0.2
-	github.com/containerd/stargz-snapshotter/estargz v0.5.0
+	github.com/containerd/stargz-snapshotter/estargz v0.6.0
 	github.com/coreos/go-systemd/v22 v22.3.1
 	github.com/docker/cli v20.10.6+incompatible
 	github.com/docker/docker v20.10.6+incompatible // indirect


### PR DESCRIPTION
# release note

Since this release, lazy pulling of eStargz is possible on CRI-O/Podman using the brand-new Stargz Store plugin. Please refer to [our docs for details about installation](https://github.com/containerd/stargz-snapshotter/blob/v0.6.0/docs/INSTALL.md).

This release also adds changes for better resource efficiency of Stargz Snapshotter, including garbage collection of content cache (#309) and memory consumption improvement (#294).

## Notable Changes

- **Stargz Store**
  - Add Stargz Store for enabling lazy pulling on CRI-O/Podman (#301)

- **Stargz Snapshotter**
  - Add GC when unmounting snapshots (#309)
  - Improve memory consumption (#294)
  - Add `request_timeout_sec` option for making request timeout configurable in slow NW (#317)

- **estargz library**
  - Add support of compressed input blobs to `estargz.Build` (#304)

- **Test/release pipeline**
  - Remove unused `cind` target from Dockerfile (#295)
  - Switch to v2 configuration file format of containerd (#302)
  - Remove unnecessary linter config (#297)

- **Docs and dependencies**
  - Add document about installing Stargz Snapshotter for containerd with systemd (#307), thanks @chenk008
  - Add document about installing Stargz Store for CRI-O/Podman with systemd (#319)
  - Fix typos (#311, #315), thanks @hs0210 and @ilyee
  - Add eStargz-formatted `mariadb:10.5` and `wordpress:5.7` to ghcr.io/stargz-containers (#303)
  - Bump dependencies (Go to 1.16, containerd to 1.5.0, etc) (#312, #313, #299, etc)
