### PR TITLE
fs: enable to select the correct opaque xattr

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -76,10 +76,11 @@ const (
 type Option func(*options)
 
 type options struct {
-	getSources      source.GetSources
-	resolveHandlers map[string]remote.Handler
-	metadataStore   metadata.Store
-	metricsLogLevel *logrus.Level
+	getSources        source.GetSources
+	resolveHandlers   map[string]remote.Handler
+	metadataStore     metadata.Store
+	metricsLogLevel   *logrus.Level
+	overlayOpaqueType layer.OverlayOpaqueType
 }
 
 func WithGetSources(s source.GetSources) Option {
@@ -106,6 +107,12 @@ func WithMetadataStore(metadataStore metadata.Store) Option {
 func WithMetricsLogLevel(logLevel logrus.Level) Option {
 	return func(opts *options) {
 		opts.metricsLogLevel = &logLevel
+	}
+}
+
+func WithOverlayOpaqueType(overlayOpaqueType layer.OverlayOpaqueType) Option {
+	return func(opts *options) {
+		opts.overlayOpaqueType = overlayOpaqueType
 	}
 }
 
@@ -141,7 +148,7 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snapshot.F
 		})
 	}
 	tm := task.NewBackgroundTaskManager(maxConcurrency, 5*time.Second)
-	r, err := layer.NewResolver(root, tm, cfg, fsOpts.resolveHandlers, metadataStore)
+	r, err := layer.NewResolver(root, tm, cfg, fsOpts.resolveHandlers, metadataStore, fsOpts.overlayOpaqueType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup resolver: %w", err)
 	}

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -124,10 +124,11 @@ type Resolver struct {
 	resolveLock           *namedmutex.NamedMutex
 	config                config.Config
 	metadataStore         metadata.Store
+	overlayOpaqueType     OverlayOpaqueType
 }
 
 // NewResolver returns a new layer resolver.
