### PR TITLE
Add lazy loading metrics

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -301,6 +301,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 				log.G(ctx).WithError(err).Warnf("failed to fetch whole layer=%v", digest)
 				return
 			}
+			commonmetrics.LogLatencyForLastOnDemandFetch(ctx, digest, start, l.Info().ReadTime) // write log record for the latency between mount start and last on demand fetch
 			log.G(ctx).Debug("completed to fetch all layer data in background")
 		}()
 	}

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -65,11 +65,13 @@ type breakableLayer struct {
 	success bool
 }
 
-func (l *breakableLayer) Info() layer.Info                                    { return layer.Info{} }
-func (l *breakableLayer) RootNode() (fusefs.InodeEmbedder, error)             { return nil, nil }
-func (l *breakableLayer) Verify(tocDigest digest.Digest) error                { return nil }
-func (l *breakableLayer) SkipVerify()                                         {}
-func (l *breakableLayer) Prefetch(prefetchSize int64) error                   { return fmt.Errorf("fail") }
+func (l *breakableLayer) Info() layer.Info                        { return layer.Info{} }
+func (l *breakableLayer) RootNode() (fusefs.InodeEmbedder, error) { return nil, nil }
+func (l *breakableLayer) Verify(tocDigest digest.Digest) error    { return nil }
+func (l *breakableLayer) SkipVerify()                             {}
+func (l *breakableLayer) Prefetch(prefetchSize int64) error {
+	return fmt.Errorf("fail")
+}
 func (l *breakableLayer) ReadAt([]byte, int64, ...remote.Option) (int, error) { return 0, nil }
 func (l *breakableLayer) WaitForPrefetchCompletion() error                    { return fmt.Errorf("fail") }
 func (l *breakableLayer) BackgroundFetch() error                              { return fmt.Errorf("fail") }

