### PR TITLE
Make fuse timeout values configurable

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -52,6 +52,8 @@ type Config struct {
 
 	// DirectoryCacheConfig is config for directory-based cache.
 	DirectoryCacheConfig `toml:"directory_cache"`
+
+	FuseConfig `toml:"fuse"`
 }
 
 type BlobConfig struct {
@@ -67,4 +69,12 @@ type DirectoryCacheConfig struct {
 	MaxCacheFds      int  `toml:"max_cache_fds"`
 	SyncAdd          bool `toml:"sync_add"`
 	Direct           bool `toml:"direct"`
+}
+
+type FuseConfig struct {
+	// AttrTimeout defines overall timeout attribute for a file system in seconds.
+	AttrTimeout int64 `toml:"attr_timeout"`
+
+	// EntryTimeout defines TTL for directory, name lookup in seconds.
+	EntryTimeout int64 `toml:"entry_timeout"`
 }


### PR DESCRIPTION
stargz-snapshotter currently sets fuse timeout values to one second. Container
images are immutable and hence some applications may want to set higher
timeout values.

This patch makes the timeout values configurable.

Signed-off-by: Sumeet Bhatia <sumee@amazon.com>