### PR TITLE
Allow users to specify a GZIP compression level for image when using …

### DIFF
--- a/docs/ctr-remote.md
+++ b/docs/ctr-remote.md
@@ -56,6 +56,16 @@ ctr-remote image push --plain-http registry2:5000/golang:1.15.3-esgz
 When you run `ctr-remote image optimize`, this runs the source image (`ghcr.io/stargz-containers/golang:1.15.3-buster-org`) as a container and profiles all file accesses during the execution.
 Then these accessed files are marked as "prioritized" files and will be prefetched on runtime.
 
+You can specify the GZIP compression level the converter should use using the `--estargz-compression-level` flag. The values range from 1-9. If the flag isn't provided, the compression level will default to 9.
+
+A value of 9 indicates the archive will be gzipped with max compression. This will reduce the bytes transferred over the network but increase the CPU cycles required to decompress the payload. Whereas gzip compression value 1 indicates archive will be gzipped with least compression. This will increase the bytes transferred over the network but decreases the CPU cycles required to decompress the payload. This value should be chosen based on the workload and host characteristics.
+
+The following example optimizes an image with a compression level of 1.
+
+```console
+# ctr-remote image optimize --oci --estargz-compression-level 1 ghcr.io/stargz-containers/golang:1.15.3-buster-org registry2:5000/golang:1.15.3-esgz
+```
+
 `--oci` option is highly recommended to add when you create eStargz image.
 If the source image is [Docker image](https://github.com/moby/moby/blob/master/image/spec/v1.2.md) that doesn't allow us [content verification of eStargz](/docs/verification.md), `ctr-remote` converts this image into the [OCI starndard compliant image](https://github.com/opencontainers/image-spec/).
 OCI image also can run on most of modern container runtimes.


### PR DESCRIPTION
…`ctr-remote image optimize`

Currently, there is no way for users to specify the GZIP compresssion level when optimizing their images to eStargz format, using the ctr-remote tool.

This commit adds a new flag to the 'optimize' subcommand: estargz-compression-level (similar to the flag in convert subcommand) which defaults to 9. Users can specify compression level using --estargz-compression-level <value> while optimizing the image.

Also, changes to ctr-remote.md explaining the new flag and its usage.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>