### PR TITLE
Allow users to manually set the fetcher to use single range mode 

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -55,10 +55,11 @@ type Config struct {
 }
 
 type BlobConfig struct {
-	ValidInterval   int64 `toml:"valid_interval"`
-	CheckAlways     bool  `toml:"check_always"`
-	ChunkSize       int64 `toml:"chunk_size"`
-	FetchTimeoutSec int64 `toml:"fetching_timeout_sec"`
+	ValidInterval        int64 `toml:"valid_interval"`
+	CheckAlways          bool  `toml:"check_always"`
+	ChunkSize            int64 `toml:"chunk_size"`
+	FetchTimeoutSec      int64 `toml:"fetching_timeout_sec"`
+	ForceSingleRangeMode bool  `toml:"force_single_range_mode"`
 }
 
 type DirectoryCacheConfig struct {

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -82,6 +82,10 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 	if err != nil {
 		return nil, err
 	}
+
+	if r.blobConfig.ForceSingleRangeMode {
+		fetcher.singleRangeMode()
+	}
 	return &blob{
 		fetcher:       fetcher,
 		size:          size,


### PR DESCRIPTION


Stargz-snapshotter has a mechanism to support registries that do not allow multiple ranges in a single GET request. For the fallback mechanism to kick in, the snapshotter expects the registry to return an error.

Some registries like AWS ECR neither support retrieving multiple ranges of data per GET request nor return an error. Instead they send back the entire requested object.

This patch enables users to configure the fetcher to use single range mode.

Changes:

1) fs/config/config.go: Added a field 'ForceSingleRangeMode' in BlobConfig, corresponding to 'force_single_range_mode' in config.toml
2) fs/remote/resolver.go: Checks whether blobConfig.ForceSingleRangeMode is true; if it is, the fetcher is set to single range mode using fetcher.singleRangeMode()

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>