### PR TITLE
Fix jitter panics with `invalid argument to Int63n`

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -164,6 +164,9 @@ type fetcherConfig struct {
 }
 
 func jitter(duration time.Duration) time.Duration {
+	if duration <= 0 {
+		return duration
+	}
 	return time.Duration(rand.Int63n(int64(duration)) + int64(duration))
 }
 


### PR DESCRIPTION
`rand.Int63n` panics if passed value <= 0. https://pkg.go.dev/math/rand#Int63n
Necessary to pass test https://github.com/containerd/stargz-snapshotter/runs/5282251000?check_suite_focus=true