### PR TITLE
Update ctr to the correct name ctr-remote

### DIFF
--- a/cmd/ctr-remote/main.go
+++ b/cmd/ctr-remote/main.go
@@ -65,7 +65,7 @@ func main() {
 	}
 	app.Commands = append(app.Commands, commands.FanotifyCommand)
 	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "ctr: %v\n", err)
+		fmt.Fprintf(os.Stderr, "ctr-remote: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
If the `ctr-remote` command has failed, it will print `ctr` as the command name:

```
fetching sha256:9523a2de... application/vnd.oci.image.manifest.v1+json
fetching sha256:a2cdb40d... application/vnd.oci.image.config.v1+json
ctr: failed to prepare extraction snapshot ...
...
```

It should be `ctr-remote`.

Signed-off-by: bin liu <liubin0329@gmail.com>