### PR TITLE
Bump kindest/node to v1.22.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,11 +206,14 @@ RUN apt-get update && apt-get install -y iptables && \
     curl -Ls https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-${TARGETARCH:-amd64}-${CNI_PLUGINS_VERSION}.tgz | tar xzv -C /opt/cni/bin
 
 # Image which can be used as a node image for KinD (containerd with builtin snapshotter)
-FROM kindest/node:v1.22.1 AS kind-builtin-snapshotter
+FROM kindest/node:v1.22.2 AS kind-builtin-snapshotter
+# see https://medium.com/nttlabs/ubuntu-21-10-and-fedora-35-do-not-work-on-docker-20-10-9-1cd439d9921
+ADD https://github.com/AkihiroSuda/clone3-workaround/releases/download/v1.0.0/clone3-workaround.x86_64 /clone3-workaround
+RUN chmod 755 /clone3-workaround
 COPY --from=containerd-snapshotter-dev /out/bin/containerd /out/bin/containerd-shim-runc-v2 /usr/local/bin/
 COPY --from=snapshotter-dev /out/ctr-remote /usr/local/bin/
 COPY ./script/config/ /
-RUN apt-get update -y && apt-get install --no-install-recommends -y fuse
+RUN /clone3-workaround apt-get update -y && /clone3-workaround apt-get install --no-install-recommends -y fuse
 ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]
 
 # Image for testing CRI-O with Stargz Store.
@@ -244,10 +247,13 @@ COPY ./script/config-cri-o/ /
 ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
 
 # Image which can be used as a node image for KinD
-FROM kindest/node:v1.22.1
+FROM kindest/node:v1.22.2
+# see https://medium.com/nttlabs/ubuntu-21-10-and-fedora-35-do-not-work-on-docker-20-10-9-1cd439d9921
+ADD https://github.com/AkihiroSuda/clone3-workaround/releases/download/v1.0.0/clone3-workaround.x86_64 /clone3-workaround
+RUN chmod 755 /clone3-workaround
 COPY --from=containerd-dev /out/bin/containerd /out/bin/containerd-shim-runc-v2 /usr/local/bin/
 COPY --from=snapshotter-dev /out/* /usr/local/bin/
 COPY ./script/config/ /
-RUN apt-get update -y && apt-get install --no-install-recommends -y fuse && \
+RUN /clone3-workaround apt-get update -y && /clone3-workaround apt-get install --no-install-recommends -y fuse && \
     systemctl enable stargz-snapshotter
 ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]

--- a/script/cri-containerd/test.sh
+++ b/script/cri-containerd/test.sh
@@ -113,6 +113,9 @@ cat <<EOF > "${TMP_CONTEXT}/Dockerfile"
 FROM ${NODE_BASE_IMAGE_NAME}
 ARG TARGETARCH
 
+# see https://medium.com/nttlabs/ubuntu-21-10-and-fedora-35-do-not-work-on-docker-20-10-9-1cd439d9921
+SHELL ["/clone3-workaround", "/bin/sh", "-c"]
+
 ENV PATH=$PATH:/usr/local/go/bin
 ENV GOPATH=/go
 # Do not install git and its dependencies here which will cause failure of building the image


### PR DESCRIPTION
Alternative of #491.

This commit uses https://github.com/AkihiroSuda/clone3-workaround to avoid the following error:

```
#15 [stage-19 5/5] RUN apt-get update -y && apt-get install --no-install-recommends -y fuse &&     systemctl enable stargz-snapshotter
#15 sha256:47959c2d183bab2dd4d61b2171253a3f2567e7b93ce490e74be619d2dea766c9
#15 0.666 Get:1 http://security.ubuntu.com/ubuntu impish-security InRelease [90.7 kB]
#15 0.791 Get:2 http://archive.ubuntu.com/ubuntu impish InRelease [270 kB]
#15 1.368 Get:3 http://archive.ubuntu.com/ubuntu impish-updates InRelease [90.7 kB]
#15 1.501 Get:4 http://archive.ubuntu.com/ubuntu impish-backports InRelease [90.7 kB]
#15 1.635 Get:5 http://archive.ubuntu.com/ubuntu impish/universe amd64 Packages [16.7 MB]
#15 2.516 Get:6 http://archive.ubuntu.com/ubuntu impish/restricted amd64 Packages [110 kB]
#15 2.516 Get:7 http://archive.ubuntu.com/ubuntu impish/multiverse amd64 Packages [256 kB]
#15 2.516 Get:8 http://archive.ubuntu.com/ubuntu impish/main amd64 Packages [1793 kB]
#15 3.443 Fetched 19.4 MB in 3s (6751 kB/s)
#15 3.443 Reading package lists...
#15 4.002 E: Problem executing scripts APT::Update::Post-Invoke 'rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true'
#15 4.002 E: Sub-process returned an error code
#15 ERROR: executor failed running [/bin/sh -c apt-get update -y && apt-get install --no-install-recommends -y fuse &&     systemctl enable stargz-snapshotter]: exit code: 100
```

Thank you @AkihiroSuda .
