### PR TITLE
Prepare for v0.10.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/containerd/containerd v1.6.0-beta.1.0.20211101005050-f0d3ea96cf8c
 	github.com/containerd/containerd/api v1.6.0-beta.1.0.20211101005050-f0d3ea96cf8c
 	github.com/containerd/go-cni v1.1.0
-	github.com/containerd/stargz-snapshotter v0.9.0
-	github.com/containerd/stargz-snapshotter/estargz v0.9.0
-	github.com/containerd/stargz-snapshotter/ipfs v0.9.0
+	github.com/containerd/stargz-snapshotter v0.10.0
+	github.com/containerd/stargz-snapshotter/estargz v0.10.0
+	github.com/containerd/stargz-snapshotter/ipfs v0.10.0
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/go-metrics v0.0.1
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.0-beta.1.0.20211101005050-f0d3ea96cf8c
 	github.com/containerd/continuity v0.2.1
-	github.com/containerd/stargz-snapshotter/estargz v0.9.0
+	github.com/containerd/stargz-snapshotter/estargz v0.10.0
 	github.com/docker/cli v20.10.10+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect


### PR DESCRIPTION
```
This release comes with experimental support for image distribution on IPFS with lazy pulling ([`/docs/ipfs.md`](/docs/ipfs.md)), support for storing filesystem metadata on disk (bbolt) and reorganization of eStargz documents.

This release introduces new go modules `ipfs` and `cmd`.
We have the following go modules as of now.

- `github.com/containerd/stargz-snapshotter` : Plugins for container runtimes to enable lazy pulling of eStargz and the image creation.
- `github.com/containerd/stargz-snapshotter/estargz` : Utilities to create and manipulate eStargz.
- `github.com/containerd/stargz-snapshotter/ipfs` : Plugins for containerd to support IPFS
- `github.com/containerd/stargz-snapshotter/cmd` : CLI commands

## Notable Changes

- modules
  - Introduce the following go modules (#511)
    - `ipfs`: Plugins for containerd to image distribution on IPFS
    - `cmd`: CLI commands provided by this project
- ipfs ([`/docs/ipfs.md`](/docs/ipfs.md))
  - Experimental support for distributing images on IPFS (#496, #501, #502, #511, #514)
- Stargz Snapshotter and Stargz Store
  - Enable to store filesystem metadata on disk to reduce memory usage (#415)
  - Make HTTP requests retryable (#479), thanks to @rdpsin
  - Add microsecond latency measuring to metrics (#485), thanks to @gtxu
- estargz
  - Unify eStargz specification documents (#513)
- `ctr-remote`
  -  Fix ctr-remote to print the correct command name (#500), thanks to @liubin
```