### PR TITLE
layer resolver: Avoid many cache misses occur when many pullings of images happen

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -34,18 +34,21 @@ const (
 )
 
 type Config struct {
-	HTTPCacheType       string `toml:"http_cache_type"`
-	FSCacheType         string `toml:"filesystem_cache_type"`
-	ResolveResultEntry  int    `toml:"resolve_result_entry"`
-	PrefetchSize        int64  `toml:"prefetch_size"`
-	PrefetchTimeoutSec  int64  `toml:"prefetch_timeout_sec"`
-	NoPrefetch          bool   `toml:"noprefetch"`
-	NoBackgroundFetch   bool   `toml:"no_background_fetch"`
-	Debug               bool   `toml:"debug"`
-	AllowNoVerification bool   `toml:"allow_no_verification"`
-	DisableVerification bool   `toml:"disable_verification"`
-	MaxConcurrency      int64  `toml:"max_concurrency"`
-	NoPrometheus        bool   `toml:"no_prometheus"`
+	HTTPCacheType string `toml:"http_cache_type"`
+	FSCacheType   string `toml:"filesystem_cache_type"`
+	// ResolveResultEntryTTLSec is TTL (in sec) to cache resolved layers for
+	// future use. (default 120s)
+	ResolveResultEntryTTLSec int   `toml:"resolve_result_entry_ttl_sec"`
+	ResolveResultEntry       int   `toml:"resolve_result_entry"` // deprecated
+	PrefetchSize             int64 `toml:"prefetch_size"`
+	PrefetchTimeoutSec       int64 `toml:"prefetch_timeout_sec"`
+	NoPrefetch               bool  `toml:"noprefetch"`
+	NoBackgroundFetch        bool  `toml:"no_background_fetch"`
+	Debug                    bool  `toml:"debug"`
+	AllowNoVerification      bool  `toml:"allow_no_verification"`
+	DisableVerification      bool  `toml:"disable_verification"`
+	MaxConcurrency           int64 `toml:"max_concurrency"`
+	NoPrometheus             bool  `toml:"no_prometheus"`
 
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob"`

--- a/store/refs.go
+++ b/store/refs.go
@@ -33,8 +33,8 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/stargz-snapshotter/fs/source"
+	"github.com/containerd/stargz-snapshotter/util/cacheutil"
 	"github.com/containerd/stargz-snapshotter/util/containerdutil"
-	"github.com/containerd/stargz-snapshotter/util/lrucache"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -54,7 +54,7 @@ func newRefPool(ctx context.Context, root string, hosts source.RegistryHosts) (*
 		hosts:      hosts,
 		refcounter: make(map[string]*releaser),
 	}
-	p.cache = lrucache.New(refCacheEntry)
+	p.cache = cacheutil.NewLRUCache(refCacheEntry)
 	p.cache.OnEvicted = func(key string, value interface{}) {
 		refspec := value.(reference.Spec)
 		if err := os.RemoveAll(p.metadataDir(refspec)); err != nil {
@@ -71,7 +71,7 @@ type refPool struct {
 	hosts source.RegistryHosts
 
 	refcounter map[string]*releaser
-	cache      *lrucache.Cache
+	cache      *cacheutil.LRUCache
 	mu         sync.Mutex
 }
 

--- a/util/cacheutil/lrucache.go
+++ b/util/cacheutil/lrucache.go
@@ -1,0 +1,140 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cacheutil
+
+import (
+	"sync"
+
+	"github.com/golang/groupcache/lru"
+)
+
+// LRUCache is "groupcache/lru"-like cache. The difference is that "groupcache/lru" immediately
+// finalizes theevicted contents using OnEvicted callback but our version strictly tracks the
+// reference counts of contents and calls OnEvicted when nobody refers to the evicted contents.
+type LRUCache struct {
+	cache *lru.Cache
+	mu    sync.Mutex
+
+	// OnEvicted optionally specifies a callback function to be
+	// executed when an entry is purged from the cache.
+	OnEvicted func(key string, value interface{})
+}
+
+// NewLRUCache creates new lru cache.
+func NewLRUCache(maxEntries int) *LRUCache {
+	inner := lru.New(maxEntries)
+	inner.OnEvicted = func(key lru.Key, value interface{}) {
+		// Decrease the ref count incremented in Add().
+		// When nobody refers to this value, this value will be finalized via refCounter.
+		value.(*refCounter).finalize()
+	}
+	return &LRUCache{
+		cache: inner,
+	}
+}
+
+// Get retrieves the specified object from the cache and increments the reference counter of the
+// target content. Client must call `done` callback to decrease the reference count when the value
+// will no longer be used.
+func (c *LRUCache) Get(key string) (value interface{}, done func(), ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	o, ok := c.cache.Get(key)
+	if !ok {
+		return nil, nil, false
+	}
+	rc := o.(*refCounter)
+	rc.inc()
+	return rc.v, c.decreaseOnceFunc(rc), true
+}
+
+// Add adds object to the cache and returns the cached contents with incrementing the reference count.
+// If the specified content already exists in the cache, this sets `added` to false and returns
+// "already cached" content (i.e. doesn't replace the content with the new one). Client must call
+// `done` callback to decrease the counter when the value will no longer be used.
+func (c *LRUCache) Add(key string, value interface{}) (cachedValue interface{}, done func(), added bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if o, ok := c.cache.Get(key); ok {
+		rc := o.(*refCounter)
+		rc.inc()
+		return rc.v, c.decreaseOnceFunc(rc), false
+	}
+	rc := &refCounter{
+		key:       key,
+		v:         value,
+		onEvicted: c.OnEvicted,
+	}
+	rc.initialize() // Keep this object having at least 1 ref count (will be decreased in OnEviction)
+	rc.inc()        // The client references this object (will be decreased on "done")
+	c.cache.Add(key, rc)
+	return rc.v, c.decreaseOnceFunc(rc), true
+}
+
+// Remove removes the specified contents from the cache. OnEvicted callback will be called when
+// nobody refers to the removed content.
+func (c *LRUCache) Remove(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache.Remove(key)
+}
+
+func (c *LRUCache) decreaseOnceFunc(rc *refCounter) func() {
+	var once sync.Once
+	return func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		once.Do(func() { rc.dec() })
+	}
+}
+
+type refCounter struct {
+	onEvicted func(key string, value interface{})
+
+	key       string
+	v         interface{}
+	refCounts int64
+
+	mu sync.Mutex
+
+	initializeOnce sync.Once
+	finalizeOnce   sync.Once
+}
+
+func (r *refCounter) inc() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refCounts++
+}
+
+func (r *refCounter) dec() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refCounts--
+	if r.refCounts <= 0 && r.onEvicted != nil {
+		// nobody will refer this object
+		r.onEvicted(r.key, r.v)
+	}
+}
+
+func (r *refCounter) initialize() {
+	r.initializeOnce.Do(func() { r.inc() })
+}
+
+func (r *refCounter) finalize() {
+	r.finalizeOnce.Do(func() { r.dec() })
+}

