### PR TITLE
Prepare for v0.11.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/containerd/containerd v1.6.0-rc.1
 	github.com/containerd/go-cni v1.1.1
-	github.com/containerd/stargz-snapshotter v0.10.1
-	github.com/containerd/stargz-snapshotter/estargz v0.10.1
-	github.com/containerd/stargz-snapshotter/ipfs v0.10.1
+	github.com/containerd/stargz-snapshotter v0.11.0
+	github.com/containerd/stargz-snapshotter/estargz v0.11.0
+	github.com/containerd/stargz-snapshotter/ipfs v0.11.0
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.9.4

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.0-rc.1
 	github.com/containerd/continuity v0.2.2
-	github.com/containerd/stargz-snapshotter/estargz v0.10.1
+	github.com/containerd/stargz-snapshotter/estargz v0.11.0
 	github.com/docker/cli v20.10.12+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect


### PR DESCRIPTION
```
## Notable Changes

- Stargz Snapshotter and Stargz Store
  - Avoid many cache misses occur when many pullings of images happen (#600)
  - Avoid using unsupported field by logrus (#539, #589)
  - Prevent potential panic by type inconsistency on sync/atomic (#592)
- ctr-remote
  -  Log success record path count (#548), thanks to @jonyhy96
- CI/Docs/Tests/Typo fixes
  -  Fix golint issue (#524), thanks to @hs0210
  -  Fix some spelling mistakes (#572), thanks to @changweige
```