### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+
+  # Automatic upgrade for go modules.
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # We upgrade this manually on each release
+      - dependency-name: "github.com/containerd/stargz-snapshotter/estargz"
+      # This forcefully points to v1.22.1. See go.mod.
+      - dependency-name: "github.com/urfave/cli"
+
+  # Automatic upgrade for base images used in the Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Automatic upgrade for Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/" # means ".github/workflows"
+    schedule:
+      interval: "daily"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ ARG CONMON_VERSION=v2.0.26
 ARG COMMON_VERSION=v0.37.1
 ARG CRIO_TEST_PAUSE_IMAGE_NAME=k8s.gcr.io/pause:3.5
 
+# Used in CI
+ARG CRI_TOOLS_VERSION=v1.21.0
+
 # Legacy builder that doesn't support TARGETARCH should set this explicitly using --build-arg.
 # If TARGETARCH isn't supported by the builder, the default value is "amd64".
 

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,9 @@ replace (
 	// Import local package for estargz.
 	github.com/containerd/stargz-snapshotter/estargz => ./estargz
 
-	// NOTE: github.com/containerd/containerd v1.4.0 depends on github.com/urfave/cli v1.22.1
-	//       because of https://github.com/urfave/cli/issues/1092
+	// NOTE1: github.com/containerd/containerd v1.4.0 depends on github.com/urfave/cli v1.22.1
+	//        because of https://github.com/urfave/cli/issues/1092
+	// NOTE2: Automatic upgrade of this is disabled in denendabot.yml. When we remove this replace
+	//        directive, we must remove the corresponding "ignore" configuration from dependabot.yml
 	github.com/urfave/cli => github.com/urfave/cli v1.22.1
 )

--- a/script/cri-containerd/test.sh
+++ b/script/cri-containerd/test.sh
@@ -18,11 +18,13 @@ set -euo pipefail
 
 CONTEXT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/"
 REPO="${CONTEXT}../../"
-CRI_TOOLS_VERSION=53ad8bb7f97e1b1d1c0c0634e43a3c2b8b07b718
-CNI_VERSION="v0.9.1"
 SNAPSHOTTER_SOCK_PATH=/run/containerd-stargz-grpc/containerd-stargz-grpc.sock
 
 source "${CONTEXT}/const.sh"
+source "${REPO}/script/util/utils.sh"
+
+CNI_PLUGINS_VERSION=$(get_version_from_arg "${REPO}/Dockerfile" "CNI_PLUGINS_VERSION")
+CRI_TOOLS_VERSION=v$(get_version_from_arg "${REPO}/Dockerfile" "CRI_TOOLS_VERSION")
 
 if [ "${CRI_NO_RECREATE:-}" != "true" ] ; then
     echo "Preparing node image..."
@@ -121,7 +123,7 @@ RUN apt install -y --no-install-recommends git make gcc build-essential jq && \
     cd \${GOPATH}/src/github.com/kubernetes-sigs/cri-tools && \
     git checkout ${CRI_TOOLS_VERSION} && \
     make && make install -e BINDIR=\${GOPATH}/bin && \
-    curl -Ls https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-\${TARGETARCH:-amd64}-${CNI_VERSION}.tgz | tar xzv -C /opt/cni/bin && \
+    curl -Ls https://github.com/containernetworking/plugins/releases/download/v${CNI_PLUGINS_VERSION}/cni-plugins-linux-\${TARGETARCH:-amd64}-v${CNI_PLUGINS_VERSION}.tgz | tar xzv -C /opt/cni/bin && \
     systemctl disable kubelet
 
 COPY ./test.conflist /etc/cni/net.d/test.conflist

--- a/script/cri-o/test.sh
+++ b/script/cri-o/test.sh
@@ -18,9 +18,11 @@ set -euo pipefail
 
 CONTEXT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/"
 REPO="${CONTEXT}../../"
-CRI_TOOLS_VERSION=53ad8bb7f97e1b1d1c0c0634e43a3c2b8b07b718
 
 source "${CONTEXT}/const.sh"
+source "${REPO}/script/util/utils.sh"
+
+CRI_TOOLS_VERSION=v$(get_version_from_arg "${REPO}/Dockerfile" "CRI_TOOLS_VERSION")
 
 if [ "${CRI_NO_RECREATE:-}" != "true" ] ; then
     echo "Preparing node image..."

--- a/script/generated-files/generate.sh
+++ b/script/generated-files/generate.sh
@@ -18,6 +18,12 @@ set -euo pipefail
 
 CONTEXT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/"
 REPO="${CONTEXT}../../"
+
+source "${REPO}/script/util/utils.sh"
+
+GOBASE_VERSION=$(go_base_version "${REPO}/Dockerfile")
+
+# TODO: get the following versions from go.mod once we add them.
 PROTOC_VERSION=3.17.3
 GOGO_VERSION=v1.3.2
 
@@ -38,7 +44,7 @@ function cleanup {
 trap 'cleanup "$?"' EXIT SIGHUP SIGINT SIGQUIT SIGTERM
 
 cat <<EOF > "${TMP_CONTEXT}/Dockerfile"
-FROM golang:1.16-buster AS golang-base
+FROM golang:${GOBASE_VERSION} AS golang-base
 
 ARG PROTOC_VERSION=${PROTOC_VERSION}
 ARG GOGO_VERSION=${GOGO_VERSION}

--- a/script/util/make.sh
+++ b/script/util/make.sh
@@ -20,6 +20,10 @@ CONTEXT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/"
 REPO="${CONTEXT}../../"
 IMAGE_NAME="minienv"
 
+source "${REPO}/script/util/utils.sh"
+
+GOBASE_VERSION=$(go_base_version "${REPO}/Dockerfile")
+
 TMP_CONTEXT=$(mktemp -d)
 function cleanup {
     local ORG_EXIT_CODE="${1}"
@@ -29,7 +33,7 @@ function cleanup {
 trap 'cleanup "$?"' EXIT SIGHUP SIGINT SIGQUIT SIGTERM
 
 cat <<EOF > "${TMP_CONTEXT}/Dockerfile"
-FROM golang:1.16
+FROM golang:${GOBASE_VERSION}
 RUN apt-get update -y && apt-get --no-install-recommends install -y fuse
 EOF
 docker build -t "${IMAGE_NAME}" ${DOCKER_BUILD_ARGS:-} "${TMP_CONTEXT}"

--- a/script/util/utils.sh
+++ b/script/util/utils.sh
@@ -52,3 +52,16 @@ function check_remote_snapshots {
         return 1
     fi
 }
+
+# Get version from ARG directive in the specified Dockerfile.
+function get_version_from_arg {
+    local DOCKERFILE="${1}"
+    local ARGNAME="${2}"
+    cat "${DOCKERFILE}" | grep "${ARGNAME}=" | head -1 | sed -E 's/ARG +'"${ARGNAME}"'=v?([^ ]+).*/\1/g' | tr -d '\n'
+}
+
+# Get version of golang base image from the specified Dockerfile.
+function go_base_version {
+    local DOCKERFILE="${1}"
+    cat "${DOCKERFILE}" | grep -E 'FROM\s+golang:' | head -1 | sed -E 's/FROM +[^:]*:([^ ]+).*/\1/g' | tr -d '\n'
+}


### PR DESCRIPTION
This commit enables dependabot for gomod, Dockerfile and Github Actions.

Detailed guide can be found in:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates

Versions of tools (critools, cni, golang base image, nerdctl, etc.) in CI now refer to the toplevel Dockerfile.