### PR TITLE
Avoid downloading the same data from the registry multiple times

### DIFF
--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -28,6 +28,8 @@ import (
 	"io"
 	"io/ioutil"
 	"regexp"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -37,6 +39,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 )
 
 var contentRangeRegexp = regexp.MustCompile(`bytes ([0-9]+)-([0-9]+)/([0-9]+|\\*)`)
@@ -64,13 +67,31 @@ type blob struct {
 	checkInterval     time.Duration
 	fetchTimeout      time.Duration
 
-	fetchedRegionSet   regionSet
-	fetchedRegionSetMu sync.Mutex
+	fetchedRegionSet    regionSet
+	fetchedRegionSetMu  sync.Mutex
+	fetchedRegionGroup  singleflight.Group
+	fetchedRegionCopyMu sync.Mutex
 
 	resolver *Resolver
 
 	closed   bool
 	closedMu sync.Mutex
+}
+
+func makeBlob(fetcher *fetcher, size int64, chunkSize int64, prefetchChunkSize int64,
+	blobCache cache.BlobCache, lastCheck time.Time, checkInterval time.Duration,
+	r *Resolver, fetchTimeout time.Duration) *blob {
+	return &blob{
+		fetcher:           fetcher,
+		size:              size,
+		chunkSize:         chunkSize,
+		prefetchChunkSize: prefetchChunkSize,
+		cache:             blobCache,
+		lastCheck:         lastCheck,
+		checkInterval:     checkInterval,
+		resolver:          r,
+		fetchTimeout:      fetchTimeout,
+	}
 }
 
 func (b *blob) Close() error {
@@ -151,6 +172,17 @@ func (b *blob) FetchedSize() int64 {
 	sz := b.fetchedRegionSet.totalSize()
 	b.fetchedRegionSetMu.Unlock()
 	return sz
+}
+
+func makeSyncKey(allData map[region]io.Writer) string {
+	keys := make([]string, len(allData))
+	keysIndex := 0
+	for key := range allData {
+		keys[keysIndex] = fmt.Sprintf("[%d,%d]", key.b, key.e)
+		keysIndex++
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ",")
 }
 
 func (b *blob) cacheAt(offset int64, size int64, fr *fetcher, cacheOpts *options) error {
@@ -275,8 +307,9 @@ func (b *blob) ReadAt(p []byte, offset int64, opts ...Option) (int, error) {
 	return len(p), nil
 }
 
-// fetchRange fetches all specified chunks from local cache and remote blob.
-func (b *blob) fetchRange(allData map[region]io.Writer, opts *options) error {
+// fetchRegions fetches all specified chunks from remote blob and puts it in the local cache.
+// It must be called from within fetchRange and need to ensure that it is inside the singleflight `Do` operation.
+func (b *blob) fetchRegions(allData map[region]io.Writer, fetched map[region]bool, opts *options) error {
 	if len(allData) == 0 {
 		return nil
 	}
@@ -289,14 +322,15 @@ func (b *blob) fetchRange(allData map[region]io.Writer, opts *options) error {
 
 	// request missed regions
 	var req []region
-	fetched := make(map[region]bool)
 	for reg := range allData {
 		req = append(req, reg)
 		fetched[reg] = false
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), b.fetchTimeout)
 	defer cancel()
 	mr, err := fr.fetch(ctx, req, true, opts)
+
 	if err != nil {
 		return err
 	}
@@ -364,6 +398,64 @@ func (b *blob) fetchRange(allData map[region]io.Writer, opts *options) error {
 	}
 
 	return nil
+}
+
+// fetchRange fetches all specified chunks from local cache and remote blob.
+func (b *blob) fetchRange(allData map[region]io.Writer, opts *options) error {
+	if len(allData) == 0 {
+		return nil
+	}
+
+	// We build a key based on regions we need to fetch and pass it to singleflightGroup.Do(...)
+	// to block simultaneous same requests. Once the request is finished and the data is ready,
+	// all blocked callers will be unblocked and that same data will be returned by all blocked callers.
+	key := makeSyncKey(allData)
+	fetched := make(map[region]bool)
+	_, err, shared := b.fetchedRegionGroup.Do(key, func() (interface{}, error) {
+		return nil, b.fetchRegions(allData, fetched, opts)
+	})
+
+	// When unblocked try to read from cache in case if there were no errors
+	// If we fail reading from cache, fetch from remote registry again
+	if err == nil && shared {
+		for reg := range allData {
+			if _, ok := fetched[reg]; ok {
+				continue
+			}
+			err = b.walkChunks(reg, func(chunk region) error {
+				b.fetcherMu.Lock()
+				fr := b.fetcher
+				b.fetcherMu.Unlock()
+
+				// Check if the content exists in the cache
+				// And if exists, read from cache
+				r, err := b.cache.Get(fr.genID(chunk), opts.cacheOpts...)
+				if err != nil {
+					return err
+				}
+				defer r.Close()
+				rr := io.NewSectionReader(r, 0, chunk.size())
+
+				// Copy the target chunk
+				b.fetchedRegionCopyMu.Lock()
+				defer b.fetchedRegionCopyMu.Unlock()
+				if _, err := io.CopyN(allData[chunk], rr, chunk.size()); err != nil {
+					return err
+				}
+				return nil
+			})
+			if err != nil {
+				break
+			}
+		}
+
+		// if we cannot read the data from cache, do fetch again
+		if err != nil {
+			return b.fetchRange(allData, opts)
+		}
+	}
+
+	return err
 }
 
 type walkFunc func(reg region) error

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -89,17 +89,16 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 	if r.blobConfig.ForceSingleRangeMode {
 		fetcher.singleRangeMode()
 	}
-	return &blob{
-		fetcher:           fetcher,
-		size:              size,
-		chunkSize:         r.blobConfig.ChunkSize,
-		prefetchChunkSize: r.blobConfig.PrefetchChunkSize,
-		cache:             blobCache,
-		lastCheck:         time.Now(),
-		checkInterval:     time.Duration(r.blobConfig.ValidInterval) * time.Second,
-		resolver:          r,
-		fetchTimeout:      time.Duration(r.blobConfig.FetchTimeoutSec) * time.Second,
-	}, nil
+
+	return makeBlob(fetcher,
+		size,
+		r.blobConfig.ChunkSize,
+		r.blobConfig.PrefetchChunkSize,
+		blobCache,
+		time.Now(),
+		time.Duration(r.blobConfig.ValidInterval)*time.Second,
+		r,
+		time.Duration(r.blobConfig.FetchTimeoutSec)*time.Second), nil
 }
 
 func newFetcher(ctx context.Context, hosts source.RegistryHosts, refspec reference.Spec, desc ocispec.Descriptor) (*fetcher, int64, error) {


### PR DESCRIPTION
stargz snapshotter does not have the mechanism to prevent downloading the same data (or overlapping data) from the registry multiple times. This leads to waste of network bandwidth as it ends up fetching the same bytes multiple times.
Following log lines record the fact that this is happening (the logs were added to `fetchRange` function in `fs/remote/blob.go` and are not the part of this PR):
`
time="2021-08-09T22:33:27.134794144Z" level=debug msg="request header=map[Accept-Encoding:[identity] Range:[bytes=167772160-168820735]] layer=sha256:8ea1027575e92df4962031bccc31de8d8ee052960a50b7649a1f964c50bef79c."
time="2021-08-09T22:33:27.135094521Z" level=debug msg="request header=map[Accept-Encoding:[identity] Range:[bytes=167772160-168820735]] layer=sha256:8ea1027575e92df4962031bccc31de8d8ee052960a50b7649a1f964c50bef79c."
time="2021-08-09T22:33:27.135910229Z" level=debug msg="request header=map[Accept-Encoding:[identity] Range:[bytes=167772160-168820735]] layer=sha256:8ea1027575e92df4962031bccc31de8d8ee052960a50b7649a1f964c50bef79c."
`

This PR addresses this issue.

Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>