### PR TITLE
Prepare for v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/containerd/containerd v1.5.5
 	github.com/containerd/continuity v0.1.0
 	github.com/containerd/go-cni v1.0.2
-	github.com/containerd/stargz-snapshotter/estargz v0.7.0
+	github.com/containerd/stargz-snapshotter/estargz v0.8.0
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/cli v20.10.8+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect


### PR DESCRIPTION
Release note:

```
This release includes [zstd:chunked](https://github.com/containers/storage/pull/775) support, improvements on log/metrics/config of Stargz Snapshotter/Store, new NW/GPU options for ctr-remote optimizer and bugfixes.

## Notable Changes

- estargz
  - Made estargz compression-algorithm-agnostic and added support for opening/creating [zstd:chunked](https://github.com/containers/storage/pull/775) (#293)

- Stargz Store
  - Enabled to release resources when no reference to a layer (#433)

- Stargz Snapshotter
  - Enabled lazy pulling of [zstd:chunked](https://github.com/containers/storage/pull/775) (#293)
  - Added more log lines (#394), thanks to @iamsumee
  - Added support for creds rotation to docker store (#406), thanks to @iamsumee
  - Made fuse timeout values configurable (#407), thanks to @iamsumee
  - Enabled users to configure prefetch chunk size (#409), thanks to @iamsumee
  - Added image launch metrics (#408), thanks to @vkuzniet
  - Added lazy loading metrics (#418), thanks to @vkuzniet
  - Added /debug/ endpoints to expose diagnostic information (#429), thanks to @kzys
  - Fixed a race bug in task manager (#430), thanks to @rdpsin

- `ctr-remote`
  - Added `--gpus` and `--net-host` option (#382), thanks to @rdpsin
  - Added helpful message whenever optimize period expires (#419), thanks to @rdpsin

- docs
  - Added docs about prebuilt kind node image (#387)
  - Added a link to estargz.kontain.me (#388)

- CI
  - Upgraded golangci-lint to v1.42.0 (#427), thanks to @kzys

```