### PR TITLE
Allow users to specify a GZIP compression level during optimize

### DIFF
--- a/cmd/ctr-remote/commands/optimize.go
+++ b/cmd/ctr-remote/commands/optimize.go
@@ -17,6 +17,7 @@
 package commands
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -77,6 +78,11 @@ var OptimizeCommand = cli.Command{
 			Name:  "oci",
 			Usage: "convert Docker media types to OCI media types",
 		},
+		cli.IntFlag{
+			Name:  "estargz-compression-level",
+			Usage: "eStargz compression level",
+			Value: gzip.BestCompression,
+		},
 	}, samplerFlags...),
 	Action: func(clicontext *cli.Context) error {
 		convertOpts := []converter.Opt{}
@@ -129,7 +135,10 @@ var OptimizeCommand = cli.Command{
 				return errors.Wrapf(err, "failed output record file")
 			}
 		}
-		f := estargzconvert.LayerConvertWithLayerOptsFunc(esgzOptsPerLayer)
+
+		compLevel := clicontext.Int("estargz-compression-level")
+
+		f := estargzconvert.LayerConvertWithLayerAndCommonOptsFunc(esgzOptsPerLayer, estargz.WithCompressionLevel(compLevel))
 		if wrapper != nil {
 			f = wrapper(f)
 		}

--- a/docs/ctr-remote.md
+++ b/docs/ctr-remote.md
@@ -56,6 +56,16 @@ ctr-remote image push --plain-http registry2:5000/golang:1.15.3-esgz
 When you run `ctr-remote image optimize`, this runs the source image (`ghcr.io/stargz-containers/golang:1.15.3-buster-org`) as a container and profiles all file accesses during the execution.
 Then these accessed files are marked as "prioritized" files and will be prefetched on runtime.
 
+You can specify the GZIP compression level the converter should use using the `--estargz-compression-level` flag. The values range from 1-9. If the flag isn't provided, the compression level will default to 9.
+
+A value of 9 indicates the archive will be gzipped with max compression. This will reduce the bytes transferred over the network but increase the CPU cycles required to decompress the payload. Whereas gzip compression value 1 indicates archive will be gzipped with least compression. This will increase the bytes transferred over the network but decreases the CPU cycles required to decompress the payload. This value should be chosen based on the workload and host characteristics.
+
+The following example optimizes an image with a compression level of 1.
+
+```console
+# ctr-remote image optimize --oci --estargz-compression-level 1 ghcr.io/stargz-containers/golang:1.15.3-buster-org registry2:5000/golang:1.15.3-esgz
+```
+
 `--oci` option is highly recommended to add when you create eStargz image.
 If the source image is [Docker image](https://github.com/moby/moby/blob/master/image/spec/v1.2.md) that doesn't allow us [content verification of eStargz](/docs/verification.md), `ctr-remote` converts this image into the [OCI starndard compliant image](https://github.com/opencontainers/image-spec/).
 OCI image also can run on most of modern container runtimes.

--- a/nativeconverter/estargz/estargz.go
+++ b/nativeconverter/estargz/estargz.go
@@ -38,14 +38,14 @@ import (
 // Media type is unchanged. Should be used in conjunction with WithDockerToOCI(). See
 // LayerConvertFunc for more details. The difference between this function and
 // LayerConvertFunc is that this allows to specify additional eStargz options per layer.
-func LayerConvertWithLayerOptsFunc(opts map[digest.Digest][]estargz.Option) converter.ConvertFunc {
+func LayerConvertWithLayerAndCommonOptsFunc(opts map[digest.Digest][]estargz.Option, commonOpts ...estargz.Option) converter.ConvertFunc {
 	if opts == nil {
-		return LayerConvertFunc()
+		return LayerConvertFunc(commonOpts...)
 	}
 	return func(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (*ocispec.Descriptor, error) {
 		// TODO: enable to speciy option per layer "index" because it's possible that there are
 		//       two layers having same digest in an image (but this should be rare case)
-		return LayerConvertFunc(opts[desc.Digest]...)(ctx, cs, desc)
+		return LayerConvertFunc(append(commonOpts, opts[desc.Digest]...)...)(ctx, cs, desc)
 	}
 }
 


### PR DESCRIPTION
Currently, there is no way for users to specify the GZIP compresssion level when optimizing their images to eStargz format, using the ctr-remote tool.

This commit adds a new flag to the 'optimize' subcommand: estargz-compression-level (similar to the flag in convert subcommand) which defaults to 9. Users can specify compression level using --estargz-compression-level <value> while optimizing the image.

Also, changes to ctr-remote.md explaining the new flag and its usage.

Updated code with suggested changes in https://github.com/containerd/stargz-snapshotter/issues/366#issuecomment-878375257. 