### PR TITLE
fs: return correct file size of symlink

### DIFF
--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -619,6 +619,9 @@ func (sf *statFile) updateStatUnlocked() ([]byte, error) {
 func entryToAttr(ino uint64, e metadata.Attr, out *fuse.Attr) fusefs.StableAttr {
 	out.Ino = ino
 	out.Size = uint64(e.Size)
+	if e.Mode&os.ModeSymlink != 0 {
+		out.Size = uint64(len(e.LinkName))
+	}
 	out.Blksize = blockSize
 	out.Blocks = out.Size / uint64(out.Blksize)
 	if out.Size%uint64(out.Blksize) > 0 {


### PR DESCRIPTION
The filesystem of stargz-snapshotter always returns size `0` when stat a symlink.

```console
# nerdctl run --snapshotter=stargz --rm -it ghcr.io/stargz-containers/python:3.9-esgz stat /usr/lib/x86_64-linux-gnu/libpq.so
  File: /usr/lib/x86_64-linux-gnu/libpq.so -> libpq.so.5.13
  Size: 0         	Blocks: 0          IO Block: 4096   symbolic link
Device: 1000e3h/1048803d	Inode: 4845        Links: 1
Access: (0777/lrwxrwxrwx)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 1970-01-01 00:00:00.000000000 +0000
Modify: 2021-05-11 20:10:35.000000000 +0000
Change: 1970-01-01 00:00:00.000000000 +0000
 Birth: -
```

But it needs to be the size of the link name according to man `stat(2)`.

https://man7.org/linux/man-pages/man2/lstat.2.html

>       st_size
>              This field gives the size of the file (if it is a regular
>              file or a symbolic link) in bytes.  The size of a symbolic
>              link is the length of the pathname it contains, without a
>              terminating null byte.

This behaviour seems to cause issue like https://github.com/moby/buildkit/issues/2703 .
This commit fixes this issue.

this PR:

```console
# nerdctl run --snapshotter=stargz --rm -it ghcr.io/stargz-containers/python:3.9-esgz stat /usr/lib/x86_64-linux-gnu/libpq.so
  File: /usr/lib/x86_64-linux-gnu/libpq.so -> libpq.so.5.13
  Size: 13        	Blocks: 1          IO Block: 4096   symbolic link
Device: 100054h/1048660d	Inode: 11801       Links: 1
Access: (0777/lrwxrwxrwx)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 1970-01-01 00:00:00.000000000 +0000
Modify: 2021-05-11 20:10:35.000000000 +0000
Change: 1970-01-01 00:00:00.000000000 +0000
 Birth: -
# nerdctl run --snapshotter=stargz --rm -it ghcr.io/stargz-containers/python:3.9-esgz /bin/bash -c "apt-get update &&  apt-get install -y libpq-dev"
Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
Get:2 http://security.debian.org/debian-security bullseye-security InRelease [44.1 kB]
Get:3 http://deb.debian.org/debian bullseye-updates InRelease [39.4 kB]
Get:4 http://security.debian.org/debian-security bullseye-security/main amd64 Packages [120 kB]
Get:5 http://deb.debian.org/debian bullseye/main amd64 Packages [8183 kB]
Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [2596 B]
Fetched 8505 kB in 7s (1227 kB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  libpq5
Suggested packages:
  postgresql-doc-13
The following packages will be upgraded:
  libpq-dev libpq5
2 upgraded, 0 newly installed, 0 to remove and 56 not upgraded.
Need to get 316 kB of archives.
After this operation, 3072 B of additional disk space will be used.
Get:1 http://deb.debian.org/debian bullseye/main amd64 libpq-dev amd64 13.5-0+deb11u1 [138 kB]
Get:2 http://deb.debian.org/debian bullseye/main amd64 libpq5 amd64 13.5-0+deb11u1 [179 kB]
Fetched 316 kB in 0s (6996 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
(Reading database ... 23378 files and directories currently installed.)
Preparing to unpack .../libpq-dev_13.5-0+deb11u1_amd64.deb ...
Unpacking libpq-dev (13.5-0+deb11u1) over (13.3-1) ...
Preparing to unpack .../libpq5_13.5-0+deb11u1_amd64.deb ...
Unpacking libpq5:amd64 (13.5-0+deb11u1) over (13.3-1) ...
Setting up libpq5:amd64 (13.5-0+deb11u1) ...
Setting up libpq-dev (13.5-0+deb11u1) ...
Processing triggers for libc-bin (2.31-13) ...
```
