### PR TITLE
Prepare for v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/containerd/containerd v1.5.3
 	github.com/containerd/continuity v0.1.0
 	github.com/containerd/go-cni v1.0.2
-	github.com/containerd/stargz-snapshotter/estargz v0.6.4
+	github.com/containerd/stargz-snapshotter/estargz v0.7.0
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/cli v20.10.7+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect


### PR DESCRIPTION
```
## Notable Changes

- Stargz Snapshotter(`containred-stargz-grpc`)
  - Allow users to manually set the fetcher to use single range mode (#350), thanks @rdpsin
  - Adds new latency metrics (mount, readdir, registry access) and skeleton for additional ones (#358), thanks @vkuzniet
  - Enable to configure `direct` mode of cache through config.toml (#372)

- `ctr-remote`
  -  Add env-file option to the optimize command (#345), thanks @mc256
  -  Allow users to specify a GZIP compression level during optimize (#368), thanks @rdpsin

- docs
  -  Fix a link of OCI Distribution Spec (#338) thanks @knqyf263
  -  Fix broken link in docs/overview.md (#362) thanks @IRCody
  -  Promote `--oci` option for ctr-remote (#339)
```