### PR TITLE
Make metrics log level configurable

### DIFF
--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -175,7 +175,7 @@ func main() {
 		runtime.RegisterImageServiceServer(rpc, criServer)
 		credsFuncs = append(credsFuncs, f)
 	}
-	var fsOpts []fs.Option
+	fsOpts := []fs.Option{fs.WithMetricsLogLevel(logrus.InfoLevel)}
 	if config.IPFS {
 		fsOpts = append(fsOpts, fs.WithResolveHandler("ipfs", new(ipfs.ResolveHandler)))
 	}


### PR DESCRIPTION
This patch is needed for solving https://github.com/moby/buildkit/issues/2656

This commit makes metrics log level configurable by introducing an option
`fs.WithMetricsLogLevel` to `fs.NewFilesystem()`.
