### PR TITLE
Add microsecond to metrics

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -275,7 +275,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 
 	// Measuring duration of Mount operation for resolved layer.
 	digest := l.Info().Digest // get layer sha
-	defer commonmetrics.MeasureLatency(commonmetrics.Mount, digest, start)
+	defer commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.Mount, digest, start)
 
 	// Register the mountpoint layer
 	fs.layerMu.Lock()
@@ -318,7 +318,7 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[s
 	fs.backgroundTaskManager.DoPrioritizedTask()
 	defer fs.backgroundTaskManager.DonePrioritizedTask()
 
-	defer commonmetrics.MeasureLatency(commonmetrics.PrefetchesCompleted, digest.FromString(""), time.Now()) // measuring the time the container launch is blocked on prefetch to complete
+	defer commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.PrefetchesCompleted, digest.FromString(""), time.Now()) // measuring the time the container launch is blocked on prefetch to complete
 
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("mountpoint", mountpoint))
 

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -280,13 +280,13 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 	// define telemetry hooks to measure latency metrics inside estargz package
 	telemetry := estargz.Telemetry{
 		GetFooterLatency: func(start time.Time) {
-			commonmetrics.MeasureLatency(commonmetrics.StargzFooterGet, desc.Digest, start)
+			commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.StargzFooterGet, desc.Digest, start)
 		},
 		GetTocLatency: func(start time.Time) {
-			commonmetrics.MeasureLatency(commonmetrics.StargzTocGet, desc.Digest, start)
+			commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.StargzTocGet, desc.Digest, start)
 		},
 		DeserializeTocLatency: func(start time.Time) {
-			commonmetrics.MeasureLatency(commonmetrics.DeserializeTocJSON, desc.Digest, start)
+			commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.DeserializeTocJSON, desc.Digest, start)
 		},
 	}
 	vr, err := reader.NewReader(sr, fsCache, desc.Digest, &telemetry, esgzOpts...)
@@ -530,7 +530,7 @@ func (l *layer) backgroundFetch(ctx context.Context) error {
 	br := io.NewSectionReader(readerAtFunc(func(p []byte, offset int64) (retN int, retErr error) {
 		l.resolver.backgroundTaskManager.InvokeBackgroundTask(func(ctx context.Context) {
 			// Measuring the time to download background fetch data (in milliseconds)
-			defer commonmetrics.MeasureLatency(commonmetrics.BackgroundFetchDownload, l.desc.Digest, time.Now()) // time to download background fetch data
+			defer commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.BackgroundFetchDownload, l.Info().Digest, time.Now()) // time to download background fetch data
 			retN, retErr = l.blob.ReadAt(
 				p,
 				offset,

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -89,9 +89,9 @@ var _ = (fusefs.InodeEmbedder)((*node)(nil))
 var _ = (fusefs.NodeReaddirer)((*node)(nil))
 
 func (n *node) Readdir(ctx context.Context) (fusefs.DirStream, syscall.Errno) {
-	// Measure how long node_readdir operation takes.
+	// Measure how long node_readdir operation takes (in microseconds).
 	start := time.Now() // set start time
-	defer commonmetrics.MeasureLatency(commonmetrics.NodeReaddir, n.layerSha, start)
+	defer commonmetrics.MeasureLatencyInMicroseconds(commonmetrics.NodeReaddir, n.layerSha, start)
 
 	var ents []fuse.DirEntry
 	whiteouts := map[string]*estargz.TOCEntry{}
@@ -272,8 +272,8 @@ type file struct {
 var _ = (fusefs.FileReader)((*file)(nil))
 
 func (f *file) Read(ctx context.Context, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
-	defer commonmetrics.MeasureLatency(commonmetrics.ReadOnDemand, f.n.layerSha, time.Now())   // measure time for on-demand file reads (in milliseconds)
-	defer commonmetrics.IncOperationCount(commonmetrics.OnDemandReadAccessCount, f.n.layerSha) // increment the counter for on-demand file accesses
+	defer commonmetrics.MeasureLatencyInMicroseconds(commonmetrics.ReadOnDemand, f.n.layerSha, time.Now()) // measure time for on-demand file reads (in microseconds)
+	defer commonmetrics.IncOperationCount(commonmetrics.OnDemandReadAccessCount, f.n.layerSha)             // increment the counter for on-demand file accesses
 	n, err := f.ra.ReadAt(dest, off)
 	if err != nil && err != io.EOF {
 		f.n.s.report(fmt.Errorf("failed to read node: %v", err))

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -224,7 +224,7 @@ func newFetcher(ctx context.Context, fc *fetcherConfig) (*fetcher, int64, error)
 		// TODO: we should try to use the Size field in the descriptor here.
 		start := time.Now() // start time before getting layer header
 		size, err := getSize(ctx, url, tr, timeout)
-		commonmetrics.MeasureLatency(commonmetrics.StargzHeaderGet, digest, start) // time to get layer header
+		commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.StargzHeaderGet, digest, start) // time to get layer header
 		if err != nil {
 			rErr = errors.Wrapf(rErr, "failed to get size (host %q, ref:%q, digest:%q): %v",
 				host.Host, fc.refspec, digest, err)
@@ -438,7 +438,7 @@ func (f *fetcher) fetch(ctx context.Context, rs []region, retry bool, opts *opti
 	// Recording the roundtrip latency for remote registry GET operation.
 	start := time.Now()
 	res, err := tr.RoundTrip(req) // NOT DefaultClient; don't want redirects
-	commonmetrics.MeasureLatency(commonmetrics.RemoteRegistryGet, f.digest, start)
+	commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.RemoteRegistryGet, f.digest, start)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add new measurement in microseconds for metrics.
Now using `commonmetrics.MeasureLatencyInMilliseconds(...)` for measuring in milliseconds to metrics and `commonmetrics.MeasureLatencyInMicroseconds(...)` for microsecond. As demanded, latency of`node_readdir` and `read_on_demand` now measured by microseconds.