### PR TITLE
Prepare for v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/containerd/containerd v1.5.5
 	github.com/containerd/continuity v0.2.0
 	github.com/containerd/go-cni v1.1.0
-	github.com/containerd/stargz-snapshotter/estargz v0.8.0
+	github.com/containerd/stargz-snapshotter/estargz v0.9.0
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/cli v20.10.8+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect


### PR DESCRIPTION
Release note:

```
This release comes with performance fixes of snapshotter implementation and lossless compression of eStargz.

## Notable Changes

- estargz
  - Support lossless compression (#453)
- Stargz Store
  - Add logging of statFile errors (#442), thanks to @vkuzniet
  - Reset bytes.Buffer before returning it to sync.Pool (#448), thanks to @kzys
  - Avoid downloading the same data from the registry multiple times (#446), thanks to @vkuzniet
  - Start pre/background-fetch of layers in an image simultaneously (#467)
- CI
  - Reduce required environment variables on "make benchmark" (#441), thanks to @kzys
  - Run ctr pprof against containerd-stargz-grpc in Hello Bench (#445), thanks to @kzys
  - Add test with upstream k3s (#447)
  - Add test with k3s + argo workflow (#449)
```