### PR TITLE
Prepare for v0.6.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/containerd/containerd v1.5.2
 	github.com/containerd/continuity v0.1.0
 	github.com/containerd/go-cni v1.0.2
-	github.com/containerd/stargz-snapshotter/estargz v0.6.1
+	github.com/containerd/stargz-snapshotter/estargz v0.6.2
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/cli v20.10.6+incompatible
 	github.com/docker/docker v20.10.6+incompatible // indirect


### PR DESCRIPTION
## Release Note

This release enables Podman + Stargz Store (`stargz-store`) to export (`podman save`/`podman push`) lazily pulled eStargz images (#322 and https://github.com/containers/storage/pull/902). Podman need to be newer than https://github.com/containers/podman/commit/568e911b84a0a3d2e457cebdc291fea4fea44aed.

**This change only affects to Stargz Store and doesn't affect Stargz Snapshotter.**

For using this feature, each layer descriptor in the manifest of the eStargz image must have the following OCI Annotation.

- `io.containers.estargz.uncompressed-size` : contains the uncompressed size of the layer.

Our `nativeconverter` and `ctr-remote` appends this label by default since this release.

Note that this change to eStargz is backward-compatible so you can lazily pull this eStargz image still on older versions of Stargz Snapshotter/Stargz Store.

The following table shows how this change affects to Stargz Store:

### Lazy pulling of eStargz using Stargz Store

- ✅ : Supported
- ➖ : Not Supported

||Stargz Store < v0.6.2|Stargz Store >= v0.6.2|
|---|---|---|
|eStargz < v0.6.2|✅|✅|
|eStargz >= v0.6.2|✅|✅|

### `podman save`/`podman push` of lazily pulled eStarz using Stargz Store

- ✅ : Supported
- ➖ : Not Supported

||Stargz Store < v0.6.2|Stargz Store >= v0.6.2|
|---|---|---|
|eStargz < v0.6.2|➖ |➖ |
|eStargz >= v0.6.2|➖ |✅|

The following is an example manifest (`ghcr.io/stargz-containers/golang:1.12.9-esgz`) which supports podman's export-related commands:

```json
{
  "schemaVersion": 2,
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "digest": "sha256:b04dc2badd2e5c5955f88e2240056e99953cf0d6ca9256251f77feedd7bdfed8",
    "size": 5294
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:d7036ba899baedb29dd01479609a07ca7a528679135dd6a6f573226e5a8d0925",
      "size": 52959079,
      "annotations": {
        "containerd.io/snapshot/stargz/toc.digest": "sha256:98a8bb61bfcb79f306b12fb7ec45c31d2e7459ce49e927cd6d23035613538005",
        "io.containers.estargz.uncompressed-size": "121476608"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:45a80f3bed7745d368b34092fd5239788f95a423521c71f330eb4e615eb3572e",
      "size": 7893201,
      "annotations": {
        "containerd.io/snapshot/stargz/toc.digest": "sha256:17586ee4b505100c5936dbcae9e09b5bbd247b0b102a7904056dcac9033f1250",
        "io.containers.estargz.uncompressed-size": "17394688"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:6c13627875ec5b73083616db5535d09db29af39505f016e240b46964e19bceeb",
      "size": 10048928,
      "annotations": {
        "containerd.io/snapshot/stargz/toc.digest": "sha256:137ad91b13cbc0454bd68770deaa006234ed0977fdbeb47a53a8a53d4eed2913",
        "io.containers.estargz.uncompressed-size": "17989120"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:da3b382684ad8d8a7a4939dba8c1b99f02e432a08fb98aab34218cb0e0881a90",
      "size": 54376902,
      "annotations": {
        "containerd.io/snapshot/stargz/toc.digest": "sha256:acc989d40d7aa28c177b3a684a52ae1371db552aefd016119cf861f163149295",
        "io.containers.estargz.uncompressed-size": "151897600"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:56c008d960d6b29c1bba571275a5a24906e634cd84a6382d0c6d98c5fbda966a",
      "size": 70374658,
      "annotations": {
        "containerd.io/snapshot/stargz/toc.digest": "sha256:7baa8f2c29aeb5dc5c9dd4aac51ee01fd468c3f0d6b0c0814749b039efa765cd",
        "io.containers.estargz.uncompressed-size": "185508864"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:69ace8b12b44af07f59fa6ba765585f37483605d51bf21ae52d67e05816174e4",
      "size": 131385022,
      "annotations": {
        "containerd.io/snapshot/stargz/toc.digest": "sha256:9155407db408c0e5e4536bb2571c9d906989525d45267376429ec6bc59eabc45",
        "io.containers.estargz.uncompressed-size": "349913088"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:ed3e61cce63a9ed48c4c67541634a699456da51def0bb5c6270a49f09ea827c2",
      "size": 750,
      "annotations": {
        "containerd.io/snapshot/stargz/toc.digest": "sha256:2acc3b983874129408c86e1ff542e75f5f562c2a62f2187b36ebdfb419f1be9b",
        "io.containers.estargz.uncompressed-size": "5120"
      }
    }
  ]
}
```
