### PR TITLE
Reduce required environment variables on "make benchmark"

### DIFF
--- a/script/benchmark/test.sh
+++ b/script/benchmark/test.sh
@@ -19,10 +19,21 @@ set -euo pipefail
 CONTEXT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/"
 REPO="${CONTEXT}../../"
 
+# This project's Dockerfile doesn't work without BuildKit.
+export DOCKER_BUILDKIT=1
+
+BENCHMARK_TARGETS="${BENCHMARK_TARGETS:-}"
+if [[ -z "$BENCHMARK_TARGETS" ]]; then
+  echo "BENCHMARK_TARGETS must be specified."
+  exit 1
+fi
+
 BENCHMARKING_BASE_IMAGE_NAME="benchmark-image-base"
 BENCHMARKING_NODE_IMAGE_NAME="benchmark-image-test"
 BENCHMARKING_NODE=hello-bench
 BENCHMARKING_CONTAINER=hello-bench-container
+BENCHMARK_USER=${BENCHMARK_USER:-stargz-containers}
+export BENCHMARK_RUNTIME_MODE=${BENCHMARK_RUNTIME_MODE:-containerd}
 
 BENCHMARKING_TARGET_BASE_IMAGE=
 BENCHMARKING_TARGET_CONFIG_DIR=
@@ -129,7 +140,7 @@ if ! ( cd "${CONTEXT}" && \
            docker exec -e BENCHMARK_RUNTIME_MODE -e BENCHMARK_SAMPLES_NUM \
                   -i "${BENCHMARKING_CONTAINER}" \
                   script/benchmark/hello-bench/run.sh \
-                  "${BENCHMARK_REGISTRY:-docker.io}/${BENCHMARK_USER}" \
+                  "${BENCHMARK_REGISTRY:-ghcr.io}/${BENCHMARK_USER}" \
                   ${BENCHMARK_TARGETS} &> "${LOG_FILE}" ) ; then
     echo "Failed to run benchmark."
     FAIL=true

--- a/script/benchmark/tools/percentiles.sh
+++ b/script/benchmark/tools/percentiles.sh
@@ -40,9 +40,9 @@ if [ ${#IMAGES[@]} -eq 0 ] ; then
     IMAGES=( $(cat "${JSON}" | jq -r '[ .[] | select(.mode=="'${MODES[0]}'").repo ] | unique[]') )
 fi
 
-GRANULARITY="${BENCHMARK_PERCENTILES_GRANULARITY}"
+GRANULARITY="${BENCHMARK_PERCENTILES_GRANULARITY:-}"
 if [ "${GRANULARITY}" == "" ] ; then
-    GRANULARITY="0.1"
+    GRANULARITY="10"
 fi
 
 # Ensure we use the exact same number of samples among benchmarks


### PR DESCRIPTION
"make benchmark" needs multiple environment variables to be set
correctly.

~This change makes some of them optional. The rest are~

The only remaining environment variable is

- BENCHMARK_TARGETS
- ~BENCHMARK_RUNTIME_MODE~
- ~DOCKER_BUILDKIT~

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>