### PR TITLE
Prepare for v0.6.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/containerd/containerd v1.5.2
 	github.com/containerd/continuity v0.1.0
 	github.com/containerd/go-cni v1.0.2
-	github.com/containerd/stargz-snapshotter/estargz v0.6.3
+	github.com/containerd/stargz-snapshotter/estargz v0.6.4
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/cli v20.10.6+incompatible
 	github.com/docker/docker v20.10.6+incompatible // indirect


### PR DESCRIPTION
This release contains refactoring of dependencies to enable `nativeconverter` to built on windows (#333 ).