### PR TITLE
Add image launch metrics

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -325,6 +325,8 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[s
 	fs.backgroundTaskManager.DoPrioritizedTask()
 	defer fs.backgroundTaskManager.DonePrioritizedTask()
 
+	defer commonmetrics.MeasureLatency(commonmetrics.PrefetchesCompleted, digest.FromString(""), time.Now()) // measuring the time the container launch is blocked on prefetch to complete
+
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("mountpoint", mountpoint))
 
 	fs.layerMu.Lock()

--- a/fs/layer/layer_test.go
+++ b/fs/layer/layer_test.go
@@ -115,7 +115,9 @@ func TestPrefetch(t *testing.T) {
 			}
 			blob := newBlob(sr)
 			mcache := cache.NewMemoryCache()
-			vr, err := reader.NewReader(sr, mcache)
+			// define telemetry hooks to measure latency metrics inside estargz package
+			telemetry := estargz.Telemetry{}
+			vr, err := reader.NewReader(sr, mcache, &telemetry)
 			if err != nil {
 				t.Fatalf("failed to make stargz reader: %v", err)
 			}

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -35,9 +35,14 @@ const (
 
 // Lists all metric labels.
 const (
-	Mount             = "mount"
-	RemoteRegistryGet = "remote_registry_get"
-	NodeReaddir       = "node_readdir"
+	Mount               = "mount"
+	RemoteRegistryGet   = "remote_registry_get"
+	NodeReaddir         = "node_readdir"
+	StargzHeaderGet     = "stargz_header_get"
+	StargzFooterGet     = "stargz_footer_get"
+	StargzTocGet        = "stargz_toc_get"
+	DeserializeTocJSON  = "stargz_toc_json_deserialize"
+	PrefetchesCompleted = "all_prefetches_completed"
 )
 
 var (
@@ -77,6 +82,8 @@ func Register() {
 // Wraps the labels attachment as well as calling Observe into a single method.
 // Right now we attach the operation and layer sha, so it's possible to see the breakdown for latency
 // by operation and individual layers.
+// If you want this to be layer agnostic, just pass the digest from empty string, e.g.
+// layerDigest := digest.FromString("")
 func MeasureLatency(operation string, layer digest.Digest, start time.Time) {
 	operationLatency.WithLabelValues(operation, layer.String()).Observe(sinceInMilliseconds(start))
 }

--- a/fs/metrics/layer/layer.go
+++ b/fs/metrics/layer/layer.go
@@ -37,6 +37,19 @@ var layerMetrics = []*metric{
 		},
 	},
 	{
+		name: "layer_prefetch_size",
+		help: "Total prefetched size of the layer",
+		unit: metrics.Bytes,
+		vt:   prometheus.CounterValue,
+		getValues: func(l layer.Layer) []value {
+			return []value{
+				{
+					v: float64(l.Info().PrefetchSize),
+				},
+			}
+		},
+	},
+	{
 		name: "layer_size",
 		help: "Total size of the layer",
 		unit: metrics.Bytes,

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -326,7 +326,8 @@ func makeFile(t *testing.T, contents []byte, chunkSize int) *file {
 
 func newReader(sr *io.SectionReader, cache cache.BlobCache, ev estargz.TOCEntryVerifier) (*reader, *estargz.TOCEntry, error) {
 	var r *reader
-	vr, err := NewReader(sr, cache)
+	telemetry := &estargz.Telemetry{}
+	vr, err := NewReader(sr, cache, telemetry)
 	if vr != nil {
 		r = vr.r
 		r.verifier = ev

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -151,7 +151,9 @@ func newFetcher(ctx context.Context, hosts source.RegistryHosts, refspec referen
 
 		// Get size information
 		// TODO: we should try to use the Size field in the descriptor here.
+		start := time.Now() // start time before getting layer header
 		size, err := getSize(ctx, url, tr, timeout)
+		commonmetrics.MeasureLatency(commonmetrics.StargzHeaderGet, digest, start) // time to get layer header
 		if err != nil {
 			rErr = errors.Wrapf(rErr, "failed to get size (host %q, ref:%q, digest:%q): %v",
 				host.Host, refspec, digest, err)

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -264,7 +264,6 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 			return nil, err
 		}
 	}
-
 	return o.mounts(ctx, s, parent)
 }
 


### PR DESCRIPTION
This PR adds the metrics for container image launch.
The list of metrics is as follows: 

- Prefetch bytes per layer 
- GET latency for stargz header 
- GET latency for stargz footer 
- GET latency for stargz TOC 
- Latency to deserialize json TOC 
- Total time container launch is blocked on prefetch complete

Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>