### PR TITLE
CI: k3s: bump up golang to 1.17

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.16.x'
+        go-version: '1.17.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.16.x'
+        go-version: '1.17.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash
@@ -187,7 +187,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.16.x'
+        go-version: '1.17.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash


### PR DESCRIPTION
Recently k3s updated supported golang version to 1.17.