--- a/util/cacheutil/lrucache_test.go
+++ b/util/cacheutil/lrucache_test.go
@@ -14,60 +14,57 @@
    limitations under the License.
 */
 
-package lrucache
+package cacheutil
 
 import (
 	"fmt"
 	"testing"
 )
 
-func TestAdd(t *testing.T) {
-	c := New(10)
+// TestLRUAdd tests Add API
+func TestLRUAdd(t *testing.T) {
+	c := NewLRUCache(10)
 
 	key, value := "key1", "abcd"
 	v, _, added := c.Add(key, value)
 	if !added {
-		t.Errorf("failed to add %q", key)
-		return
+		t.Fatalf("failed to add %q", key)
 	} else if v.(string) != value {
-		t.Errorf("returned different object for %q; want %q; got %q", key, value, v.(string))
-		return
+		t.Fatalf("returned different object for %q; want %q; got %q", key, value, v.(string))
 	}
 
 	key, newvalue := "key1", "dummy"
 	v, _, added = c.Add(key, newvalue)
 	if added || v.(string) != value {
-		t.Errorf("%q must be originally stored one; want %q; got %q (added:%v)",
+		t.Fatalf("%q must be originally stored one; want %q; got %q (added:%v)",
 			key, value, v.(string), added)
 	}
 }
 
-func TestGet(t *testing.T) {
-	c := New(10)
+// TestLRUGet tests Get API
+func TestLRUGet(t *testing.T) {
+	c := NewLRUCache(10)
 
 	key, value := "key1", "abcd"
 	v, _, added := c.Add(key, value)
 	if !added {
-		t.Errorf("failed to add %q", key)
-		return
+		t.Fatalf("failed to add %q", key)
 	} else if v.(string) != value {
-		t.Errorf("returned different object for %q; want %q; got %q", key, value, v.(string))
-		return
+		t.Fatalf("returned different object for %q; want %q; got %q", key, value, v.(string))
 	}
 
 	v, _, ok := c.Get(key)
 	if !ok {
-		t.Errorf("failed to get obj %q (%q)", key, value)
-		return
+		t.Fatalf("failed to get obj %q (%q)", key, value)
 	} else if v.(string) != value {
-		t.Errorf("unexpected object for %q; want %q; got %q", key, value, v.(string))
-		return
+		t.Fatalf("unexpected object for %q; want %q; got %q", key, value, v.(string))
 	}
 }
 
-func TestRemove(t *testing.T) {
+// TestLRURemoe tests Remove API
+func TestLRURemove(t *testing.T) {
 	var evicted []string
-	c := New(2)
+	c := NewLRUCache(2)
 	c.OnEvicted = func(key string, value interface{}) {
 		evicted = append(evicted, key)
 	}
@@ -77,30 +74,27 @@ func TestRemove(t *testing.T) {
 
 	c.Remove(key1)
 	if len(evicted) != 0 {
-		t.Errorf("no content must be evicted after remove")
-		return
+		t.Fatalf("no content must be evicted after remove")
 	}
 
 	done1()
 	if len(evicted) != 0 {
-		t.Errorf("no content must be evicted until all reference are discarded")
-		return
+		t.Fatalf("no content must be evicted until all reference are discarded")
 	}
 
 	done12()
 	if len(evicted) != 1 {
-		t.Errorf("content must be evicted")
-		return
+		t.Fatalf("content must be evicted")
 	}
 	if evicted[0] != key1 {
-		t.Errorf("1st content %q must be evicted but got %q", key1, evicted[0])
-		return
+		t.Fatalf("1st content %q must be evicted but got %q", key1, evicted[0])
 	}
 }
 
-func TestEviction(t *testing.T) {
+// TestLRUEviction tests that eviction occurs when the overflow happens.
+func TestLRUEviction(t *testing.T) {
 	var evicted []string
-	c := New(2)
+	c := NewLRUCache(2)
 	c.OnEvicted = func(key string, value interface{}) {
 		evicted = append(evicted, key)
 	}
@@ -111,42 +105,35 @@ func TestEviction(t *testing.T) {
 	_, done22, _ := c.Get(key2)
 
 	if len(evicted) != 0 {
-		t.Errorf("no content must be evicted after addition")
-		return
+		t.Fatalf("no content must be evicted after addition")
 	}
 	for i := 0; i < 2; i++ {
 		c.Add(fmt.Sprintf("key-add-%d", i), fmt.Sprintf("abcd-add-%d", i))
 	}
 	if len(evicted) != 0 {
-		t.Errorf("no content must be evicted after overflow")
-		return
+		t.Fatalf("no content must be evicted after overflow")
 	}
 
 	done1()
 	if len(evicted) != 1 {
-		t.Errorf("1 content must be evicted")
-		return
+		t.Fatalf("1 content must be evicted")
 	}
 	if evicted[0] != key1 {
-		t.Errorf("1st content %q must be evicted but got %q", key1, evicted[0])
-		return
+		t.Fatalf("1st content %q must be evicted but got %q", key1, evicted[0])
 	}
 
 	done2() // effective
 	done2() // ignored
 	done2() // ignored
 	if len(evicted) != 1 {
-		t.Errorf("only 1 content must be evicted")
-		return
+		t.Fatalf("only 1 content must be evicted")
 	}
 
 	done22()
 	if len(evicted) != 2 {
-		t.Errorf("2 contents must be evicted")
-		return
+		t.Fatalf("2 contents must be evicted")
 	}
 	if evicted[1] != key2 {
-		t.Errorf("2nd content %q must be evicted but got %q", key2, evicted[1])
-		return
+		t.Fatalf("2nd content %q must be evicted but got %q", key2, evicted[1])
 	}
 }

--- a/util/cacheutil/ttlcache.go
+++ b/util/cacheutil/ttlcache.go
@@ -14,51 +14,43 @@
    limitations under the License.
 */
 
-// Package lrucache provides reference-count-aware lru cache.
-package lrucache
+package cacheutil
 
 import (
 	"sync"
-
-	"github.com/golang/groupcache/lru"
+	"time"
 )
 
-// Cache is "groupcache/lru"-like cache. The difference is that "groupcache/lru" immediately
-// finalizes theevicted contents using OnEvicted callback but our version strictly tracks the
-// reference counts of contents and calls OnEvicted when nobody refers to the evicted contents.
-type Cache struct {
-	cache *lru.Cache
-	mu    sync.Mutex
+// TTLCache is a ttl-based cache with reference counters.
+// Each elements is deleted as soon as expiering the configured ttl.
+type TTLCache struct {
+	m   map[string]*refCounterWithTimer
+	mu  sync.Mutex
+	ttl time.Duration
 
 	// OnEvicted optionally specifies a callback function to be
 	// executed when an entry is purged from the cache.
 	OnEvicted func(key string, value interface{})
 }
 
-// New creates new cache.
-func New(maxEntries int) *Cache {
-	inner := lru.New(maxEntries)
-	inner.OnEvicted = func(key lru.Key, value interface{}) {
-		// Decrease the ref count incremented in Add().
-		// When nobody refers to this value, this value will be finalized via refCounter.
-		value.(*refCounter).finalize()
-	}
-	return &Cache{
-		cache: inner,
+// NewTTLCache creates a new ttl-based cache.
+func NewTTLCache(ttl time.Duration) *TTLCache {
+	return &TTLCache{
+		m:   make(map[string]*refCounterWithTimer),
+		ttl: ttl,
 	}
 }
 
 // Get retrieves the specified object from the cache and increments the reference counter of the
 // target content. Client must call `done` callback to decrease the reference count when the value
 // will no longer be used.
-func (c *Cache) Get(key string) (value interface{}, done func(), ok bool) {
+func (c *TTLCache) Get(key string) (value interface{}, done func(), ok bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	o, ok := c.cache.Get(key)
+	rc, ok := c.m[key]
 	if !ok {
 		return nil, nil, false
 	}
-	rc := o.(*refCounter)
 	rc.inc()
 	return rc.v, c.decreaseOnceFunc(rc), true
 }
@@ -67,34 +59,48 @@ func (c *Cache) Get(key string) (value interface{}, done func(), ok bool) {
 // If the specified content already exists in the cache, this sets `added` to false and returns
 // "already cached" content (i.e. doesn't replace the content with the new one). Client must call
 // `done` callback to decrease the counter when the value will no longer be used.
-func (c *Cache) Add(key string, value interface{}) (cachedValue interface{}, done func(), added bool) {
+func (c *TTLCache) Add(key string, value interface{}) (cachedValue interface{}, done func(), added bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if o, ok := c.cache.Get(key); ok {
-		rc := o.(*refCounter)
+	if rc, ok := c.m[key]; ok {
 		rc.inc()
 		return rc.v, c.decreaseOnceFunc(rc), false
 	}
-	rc := &refCounter{
-		key:       key,
-		v:         value,
-		onEvicted: c.OnEvicted,
+	rc := &refCounterWithTimer{
+		refCounter: &refCounter{
+			key:       key,
+			v:         value,
+			onEvicted: c.OnEvicted,
+		},
 	}
 	rc.initialize() // Keep this object having at least 1 ref count (will be decreased in OnEviction)
 	rc.inc()        // The client references this object (will be decreased on "done")
-	c.cache.Add(key, rc)
+	rc.t = time.AfterFunc(c.ttl, func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.evictLocked(key)
+	})
+	c.m[key] = rc
 	return rc.v, c.decreaseOnceFunc(rc), true
 }
 
 // Remove removes the specified contents from the cache. OnEvicted callback will be called when
 // nobody refers to the removed content.
-func (c *Cache) Remove(key string) {
+func (c *TTLCache) Remove(key string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.cache.Remove(key)
+	c.evictLocked(key)
 }
 
-func (c *Cache) decreaseOnceFunc(rc *refCounter) func() {
+func (c *TTLCache) evictLocked(key string) {
+	if rc, ok := c.m[key]; ok {
+		delete(c.m, key)
+		rc.t.Stop() // stop timer to prevent GC to this content anymore
+		rc.finalize()
+	}
+}
+
+func (c *TTLCache) decreaseOnceFunc(rc *refCounterWithTimer) func() {
 	var once sync.Once
 	return func() {
 		c.mu.Lock()
@@ -103,39 +109,7 @@ func (c *Cache) decreaseOnceFunc(rc *refCounter) func() {
 	}
 }
 
-type refCounter struct {
-	onEvicted func(key string, value interface{})
-
-	key       string
-	v         interface{}
-	refCounts int64
-
-	mu sync.Mutex
-
-	initializeOnce sync.Once
-	finalizeOnce   sync.Once
-}
-
-func (r *refCounter) inc() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.refCounts++
-}
-
-func (r *refCounter) dec() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.refCounts--
-	if r.refCounts <= 0 && r.onEvicted != nil {
-		// nobody will refer this object
-		r.onEvicted(r.key, r.v)
-	}
-}
-
-func (r *refCounter) initialize() {
-	r.initializeOnce.Do(func() { r.inc() })
-}
-
-func (r *refCounter) finalize() {
-	r.finalizeOnce.Do(func() { r.dec() })
+type refCounterWithTimer struct {
+	*refCounter
+	t *time.Timer
 }

--- a/util/cacheutil/ttlcache_test.go
+++ b/util/cacheutil/ttlcache_test.go
@@ -1,0 +1,178 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cacheutil
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestTTLAdd tests Add API
+func TestTTLAdd(t *testing.T) {
+	c := NewTTLCache(time.Hour)
+
+	key, value := "key1", "abcd"
+	v, _, added := c.Add(key, value)
+	if !added {
+		t.Fatalf("failed to add %q", key)
+	} else if v.(string) != value {
+		t.Fatalf("returned different object for %q; want %q; got %q", key, value, v.(string))
+	}
+
+	key, newvalue := "key1", "dummy"
+	v, _, added = c.Add(key, newvalue)
+	if added || v.(string) != value {
+		t.Fatalf("%q must be originally stored one; want %q; got %q (added:%v)",
+			key, value, v.(string), added)
+	}
+}
+
+// TestTTLGet tests Get API
+func TestTTLGet(t *testing.T) {
+	c := NewTTLCache(time.Hour)
+
+	key, value := "key1", "abcd"
+	v, _, added := c.Add(key, value)
+	if !added {
+		t.Fatalf("failed to add %q", key)
+	} else if v.(string) != value {
+		t.Fatalf("returned different object for %q; want %q; got %q", key, value, v.(string))
+	}
+
+	v, _, ok := c.Get(key)
+	if !ok {
+		t.Fatalf("failed to get obj %q (%q)", key, value)
+	} else if v.(string) != value {
+		t.Fatalf("unexpected object for %q; want %q; got %q", key, value, v.(string))
+	}
+}
+
+// TestTTLRemove tests Remove API
+func TestTTLRemove(t *testing.T) {
+	var evicted []string
+	c := NewTTLCache(time.Hour)
+	c.OnEvicted = func(key string, value interface{}) {
+		evicted = append(evicted, key)
+	}
+	key1, value1 := "key1", "abcd1"
+	_, done1, _ := c.Add(key1, value1)
+	_, done12, _ := c.Get(key1)
+
+	c.Remove(key1)
+	if len(evicted) != 0 {
+		t.Fatalf("no content must be evicted after remove")
+	}
+
+	done1()
+	if len(evicted) != 0 {
+		t.Fatalf("no content must be evicted until all reference are discarded")
+	}
+
+	done12()
+	if len(evicted) != 1 {
+		t.Fatalf("content must be evicted")
+	}
+	if evicted[0] != key1 {
+		t.Fatalf("1st content %q must be evicted but got %q", key1, evicted[0])
+	}
+}
+
+// TestTTLRemoveOverwritten tests old gc doesn't affect overwritten content
+func TestTTLRemoveOverwritten(t *testing.T) {
+	var evicted []string
+	c := NewTTLCache(3 * time.Second)
+	c.OnEvicted = func(key string, value interface{}) {
+		evicted = append(evicted, key)
+	}
+	key1, value1 := "key1", "abcd1"
+	_, done1, _ := c.Add(key1, value1)
+	done1()
+	c.Remove(key1) // remove key1 as soon as possible
+
+	// add another content with a new key
+	time.Sleep(2 * time.Second)
+	value12 := value1 + "!"
+	_, done12, _ := c.Add(key1, value12)
+	time.Sleep(2 * time.Second)
+	// spent 4 sec (larger than ttl) since the previous key1 was added.
+	// but the *newly-added* key1 hasn't been expierd yet so key1 must remain.
+	v1, done122, getOK := c.Get(key1)
+	if !getOK {
+		t.Fatalf("unexpected eviction")
+	}
+	if s1, ok := v1.(string); !ok || s1 != value12 {
+		t.Fatalf("unexpected content %q(%v) != %q", s1, ok, value12)
+	}
+
+	time.Sleep(2 * time.Second)
+	done122()
+	done12()
+	// spent 4 sec since the new key1 was added. This should be expierd.
+	if _, _, ok := c.Get(key1); ok {
+		t.Fatalf("%q must be expierd but remaining", key1)
+	}
+}
+
+// TestTTLEviction tests contents are evicted after TTL witout remaining reference.
+func TestTTLEviction(t *testing.T) {
+	var (
+		evicted   []string
+		evictedMu sync.Mutex
+	)
+	c := NewTTLCache(time.Second)
+	c.OnEvicted = func(key string, value interface{}) {
+		evictedMu.Lock()
+		evicted = append(evicted, key)
+		evictedMu.Unlock()
+	}
+	key1, value1 := "key1", "abcd1"
+	key2, value2 := "key2", "abcd2"
+	_, done1, _ := c.Add(key1, value1)
+	done1() // evict key1 on expiering ttl
+	_, done2, _ := c.Add(key2, value2)
+	_, done22, _ := c.Get(key2) // hold reference of key2 to prevent eviction
+	time.Sleep(3 * time.Second) // wait until elements reach ttl
+
+	evictedMu.Lock()
+	if len(evicted) != 1 {
+		t.Fatalf("1 content must be removed")
+	}
+	if evicted[0] != key1 {
+		t.Fatalf("1st content %q must be evicted but got %q", key1, evicted[0])
+	}
+	evictedMu.Unlock()
+
+	done2() // effective
+	done2() // ignored
+	done2() // ignored
+	evictedMu.Lock()
+	if len(evicted) != 1 {
+		t.Fatalf("only 1 content must be evicted")
+	}
+	evictedMu.Unlock()
+
+	done22()
+	evictedMu.Lock()
+	if len(evicted) != 2 {
+		t.Fatalf("2 contents must be evicted")
+	}
+	if evicted[1] != key2 {
+		t.Fatalf("2nd content %q must be evicted but got %q", key2, evicted[1])
+	}
+	evictedMu.Unlock()
+}


### PR DESCRIPTION
When `filesystem.Mount` is called for the first layer in an image, stargz-snapshotter resolves all layers in that image in parallel and caches these resolved layers metadata in LRU cache. When `filesystem.Mount` is called for the neighbouring layers of that image, the cached layer can be used for speeding up the mounts.

However, when many pulling of images happen in parallel, layers are soonly evicted from the LRU cache by other image pullings and many cache misses happen. This result to many resource consumption (e.g. fd), many (duplicated) requests to the registry, etc.

This commit solves this by using TTL-based cache instead of LRU cache. TTL cache doesn't have size limitations and manages eviction using TTL of each element. This avoids the above problems of quick evictions and many cache misses when many parallel pulling of images happen. When `filesystem.Mount` of a layer of an image is called, mounts of the neighbouring layers also happen soon. And once a mount of a layer completes, reusing of the layer is managed by the snapshotter's side but not by the filesystem so we don't need to cache the layer in long term. So TTL-based cache should be a better choice than LRU cache here.

## max fd consumption comparison

The following client command mounts 7 images (74 snapshots) in parallel.

```
TARGETS="gcc:10.2.0 golang:1.12.9 jenkins:2.60.3 node:13.13.0 php:7.3.8 python:3.9 tomcat:10.0.0-jdk15-openjdk-buster"
for I in $TARGETS ; do
  ctr-remote i rpull --plain-http registry2:5000/${I}-esgz &
done
```

|branch|max fd consumption|
|---|---|
|main|381|
|This PR|211|

Each snapshot consumes 1 fd for fuse, 2 fds (at most) for registry connection.
So stargz-snapshotter consumes around `3 * number_of_snapshots` fds (+ misc fds for local cache, etc.).
Main branch consumes much more fds than expected because of lots of cache misses and duplicated layer resolves.