-func NewResolver(root string, backgroundTaskManager *task.BackgroundTaskManager, cfg config.Config, resolveHandlers map[string]remote.Handler, metadataStore metadata.Store) (*Resolver, error) {
+func NewResolver(root string, backgroundTaskManager *task.BackgroundTaskManager, cfg config.Config, resolveHandlers map[string]remote.Handler, metadataStore metadata.Store, overlayOpaqueType OverlayOpaqueType) (*Resolver, error) {
 	resolveResultEntryTTL := time.Duration(cfg.ResolveResultEntryTTLSec) * time.Second
 	if resolveResultEntryTTL == 0 {
 		resolveResultEntryTTL = defaultResolveResultEntryTTLSec * time.Second
@@ -174,6 +175,7 @@ func NewResolver(root string, backgroundTaskManager *task.BackgroundTaskManager,
 		config:                cfg,
 		resolveLock:           new(namedmutex.NamedMutex),
 		metadataStore:         metadataStore,
+		overlayOpaqueType:     overlayOpaqueType,
 	}, nil
 }
 
@@ -574,7 +576,7 @@ func (l *layer) RootNode(baseInode uint32) (fusefs.InodeEmbedder, error) {
 	if l.r == nil {
 		return nil, fmt.Errorf("layer hasn't been verified yet")
 	}
-	return newNode(l.desc.Digest, l.r, l.blob, baseInode)
+	return newNode(l.desc.Digest, l.r, l.blob, baseInode, l.resolver.overlayOpaqueType)
 }
 
 func (l *layer) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, error) {

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -59,19 +59,36 @@ const (
 	stateDirMode      = syscall.S_IFDIR | 0500 // dr-x------
 )
 
-var opaqueXattrs = []string{"trusted.overlay.opaque", "user.overlay.opaque"}
+type OverlayOpaqueType int
 
-func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseInode uint32) (fusefs.InodeEmbedder, error) {
+const (
+	OverlayOpaqueAll OverlayOpaqueType = iota
+	OverlayOpaqueTrusted
+	OverlayOpaqueUser
+)
+
+var opaqueXattrs = map[OverlayOpaqueType][]string{
+	OverlayOpaqueAll:     {"trusted.overlay.opaque", "user.overlay.opaque"},
+	OverlayOpaqueTrusted: {"trusted.overlay.opaque"},
+	OverlayOpaqueUser:    {"user.overlay.opaque"},
+}
+
+func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseInode uint32, opaque OverlayOpaqueType) (fusefs.InodeEmbedder, error) {
 	rootID := r.Metadata().RootID()
 	rootAttr, err := r.Metadata().GetAttr(rootID)
 	if err != nil {
 		return nil, err
 	}
+	opq, ok := opaqueXattrs[opaque]
+	if !ok {
+		return nil, fmt.Errorf("Unknown overlay opaque type")
+	}
 	ffs := &fs{
-		r:           r,
-		layerDigest: layerDgst,
-		baseInode:   baseInode,
-		rootID:      rootID,
+		r:            r,
+		layerDigest:  layerDgst,
+		baseInode:    baseInode,
+		rootID:       rootID,
+		opaqueXattrs: opq,
 	}
 	ffs.s = ffs.newState(layerDgst, blob)
 	return &node{
@@ -83,11 +100,12 @@ func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseIno
 
 // fs contains global metadata used by nodes
 type fs struct {
-	r           reader.Reader
-	s           *state
-	layerDigest digest.Digest
-	baseInode   uint32
-	rootID      uint32
+	r            reader.Reader
+	s            *state
+	layerDigest  digest.Digest
+	baseInode    uint32
+	rootID       uint32
+	opaqueXattrs []string
 }
 
 func (fs *fs) inodeOfState() uint64 {
@@ -335,7 +353,7 @@ var _ = (fusefs.NodeGetxattrer)((*node)(nil))
 func (n *node) Getxattr(ctx context.Context, attr string, dest []byte) (uint32, syscall.Errno) {
 	ent := n.attr
 	opq := n.isOpaque()
-	for _, opaqueXattr := range opaqueXattrs {
+	for _, opaqueXattr := range n.fs.opaqueXattrs {
 		if attr == opaqueXattr && opq {
 			// This node is an opaque directory so give overlayfs-compliant indicator.
 			if len(dest) < len(opaqueXattrValue) {
@@ -361,7 +379,7 @@ func (n *node) Listxattr(ctx context.Context, dest []byte) (uint32, syscall.Errn
 	var attrs []byte
 	if opq {
 		// This node is an opaque directory so add overlayfs-compliant indicator.
-		for _, opaqueXattr := range opaqueXattrs {
+		for _, opaqueXattr := range n.fs.opaqueXattrs {
 			attrs = append(attrs, []byte(opaqueXattr+"\x00")...)
 		}
 	}

--- a/store/manager.go
+++ b/store/manager.go
@@ -58,7 +58,7 @@ func NewLayerManager(ctx context.Context, root string, hosts source.RegistryHost
 		maxConcurrency = defaultMaxConcurrency
 	}
 	tm := task.NewBackgroundTaskManager(maxConcurrency, 5*time.Second)
-	r, err := layer.NewResolver(root, tm, cfg, nil, metadataStore) // TODO: support IPFS
+	r, err := layer.NewResolver(root, tm, cfg, nil, metadataStore, layer.OverlayOpaqueAll) // TODO: support IPFS
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup resolver: %w", err)
 	}


### PR DESCRIPTION
Currently, stargz-snapshotter's filesystem adds **both** `"trusted.overlay.opaque"` and `"user.overlay.opaque"` to each opaque directory. But overlayfs uses **either** `"trusted.overlay.opaque"`(userxattr=false) or `"user.overlay.opaque"`(userxattr=true) for the opaque xattr and prevents it to be copied up to the upper. Thus the other (i.e. `"user.overlay.opaque"` when userxattr=false or `"trusted.overlay.opaque"`  when userxattr=true) is treated as a normal xattr and can be copied up.

This behaviour of copying up of the xattr is problematic for BuildKit's overlayfs differ because it mistakenly treats a dir with the **copied up** opaque xattr as an opaque dir and creates unnecessary whiteout files. (this causes https://github.com/moby/buildkit/issues/2720.)

This commit fixes this issue by allowing the caller of `fs.NewFilesystem` (e.g. BuildKit) to choose whether of `"user.overlay.opaque"` or `"trusted.overlay.opaque"` (or the both) to use for the opaque dir. If the caller uses `userxattr` option for overlayfs, it should specify `"user.overlay.opaque"`. If not, should specify `"trusted.overlay.opaque"`.

This issue can be reproduced with the example provided by https://github.com/moby/buildkit/issues/2720.

```console
# mkdir -p /tmp/ctx && cat <<EOF > /tmp/ctx/Dockerfile
FROM registry2-buildkit:5000/python:3.9-esgz as base
RUN pip --help
RUN echo hello_world
RUN ls /usr/local/lib/python3.9/site-packages/pip/_internal/cli/main.py
EOF
# nerdctl build --cache-to type=inline --output type=image,name=registry2-buildkit:5000/repo:something,push=true /tmp/ctx

(clear cache here)

# sed -i 's/hello_world/hello_world_/' /tmp/ctx/Dockerfile
# nerdctl build --cache-from registry2-buildkit:5000/repo:something /tmp/ctx
```

The last build fails:

```
[+] Building 3.3s (9/9) FINISHED                                                                                                                                                                                                                                                         
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                0.1s
 => => transferring dockerfile: 201B                                                                                                                                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                   0.1s
 => => transferring context: 2B                                                                                                                                                                                                                                                     0.0s
 => [internal] load metadata for registry2-buildkit:5000/python:3.9-esgz                                                                                                                                                                                                            0.1s
 => [auth] sharing credentials for registry2-buildkit:5000                                                                                                                                                                                                                          0.0s
 => importing cache manifest from registry2-buildkit:5000/repo:something                                                                                                                                                                                                            0.0s
 => [1/4] FROM registry2-buildkit:5000/python:3.9-esgz@sha256:41b443dadc9900a26845b974e83a33666cd9de9088304a108a5b448776322007                                                                                                                                                      0.0s
 => => resolve registry2-buildkit:5000/python:3.9-esgz@sha256:41b443dadc9900a26845b974e83a33666cd9de9088304a108a5b448776322007                                                                                                                                                      0.0s
 => [2/4] RUN pip --help                                                                                                                                                                                                                                                            0.7s
 => => extracting sha256:bdfd511c91ed6482cc7c41d00e906b26162c4f433ef4aa5d031da646cd924a1a                                                                                                                                                                                           0.1s
 => [3/4] RUN echo hello_world_                                                                                                                                                                                                                                                     0.7s
 => ERROR [4/4] RUN ls /usr/local/lib/python3.9/site-packages/pip/_internal/cli/main.py                                                                                                                                                                                             0.8s
                                                                                                                                                                                                                                                                                         
------
 > [4/4] RUN ls /usr/local/lib/python3.9/site-packages/pip/_internal/cli/main.py:
#0 0.698 ls: cannot access '/usr/local/lib/python3.9/site-packages/pip/_internal/cli/main.py': No such file or directory
------
Dockerfile:4
--------------------
   2 |     RUN pip --help
   3 |     RUN echo hello_world_
   4 | >>> RUN ls /usr/local/lib/python3.9/site-packages/pip/_internal/cli/main.py
   5 |     
--------------------
error: failed to solve: process "/bin/sh -c ls /usr/local/lib/python3.9/site-packages/pip/_internal/cli/main.py" did not complete successfully: exit code: 2
```

The exported cache contains an unnecessary whitout for `usr/local/lib/python3.9/site-packages/pip/_internal/cli/main.py`.

```console
# crane blob registry2-buildkit:5000/repo:something@sha256:48cb6bf9990853b88d3a7fd3debd1a6399b4f276b48ed13a5a079137c3cb74b7 | tar -z --list
...
usr/local/lib/python3.9/site-packages/pip/_internal/cli/.wh.main.py
...
```
