### PR TITLE
Prepare for v0.11.2

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/containerd/containerd v1.6.1
 	github.com/containerd/go-cni v1.1.3
-	github.com/containerd/stargz-snapshotter v0.11.1
-	github.com/containerd/stargz-snapshotter/estargz v0.11.1
-	github.com/containerd/stargz-snapshotter/ipfs v0.11.1
+	github.com/containerd/stargz-snapshotter v0.11.2
+	github.com/containerd/stargz-snapshotter/estargz v0.11.2
+	github.com/containerd/stargz-snapshotter/ipfs v0.11.2
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.9.5

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.1
 	github.com/containerd/continuity v0.2.2
-	github.com/containerd/stargz-snapshotter/estargz v0.11.1
+	github.com/containerd/stargz-snapshotter/estargz v0.11.2
 	github.com/docker/cli v20.10.12+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect


### PR DESCRIPTION
```
## Notable Changes

- fs: return correct file size of symlink (#672)
- snapshotter: make restoring configurable (#659)
```