### PR TITLE
dockerconfig: Add support for creds rotation to docker store

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -196,6 +196,7 @@ func (tr *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// TODO: support more status codes and retries
 	if resp.StatusCode == http.StatusUnauthorized {
+		log.G(ctx).Infof("Received status code: %v. Refreshing creds...", resp.Status)
 
 		// prepare authorization for the target host using docker.Authorizer
 		if err := tr.auth.AddResponses(ctx, []*http.Response{resp}); err != nil {

--- a/service/keychain/dockerconfig/dockerconfig.go
+++ b/service/keychain/dockerconfig/dockerconfig.go
@@ -26,14 +26,13 @@ import (
 )
 
 func NewDockerconfigKeychain(ctx context.Context) resolver.Credential {
-	cf, err := config.Load("")
-	if err != nil {
-		log.G(ctx).WithError(err).Warnf("failed to load docker config file")
-		return func(string, reference.Spec) (string, string, error) {
+	return func(host string, refspec reference.Spec) (string, string, error) {
+		cf, err := config.Load("")
+		if err != nil {
+			log.G(ctx).WithError(err).Warnf("failed to load docker config file")
 			return "", "", nil
 		}
-	}
-	return func(host string, refspec reference.Spec) (string, string, error) {
+
 		if host == "docker.io" || host == "registry-1.docker.io" {
 			// Creds of docker.io is stored keyed by "https://index.docker.io/v1/".
 			host = "https://index.docker.io/v1/"


### PR DESCRIPTION
stargz-snapshotter reads creds from docker store only at startup time. The
credentials stored in docker config can get periodically rotated.
If stargz-snapshotter is running for extended time on a host before an image is
launched the current mechanism fails because rotated creds are not re-read.

This patch reads creds file everytime authorizer invokes the
'credentials' function and handles cred rotation.

Signed-off-by: Sumeet Bhatia <sumee@amazon.com>