### PR TITLE
Add `direct` field for cache configuration in config.toml

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -66,4 +66,5 @@ type DirectoryCacheConfig struct {
 	MaxLRUCacheEntry int  `toml:"max_lru_cache_entry"`
 	MaxCacheFds      int  `toml:"max_cache_fds"`
 	SyncAdd          bool `toml:"sync_add"`
+	Direct           bool `toml:"direct"`
 }

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -209,6 +209,7 @@ func newCache(root string, cacheType string, cfg config.Config) (cache.BlobCache
 			DataCache: dCache,
 			FdCache:   fCache,
 			BufPool:   bufPool,
+			Direct:    dcc.Direct,
 		},
 	)
 }


### PR DESCRIPTION
This commit adds `direct=true/false` to the cache configuration of config.toml.
When it's true, cache always works in "direct" mode that doesn't hold data in memory buffers.

```toml
[directory_cache]
direct = true
```

Can be used to avoid #369.

cc @rdpsin