### PR TITLE
Latency metrics design proposal

### DIFF
--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -72,6 +72,9 @@ type snapshotterConfig struct {
 
 	// MetricsAddress is address for the metrics API
 	MetricsAddress string `toml:"metrics_address"`
+
+	// NoPrometheus is a flag to disable the emission of the metrics
+	NoPrometheus bool `toml:"no_prometheus"`
 }
 
 func main() {
@@ -189,7 +192,8 @@ func serve(ctx context.Context, rpc *grpc.Server, addr string, rs snapshots.Snap
 
 	errCh := make(chan error, 1)
 
-	if config.MetricsAddress != "" {
+	// We need to consider both the existence of MetricsAddress as well as NoPrometheus flag not set
+	if config.MetricsAddress != "" && !config.NoPrometheus {
 		l, err := net.Listen("tcp", config.MetricsAddress)
 		if err != nil {
 			return false, errors.Wrapf(err, "failed to get listener for metrics endpoint")

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -1,0 +1,82 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commonmetrics
+
+import (
+	"sync"
+	"time"
+
+	digest "github.com/opencontainers/go-digest"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// OperationLatencyKey is the key for stargz operation metrics.
+	OperationLatencyKey = "operation_duration"
+
+	// Keep namespace as stargz and subsystem as fs.
+	namespace = "stargz"
+	subsystem = "fs"
+)
+
+// Lists all metric labels.
+const (
+	Mount             = "mount"
+	RemoteRegistryGet = "remote_registry_get"
+	NodeReaddir       = "node_readdir"
+)
+
+var (
+	// Buckets for OperationLatency metric in milliseconds.
+	latencyBuckets = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384} // in milliseconds
+
+	// OperationLatency collects operation latency numbers by operation
+	// type.
+	operationLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      OperationLatencyKey,
+			Help:      "Latency in milliseconds of stargz snapshotter operations. Broken down by operation type.",
+			Buckets:   latencyBuckets,
+		},
+		[]string{"operation_type", "layer"},
+	)
+)
+
+var register sync.Once
+
+// sinceInMilliseconds gets the time since the specified start in milliseconds.
+// The division by 1e6 is made to have the milliseconds value as floating point number, since the native method
+// .Milliseconds() returns an integer value and you can lost a precision for sub-millisecond values.
+func sinceInMilliseconds(start time.Time) float64 {
+	return float64(time.Since(start).Nanoseconds()) / 1e6
+}
+
+// Register metrics. This is always called only once.
+func Register() {
+	register.Do(func() {
+		prometheus.MustRegister(operationLatency)
+	})
+}
+
+// Wraps the labels attachment as well as calling Observe into a single method.
+// Right now we attach the operation and layer sha, so it's possible to see the breakdown for latency
+// by operation and individual layers.
+func MeasureLatency(operation string, layer digest.Digest, start time.Time) {
+	operationLatency.WithLabelValues(operation, layer.String()).Observe(sinceInMilliseconds(start))
+}

--- a/fs/metrics/layer/layer.go
+++ b/fs/metrics/layer/layer.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package metrics
+package layermetrics
 
 import (
 	"github.com/containerd/stargz-snapshotter/fs/layer"

--- a/fs/metrics/layer/metrics.go
+++ b/fs/metrics/layer/metrics.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package metrics
+package layermetrics
 
 import (
 	"sync"

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -43,7 +43,9 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/stargz-snapshotter/cache"
 	"github.com/containerd/stargz-snapshotter/fs/config"
+	commonmetrics "github.com/containerd/stargz-snapshotter/fs/metrics/common"
 	"github.com/containerd/stargz-snapshotter/fs/source"
+	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -160,6 +162,7 @@ func newFetcher(ctx context.Context, hosts source.RegistryHosts, refspec referen
 			url:     url,
 			tr:      tr,
 			blobURL: blobURL,
+			digest:  digest,
 			timeout: timeout,
 		}, size, nil
 	}
@@ -299,6 +302,7 @@ type fetcher struct {
 	urlMu         sync.Mutex
 	tr            http.RoundTripper
 	blobURL       string
+	digest        digest.Digest
 	singleRange   bool
 	singleRangeMu sync.Mutex
 	timeout       time.Duration
@@ -355,7 +359,11 @@ func (f *fetcher) fetch(ctx context.Context, rs []region, retry bool, opts *opti
 	req.Header.Add("Range", fmt.Sprintf("bytes=%s", ranges[:len(ranges)-1]))
 	req.Header.Add("Accept-Encoding", "identity")
 	req.Close = false
+
+	// Recording the roundtrip latency for remote registry GET operation.
+	start := time.Now()
 	res, err := tr.RoundTrip(req) // NOT DefaultClient; don't want redirects
+	commonmetrics.MeasureLatency(commonmetrics.RemoteRegistryGet, f.digest, start)
 	if err != nil {
 		return nil, err
 	}

--- a/store/pool.go
+++ b/store/pool.go
@@ -36,7 +36,7 @@ import (
 	"github.com/containerd/stargz-snapshotter/estargz"
 	"github.com/containerd/stargz-snapshotter/fs/config"
 	"github.com/containerd/stargz-snapshotter/fs/layer"
-	fsmetrics "github.com/containerd/stargz-snapshotter/fs/metrics"
+	layermetrics "github.com/containerd/stargz-snapshotter/fs/metrics/layer"
 	"github.com/containerd/stargz-snapshotter/fs/source"
 	"github.com/containerd/stargz-snapshotter/task"
 	"github.com/containerd/stargz-snapshotter/util/namedmutex"
@@ -80,7 +80,7 @@ func NewPool(root string, hosts source.RegistryHosts, cfg config.Config) (*Pool,
 	if !cfg.NoPrometheus {
 		ns = metrics.NewNamespace("stargz", "fs", nil)
 	}
-	c := fsmetrics.NewLayerMetrics(ns)
+	c := layermetrics.NewLayerMetrics(ns)
 	if ns != nil {
 		metrics.Register(ns)
 	}
@@ -118,7 +118,7 @@ type Pool struct {
 	backgroundTaskManager *task.BackgroundTaskManager
 	allowNoVerification   bool
 	disableVerification   bool
-	metricsController     *fsmetrics.Controller
+	metricsController     *layermetrics.Controller
 	resolveLock           *namedmutex.NamedMutex
 }
 


### PR DESCRIPTION
Hello Container community,

I’m new to the container ecosystem and in the early stages of exploring stargz snapshotter. While exploring the stargz snapshotter, I saw that it does not emit many metrics and it’s really challenging to get alerted if something goes wrong as well as to measure performance characteristics of lazy loading. 
Currently stargz snapshotter emits only 2 metrics: layer_fetched_size and layer_size. In addition to those metrics, I suggest adding the following:    

    * Image and layer metrics
        * Prefetch bytes per layer (or prefetch ratio)
    * Quantifying accuracy of prefetch files
        * Number of cache hits
        * Total on-demand bytes served out of cache
        * Number of on-demand file fetches (aka cache miss)
        * Total bytes fetched on-demand
        * Latency between mounting a layer and last on-demand fetch
    * Latency Metrics
        * Prefetch
            * Time to download prefetch data
            * Time to decompress prefetch data
            * Total time to complete prefetch
        * Background fetch
            * Time to download background fetch data
            * Time to decompress background fetch data
            * Total time to  complete background fetch
        * Mount
            * Time to deserialize json TOC
            * Total time to mount
            * Total wait time for all mounts to complete
        * Remote registry access latency 
        * Decompression latency
        * Total request latency for on-demand reads from the container
    * Count Metrics
        * Number of retries to download data
        * Count of concurrent remote registry requests
        * Number of times a background task was preemptively cancelled

With regards to the approach, the current PR presents the skeleton for adding latency metrics to stargz snapshotter project (it’s based on the approach used in Kubernetes project: https://github.com/kubernetes/kubernetes/blob/c8b135d0b49c44554ed5b78878f15f09cab350b6/pkg/kubelet/dockershim/metrics/metrics.go#L1). 
This approach makes the process of adding latency metrics as easy as import a latencymetrics package and calling Observe on OperationLatency with specifying a metric name as a label.

Please let me know what you think.