--- a/fs/layer/layer_test.go
+++ b/fs/layer/layer_test.go
@@ -117,7 +117,7 @@ func TestPrefetch(t *testing.T) {
 			mcache := cache.NewMemoryCache()
 			// define telemetry hooks to measure latency metrics inside estargz package
 			telemetry := estargz.Telemetry{}
-			vr, err := reader.NewReader(sr, mcache, &telemetry)
+			vr, err := reader.NewReader(sr, mcache, testStateLayerDigest, &telemetry)
 			if err != nil {
 				t.Fatalf("failed to make stargz reader: %v", err)
 			}

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -269,6 +269,8 @@ type file struct {
 var _ = (fusefs.FileReader)((*file)(nil))
 
 func (f *file) Read(ctx context.Context, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
+	defer commonmetrics.MeasureLatency(commonmetrics.ReadOnDemand, f.n.layerSha, time.Now())   // measure time for on-demand file reads (in milliseconds)
+	defer commonmetrics.IncOperationCount(commonmetrics.OnDemandReadAccessCount, f.n.layerSha) // increment the counter for on-demand file accesses
 	n, err := f.ra.ReadAt(dest, off)
 	if err != nil && err != io.EOF {
 		f.n.s.report(fmt.Errorf("failed to read node: %v", err))

--- a/fs/layer/node_test.go
+++ b/fs/layer/node_test.go
@@ -324,6 +324,7 @@ func (tr *testReader) OpenFile(name string) (io.ReaderAt, error)    { return tr.
 func (tr *testReader) Lookup(name string) (*estargz.TOCEntry, bool) { return tr.r.Lookup(name) }
 func (tr *testReader) Cache(opts ...reader.CacheOption) error       { return nil }
 func (tr *testReader) Close() error                                 { return nil }
+func (tr *testReader) LastOnDemandReadTime() time.Time              { return time.Now() }
 
 type testBlobState struct {
 	size        int64

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -17,16 +17,24 @@
 package commonmetrics
 
 import (
+	"context"
 	"sync"
 	"time"
 
+	"github.com/containerd/containerd/log"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
-	// OperationLatencyKey is the key for stargz operation metrics.
+	// OperationLatencyKey is the key for stargz operation latency metrics.
 	OperationLatencyKey = "operation_duration"
+
+	// OperationCountKey is the key for stargz operation count metrics.
+	OperationCountKey = "operation_count"
+
+	// BytesServedKey is the key for any metric related to counting bytes served as the part of specific operation.
+	BytesServedKey = "bytes_served"
 
 	// Keep namespace as stargz and subsystem as fs.
 	namespace = "stargz"
@@ -35,29 +43,69 @@ const (
 
 // Lists all metric labels.
 const (
-	Mount               = "mount"
-	RemoteRegistryGet   = "remote_registry_get"
-	NodeReaddir         = "node_readdir"
-	StargzHeaderGet     = "stargz_header_get"
-	StargzFooterGet     = "stargz_footer_get"
-	StargzTocGet        = "stargz_toc_get"
-	DeserializeTocJSON  = "stargz_toc_json_deserialize"
-	PrefetchesCompleted = "all_prefetches_completed"
+	// prometheus metrics
+	Mount                         = "mount"
+	RemoteRegistryGet             = "remote_registry_get"
+	NodeReaddir                   = "node_readdir"
+	StargzHeaderGet               = "stargz_header_get"
+	StargzFooterGet               = "stargz_footer_get"
+	StargzTocGet                  = "stargz_toc_get"
+	DeserializeTocJSON            = "stargz_toc_json_deserialize"
+	PrefetchesCompleted           = "all_prefetches_completed"
+	ReadOnDemand                  = "read_on_demand"
+	MountLayerToLastOnDemandFetch = "mount_layer_to_last_on_demand_fetch"
+
+	OnDemandReadAccessCount          = "on_demand_read_access_count"
+	OnDemandRemoteRegistryFetchCount = "on_demand_remote_registry_fetch_count"
+	OnDemandBytesServed              = "on_demand_bytes_served"
+	OnDemandBytesFetched             = "on_demand_bytes_fetched"
+
+	// logs metrics
+	PrefetchTotal             = "prefetch_total"
+	PrefetchDownload          = "prefetch_download"
+	PrefetchDecompress        = "prefetch_decompress"
+	BackgroundFetchTotal      = "background_fetch_total"
+	BackgroundFetchDownload   = "background_fetch_download"
+	BackgroundFetchDecompress = "background_fetch_decompress"
+	PrefetchSize              = "prefetch_size"
 )
 
 var (
 	// Buckets for OperationLatency metric in milliseconds.
 	latencyBuckets = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384} // in milliseconds
 
-	// OperationLatency collects operation latency numbers by operation
-	// type.
+	// operationLatency collects operation latency numbers by operation
+	// type and layer digest.
 	operationLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      OperationLatencyKey,
-			Help:      "Latency in milliseconds of stargz snapshotter operations. Broken down by operation type.",
+			Help:      "Latency in milliseconds of stargz snapshotter operations. Broken down by operation type and layer sha.",
 			Buckets:   latencyBuckets,
+		},
+		[]string{"operation_type", "layer"},
+	)
+
+	// operationCount collects operation count numbers by operation
+	// type and layer sha.
+	operationCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      OperationCountKey,
+			Help:      "The count of stargz snapshotter operations. Broken down by operation type and layer sha.",
+		},
+		[]string{"operation_type", "layer"},
+	)
+
+	// bytesCount reflects the number of bytes served as the part of specitic operation type per layer sha.
+	bytesCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      BytesServedKey,
+			Help:      "The number of bytes served per stargz snapshotter operations. Broken down by operation type and layer sha.",
 		},
 		[]string{"operation_type", "layer"},
 	)
@@ -72,18 +120,61 @@ func sinceInMilliseconds(start time.Time) float64 {
 	return float64(time.Since(start).Nanoseconds()) / 1e6
 }
 
-// Register metrics. This is always called only once.
+// Register registers metrics. This is always called only once.
 func Register() {
 	register.Do(func() {
 		prometheus.MustRegister(operationLatency)
+		prometheus.MustRegister(operationCount)
+		prometheus.MustRegister(bytesCount)
 	})
 }
 
-// Wraps the labels attachment as well as calling Observe into a single method.
-// Right now we attach the operation and layer sha, so it's possible to see the breakdown for latency
+// MeasureLatency wraps the labels attachment as well as calling Observe into a single method.
+// Right now we attach the operation and layer digest, so it's possible to see the breakdown for latency
 // by operation and individual layers.
 // If you want this to be layer agnostic, just pass the digest from empty string, e.g.
 // layerDigest := digest.FromString("")
 func MeasureLatency(operation string, layer digest.Digest, start time.Time) {
 	operationLatency.WithLabelValues(operation, layer.String()).Observe(sinceInMilliseconds(start))
+}
+
+// IncOperationCount wraps the labels attachment as well as calling Inc into a single method.
+func IncOperationCount(operation string, layer digest.Digest) {
+	operationCount.WithLabelValues(operation, layer.String()).Inc()
+}
+
+// AddBytesCount wraps the labels attachment as well as calling Add into a single method.
+func AddBytesCount(operation string, layer digest.Digest, bytes int64) {
+	bytesCount.WithLabelValues(operation, layer.String()).Add(float64(bytes))
+}
+
+// WriteLatencyLogValue wraps writing the log info record for latency in milliseconds. The log record breaks down by operation and layer digest.
+func WriteLatencyLogValue(ctx context.Context, layer digest.Digest, operation string, start time.Time) {
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField("metrics", "latency").WithField("operation", operation).WithField("layer_sha", layer.String()))
+	log.G(ctx).Infof("value=%v milliseconds", sinceInMilliseconds(start))
+}
+
+// WriteLatencyWithBytesLogValue wraps writing the log info record for latency in milliseconds with adding the size in bytes.
+// The log record breaks down by operation, layer digest and byte value.
+func WriteLatencyWithBytesLogValue(ctx context.Context, layer digest.Digest, latencyOperation string, start time.Time, bytesMetricName string, bytesMetricValue int64) {
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField("metrics", "latency").WithField("operation", latencyOperation).WithField("layer_sha", layer.String()))
+	log.G(ctx).Infof("value=%v milliseconds; %v=%v bytes", sinceInMilliseconds(start), bytesMetricName, bytesMetricValue)
+}
+
+// LogLatencyForLastOnDemandFetch implements a special case for measuring the latency of last on demand fetch, which must be invoked at the end of
+// background fetch operation only. Since this is expected to happen only once per container launch, it writes a log line,
+// instead of directly emitting a metric.
+// We do that in the following way:
+// 1. We record the mount start time
+// 2. We constantly record the timestamps when we do on demand fetch for each layer sha
+// 3. On background fetch completed we measure the difference between the last on demand fetch and mount start time
+// and record it as a metric
+func LogLatencyForLastOnDemandFetch(ctx context.Context, layer digest.Digest, start time.Time, end time.Time) {
+	diffInMilliseconds := float64(end.Sub(start).Milliseconds())
+	// value can be negative if we pass the default value for time.Time as `end`
+	// this can happen if there were no on-demand fetch for the particular layer
+	if diffInMilliseconds > 0 {
+		ctx = log.WithLogger(ctx, log.G(ctx).WithField("metrics", "latency").WithField("operation", MountLayerToLastOnDemandFetch).WithField("layer_sha", layer.String()))
+		log.G(ctx).Infof("value=%v milliseconds", diffInMilliseconds)
+	}
 }

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -327,7 +327,7 @@ func makeFile(t *testing.T, contents []byte, chunkSize int) *file {
 func newReader(sr *io.SectionReader, cache cache.BlobCache, ev estargz.TOCEntryVerifier) (*reader, *estargz.TOCEntry, error) {
 	var r *reader
 	telemetry := &estargz.Telemetry{}
-	vr, err := NewReader(sr, cache, telemetry)
+	vr, err := NewReader(sr, cache, digest.FromString(""), telemetry)
 	if vr != nil {
 		r = vr.r
 		r.verifier = ev


### PR DESCRIPTION
This PR adds the following metrics:
    
- Time to download prefetch data
- Time to decompress prefetch data
- Total time to complete prefetch
- Time to download background fetch data
- Time to decompress background fetch data
- Total time to complete background fetch
- Request latency for on-demand reads
- Number of on-demand file access
- Number of on-demand file fetches from remote registry
- Total on-demand bytes served
- Total on-demand bytes fetched from the remote registry
- Latency between mounting a layer and last on-demand fetch for that layer

I added a few metrics as logs, since they represent once per image launch events (prefetch, background fetch decompress and total time, latency between mounting a layer and last on-demand fetch for that layer).

Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>