### PR TITLE
Upgrade golangci-lint from v1.39.0 to v1.42.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
     - unconvert
     - gofmt
     - goimports
-    - golint
+    - revive
     - ineffassign
     - vet
     - unused

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ stargz-store: FORCE
 
 check:
 	@echo "$@"
-	@GO111MODULE=$(GO111MODULE_VALUE) golangci-lint run
-	@cd ./estargz ; GO111MODULE=$(GO111MODULE_VALUE) golangci-lint run
+	@GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
+	@cd ./estargz ; GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
 
 install-check-tools:
-	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.39.0
+	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.39.0
 
 install:
 	@echo "$@"

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ check:
 	@cd ./estargz ; GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
 
 install-check-tools:
-	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.39.0
+	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.42.0
 
 install:
 	@echo "$@"


### PR DESCRIPTION
The first commit is fixing Makefile. The second commit is actually upgrading golangci-lint.