### PR TITLE
Add /debug/ endpoints to expose diagnostic information

### DIFF
--- a/cmd/containerd-stargz-grpc/server.go
+++ b/cmd/containerd-stargz-grpc/server.go
@@ -1,0 +1,34 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"expvar"
+	"net/http"
+	"net/http/pprof"
+)
+
+func debugServerMux() *http.ServeMux {
+	m := http.NewServeMux()
+	m.Handle("/debug/vars", expvar.Handler())
+	m.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	m.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	m.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	m.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	m.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+	return m
+}


### PR DESCRIPTION
As like containerd, this change adds a few /debug/ endpoints. They can
be used from `ctr pprof` command.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>