### PR TITLE
add unit test coverage in GitHub workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,14 @@ jobs:
     - name: Test all
       run: ./script/util/make.sh test-all -j2
 
+  test-coverage:
+    runs-on: ubuntu-20.04
+    name: Coveralls
+    steps:
+    - uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
   linter:
     runs-on: ubuntu-20.04
     name: Linter


### PR DESCRIPTION
This plug-in added in Github workflow will trigger a comment from coveralls.io when each PR, showing the unit test coverage information and impact on test coverage that PR made.
This will resolve [Issue 509](https://github.com/containerd/stargz-snapshotter/issues/509)