### PR TITLE
Allow users to configure prefetch chunk size

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -57,11 +57,18 @@ type Config struct {
 }
 
 type BlobConfig struct {
-	ValidInterval        int64 `toml:"valid_interval"`
-	CheckAlways          bool  `toml:"check_always"`
+	ValidInterval int64 `toml:"valid_interval"`
+	CheckAlways   bool  `toml:"check_always"`
+	// ChunkSize is the granularity at which background fetch and on-demand reads
+	// are fetched from the remote registry.
 	ChunkSize            int64 `toml:"chunk_size"`
 	FetchTimeoutSec      int64 `toml:"fetching_timeout_sec"`
 	ForceSingleRangeMode bool  `toml:"force_single_range_mode"`
+	// PrefetchChunkSize is the maximum bytes transferred per http GET from remote registry
+	// during prefetch. It is recommended to have PrefetchChunkSize > ChunkSize.
+	// If PrefetchChunkSize < ChunkSize prefetch bytes will be fetched as a single http GET,
+	// else total GET requests for prefetch = ceil(PrefetchSize / PrefetchChunkSize).
+	PrefetchChunkSize int64 `toml:"prefetch_chunk_size"`
 }
 
 type DirectoryCacheConfig struct {

--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/stargz-snapshotter/fs/source"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 var contentRangeRegexp = regexp.MustCompile(`bytes ([0-9]+)-([0-9]+)/([0-9]+|\\*)`)
@@ -54,13 +55,14 @@ type blob struct {
 	fetcher   *fetcher
 	fetcherMu sync.Mutex
 
-	size          int64
-	chunkSize     int64
-	cache         cache.BlobCache
-	lastCheck     time.Time
-	lastCheckMu   sync.Mutex
-	checkInterval time.Duration
-	fetchTimeout  time.Duration
+	size              int64
+	chunkSize         int64
+	prefetchChunkSize int64
+	cache             cache.BlobCache
+	lastCheck         time.Time
+	lastCheckMu       sync.Mutex
+	checkInterval     time.Duration
+	fetchTimeout      time.Duration
 
 	fetchedRegionSet   regionSet
 	fetchedRegionSetMu sync.Mutex
@@ -151,6 +153,24 @@ func (b *blob) FetchedSize() int64 {
 	return sz
 }
 
+func (b *blob) cacheAt(offset int64, size int64, fr *fetcher, cacheOpts *options) error {
+	fetchReg := region{floor(offset, b.chunkSize), ceil(offset+size-1, b.chunkSize) - 1}
+	discard := make(map[region]io.Writer)
+
+	err := b.walkChunks(fetchReg, func(reg region) error {
+		if r, err := b.cache.Get(fr.genID(reg), cacheOpts.cacheOpts...); err == nil {
+			return r.Close() // nop if the cache hits
+		}
+		discard[reg] = ioutil.Discard
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return b.fetchRange(discard, cacheOpts)
+}
+
 func (b *blob) Cache(offset int64, size int64, opts ...Option) error {
 	if b.isClosed() {
 		return fmt.Errorf("blob is already closed")
@@ -165,20 +185,26 @@ func (b *blob) Cache(offset int64, size int64, opts ...Option) error {
 	fr := b.fetcher
 	b.fetcherMu.Unlock()
 
-	fetchReg := region{floor(offset, b.chunkSize), ceil(offset+size-1, b.chunkSize) - 1}
-	discard := make(map[region]io.Writer)
-	err := b.walkChunks(fetchReg, func(reg region) error {
-		if r, err := b.cache.Get(fr.genID(reg), cacheOpts.cacheOpts...); err == nil {
-			return r.Close() // nop if the cache hits
-		}
-		discard[reg] = ioutil.Discard
-		return nil
-	})
-	if err != nil {
-		return err
+	if b.prefetchChunkSize <= b.chunkSize {
+		return b.cacheAt(offset, size, fr, &cacheOpts)
 	}
 
-	return b.fetchRange(discard, &cacheOpts)
+	eg, _ := errgroup.WithContext(context.Background())
+
+	fetchSize := b.chunkSize * (b.prefetchChunkSize / b.chunkSize)
+
+	end := offset + size
+	for i := offset; i < end; i += fetchSize {
+		i, l := i, fetchSize
+		if i+l > end {
+			l = end - i
+		}
+		eg.Go(func() error {
+			return b.cacheAt(i, l, fr, &cacheOpts)
+		})
+	}
+
+	return eg.Wait()
 }
 
 // ReadAt reads remote chunks from specified offset for the buffer size.

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -90,14 +90,15 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 		fetcher.singleRangeMode()
 	}
 	return &blob{
-		fetcher:       fetcher,
-		size:          size,
-		chunkSize:     r.blobConfig.ChunkSize,
-		cache:         blobCache,
-		lastCheck:     time.Now(),
-		checkInterval: time.Duration(r.blobConfig.ValidInterval) * time.Second,
-		resolver:      r,
-		fetchTimeout:  time.Duration(r.blobConfig.FetchTimeoutSec) * time.Second,
+		fetcher:           fetcher,
+		size:              size,
+		chunkSize:         r.blobConfig.ChunkSize,
+		prefetchChunkSize: r.blobConfig.PrefetchChunkSize,
+		cache:             blobCache,
+		lastCheck:         time.Now(),
+		checkInterval:     time.Duration(r.blobConfig.ValidInterval) * time.Second,
+		resolver:          r,
+		fetchTimeout:      time.Duration(r.blobConfig.FetchTimeoutSec) * time.Second,
 	}, nil
 }
 


### PR DESCRIPTION
stargz-snapshotter fetches entire prefetch range using a single HTTP GET request.
This reduces number of requests to remote registry. However some registries give
better throughput with multiple concurrent requests rather than a single GET request.

This patch adds a configurable parameter to enable users to decide the optimal
prefetch chunk size for their registries.

Signed-off-by: Sumeet Bhatia <sumee@amazon.com>