### PR TITLE
Migrate from `ioutil` to `io` and `os`

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"sync"
@@ -61,7 +60,7 @@ func Analyze(ctx context.Context, client *containerd.Client, ref string, opts ..
 		return "", fmt.Errorf("wait-on-signal option cannot be used with terminal option")
 	}
 
-	target, err := ioutil.TempDir("", "target")
+	target, err := os.MkdirTemp("", "target")
 	if err != nil {
 		return "", err
 	}

--- a/analyzer/recorder/recorder_test.go
+++ b/analyzer/recorder/recorder_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -202,7 +201,7 @@ func TestNodeIndex(t *testing.T) {
 		},
 	}
 
-	tempDir, err := ioutil.TempDir("", "test-recorder")
+	tempDir, err := os.MkdirTemp("", "test-recorder")
 	if err != nil {
 		t.Fatalf("failed to prepare content store dir: %v", err)
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -365,7 +364,7 @@ func (dc *directoryCache) cachePath(key string) string {
 }
 
 func (dc *directoryCache) wipFile(key string) (*os.File, error) {
-	return ioutil.TempFile(dc.wipDirectory, key+"-*")
+	return os.CreateTemp(dc.wipDirectory, key+"-*")
 }
 
 func NewMemoryCache() BlobCache {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -26,7 +26,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -39,7 +38,7 @@ func TestDirectoryCache(t *testing.T) {
 
 	// with enough memory cache
 	newCache := func() (BlobCache, cleanFunc) {
-		tmp, err := ioutil.TempDir("", "testcache")
+		tmp, err := os.MkdirTemp("", "testcache")
 		if err != nil {
 			t.Fatalf("failed to make tempdir: %v", err)
 		}
@@ -56,7 +55,7 @@ func TestDirectoryCache(t *testing.T) {
 
 	// with smaller memory cache
 	newCache = func() (BlobCache, cleanFunc) {
-		tmp, err := ioutil.TempDir("", "testcache")
+		tmp, err := os.MkdirTemp("", "testcache")
 		if err != nil {
 			t.Fatalf("failed to make tempdir: %v", err)
 		}

--- a/cmd/containerd-stargz-grpc/db/reader.go
+++ b/cmd/containerd-stargz-grpc/db/reader.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -221,7 +220,7 @@ func (r *reader) init(decompressedR io.Reader, rOpts metadata.Options) (retErr e
 		return fmt.Errorf("failed to get a unique id for metadata reader")
 	}
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -832,7 +831,7 @@ func (fr *fileReader) ReadAt(p []byte, off int64) (n int, err error) {
 	}
 	defer dr.Close()
 	base := off - ent.chunkOffset
-	if n, err := io.CopyN(ioutil.Discard, dr, base); n != base || err != nil {
+	if n, err := io.CopyN(io.Discard, dr, base); n != base || err != nil {
 		return 0, fmt.Errorf("discard of %d bytes = %v, %v", base, n, err)
 	}
 	return io.ReadFull(dr, p)

--- a/cmd/containerd-stargz-grpc/db/reader_test.go
+++ b/cmd/containerd-stargz-grpc/db/reader_test.go
@@ -18,7 +18,6 @@ package db
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -41,7 +40,7 @@ func TestFSLayer(t *testing.T) {
 }
 
 func newTestableReader(sr *io.SectionReader, opts ...metadata.Option) (metadata.TestableReader, error) {
-	f, err := ioutil.TempFile("", "readertestdb")
+	f, err := os.CreateTemp("", "readertestdb")
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +64,7 @@ func newTestableReader(sr *io.SectionReader, opts ...metadata.Option) (metadata.
 }
 
 func newStore(sr *io.SectionReader, opts ...metadata.Option) (metadata.Reader, error) {
-	f, err := ioutil.TempFile("", "readertestdb")
+	f, err := os.CreateTemp("", "readertestdb")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ctr-remote/commands/flags.go
+++ b/cmd/ctr-remote/commands/flags.go
@@ -22,7 +22,6 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -338,7 +337,7 @@ func withResolveConfig(clicontext *cli.Context) (specOpt oci.SpecOpts, cleanup f
 	}
 
 	// Generate /etc/hosts and /etc/resolv.conf
-	resolvDir, err := ioutil.TempDir("", "tmpetc")
+	resolvDir, err := os.MkdirTemp("", "tmpetc")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -369,7 +368,7 @@ func withResolveConfig(clicontext *cli.Context) (specOpt oci.SpecOpts, cleanup f
 			return
 		}
 	}
-	if err := ioutil.WriteFile(etcResolvConfPath, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(etcResolvConfPath, buf.Bytes(), 0644); err != nil {
 		rErr = fmt.Errorf("failed to write contents to /etc/resolv.conf: %w", err)
 		return
 	}
@@ -404,7 +403,7 @@ func withResolveConfig(clicontext *cli.Context) (specOpt oci.SpecOpts, cleanup f
 			return
 		}
 	}
-	if err := ioutil.WriteFile(etcHostsPath, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(etcHostsPath, buf.Bytes(), 0644); err != nil {
 		rErr = fmt.Errorf("failed to write contents to /etc/hosts: %w", err)
 		return
 	}

--- a/estargz/build.go
+++ b/estargz/build.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -511,7 +510,7 @@ type tempFiles struct {
 }
 
 func (tf *tempFiles) TempFile(dir, pattern string) (*os.File, error) {
-	f, err := ioutil.TempFile(dir, pattern)
+	f, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/estargz/build_test.go
+++ b/estargz/build_test.go
@@ -28,7 +28,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"testing"
 )
@@ -425,11 +424,11 @@ func TestSort(t *testing.T) {
 
 							}
 
-							got, err := ioutil.ReadAll(gotTar)
+							got, err := io.ReadAll(gotTar)
 							if err != nil {
 								t.Fatal("failed to read got tar payload")
 							}
-							want, err := ioutil.ReadAll(wantTar)
+							want, err := io.ReadAll(wantTar)
 							if err != nil {
 								t.Fatal("failed to read want tar payload")
 							}

--- a/estargz/estargz.go
+++ b/estargz/estargz.go
@@ -31,7 +31,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -579,7 +578,7 @@ func (fr *fileReader) ReadAt(p []byte, off int64) (n int, err error) {
 		return 0, fmt.Errorf("fileReader.ReadAt.decompressor.Reader: %v", err)
 	}
 	defer dr.Close()
-	if n, err := io.CopyN(ioutil.Discard, dr, off); n != off || err != nil {
+	if n, err := io.CopyN(io.Discard, dr, off); n != off || err != nil {
 		return 0, fmt.Errorf("discard of %d bytes = %v, %v", off, n, err)
 	}
 	return io.ReadFull(dr, p)
@@ -933,7 +932,7 @@ func (w *Writer) appendTar(r io.Reader, lossless bool) error {
 			}
 		}
 	}
-	remainDest := ioutil.Discard
+	remainDest := io.Discard
 	if lossless {
 		remainDest = dst // Preserve the remaining bytes in lossless mode
 	}

--- a/estargz/gzip_test.go
+++ b/estargz/gzip_test.go
@@ -28,7 +28,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 )
 
@@ -70,7 +69,7 @@ func (gc *gzipController) CountStreams(t *testing.T, b []byte) (numStreams int) 
 			t.Fatalf("countStreams(gzip), Reset: %v", err)
 		}
 		zr.Multistream(false)
-		n, err := io.Copy(ioutil.Discard, zr)
+		n, err := io.Copy(io.Discard, zr)
 		if err != nil {
 			t.Fatalf("countStreams(gzip), Copy: %v", err)
 		}

--- a/estargz/testutil.go
+++ b/estargz/testutil.go
@@ -31,7 +31,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -287,11 +286,11 @@ func isSameTarGz(t *testing.T, controller TestingController, a, b []byte) bool {
 			return false
 
 		}
-		aFile, err := ioutil.ReadAll(aTar)
+		aFile, err := io.ReadAll(aTar)
 		if err != nil {
 			t.Fatal("failed to read tar payload of A")
 		}
-		bFile, err := ioutil.ReadAll(bTar)
+		bFile, err := io.ReadAll(bTar)
 		if err != nil {
 			t.Fatal("failed to read tar payload of B")
 		}

--- a/estargz/zstdchunked/zstdchunked_test.go
+++ b/estargz/zstdchunked/zstdchunked_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/containerd/stargz-snapshotter/estargz"
@@ -119,7 +118,7 @@ func (zc *zstdController) CountStreams(t *testing.T, b []byte) (numStreams int) 
 				continue
 			}
 			defer zr.Close()
-			res, err := ioutil.ReadAll(zr)
+			res, err := io.ReadAll(zr)
 			if err != nil && err != io.ErrUnexpectedEOF {
 				t.Fatalf("countStreams(zstd), ReadAll: %v", err)
 			}

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -211,7 +210,7 @@ func newCache(root string, cacheType string, cfg config.Config) (cache.BlobCache
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
 	}
-	cachePath, err := ioutil.TempDir(root, "")
+	cachePath, err := os.MkdirTemp(root, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize directory cache: %w", err)
 	}

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -29,7 +29,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -200,7 +199,7 @@ func testPrefetch(t *testing.T, factory metadata.Store) {
 					t.Fatalf("failed to open file %q", file)
 				}
 				blob.readCalled = false
-				if _, err := io.Copy(ioutil.Discard, io.NewSectionReader(wantFile, 0, e.Size)); err != nil {
+				if _, err := io.Copy(io.Discard, io.NewSectionReader(wantFile, 0, e.Size)); err != nil {
 					t.Fatalf("failed to read file %q", file)
 				}
 				if blob.readCalled {

--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -29,7 +29,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"sync"
@@ -242,7 +241,7 @@ func (vr *VerifiableReader) cacheWithReader(ctx context.Context, currentDepth in
 					vr.storeLastVerifyErr(err)
 					vr.prohibitVerifyFailureMu.RUnlock()
 				}
-				tee := ioutil.Discard
+				tee := io.Discard
 				if v != nil {
 					tee = io.Writer(v) // verification is required
 				}

--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"sort"
 	"strings"
@@ -193,7 +192,7 @@ func (b *blob) cacheAt(offset int64, size int64, fr fetcher, cacheOpts *options)
 		if r, err := b.cache.Get(fr.genID(reg), cacheOpts.cacheOpts...); err == nil {
 			return r.Close() // nop if the cache hits
 		}
-		discard[reg] = ioutil.Discard
+		discard[reg] = io.Discard
 		return nil
 	})
 	if err != nil {

--- a/fs/remote/blob_test.go
+++ b/fs/remote/blob_test.go
@@ -26,7 +26,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -646,7 +645,7 @@ func (c *callsCountRoundTripper) RoundTrip(req *http.Request) (res *http.Respons
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     header,
-		Body:       convertBody(ioutil.NopCloser(bytes.NewReader([]byte(c.content)))),
+		Body:       convertBody(io.NopCloser(bytes.NewReader([]byte(c.content)))),
 	}, nil
 }
 
@@ -659,7 +658,7 @@ func (c *calledRoundTripper) RoundTrip(req *http.Request) (res *http.Response, e
 	res = &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     make(http.Header),
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte("test"))),
+		Body:       io.NopCloser(bytes.NewReader([]byte("test"))),
 	}
 	return
 }
@@ -691,7 +690,7 @@ func multiRoundTripper(t *testing.T, contents []byte, opts ...interface{}) Round
 		return &http.Response{
 			StatusCode: statusCode,
 			Header:     make(http.Header),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	}
 
@@ -740,7 +739,7 @@ func multiRoundTripper(t *testing.T, contents []byte, opts ...interface{}) Round
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     header,
-					Body:       convertBody(ioutil.NopCloser(bytes.NewReader(contents))),
+					Body:       convertBody(io.NopCloser(bytes.NewReader(contents))),
 				}
 			}
 		}
@@ -768,7 +767,7 @@ func multiRoundTripper(t *testing.T, contents []byte, opts ...interface{}) Round
 			return &http.Response{
 				StatusCode: http.StatusPartialContent,
 				Header:     header,
-				Body:       convertBody(ioutil.NopCloser(bytes.NewReader(part))),
+				Body:       convertBody(io.NopCloser(bytes.NewReader(part))),
 			}
 		}
 
@@ -809,7 +808,7 @@ func multiRoundTripper(t *testing.T, contents []byte, opts ...interface{}) Round
 		return &http.Response{
 			StatusCode: http.StatusPartialContent,
 			Header:     header,
-			Body:       convertBody(ioutil.NopCloser(&buf)),
+			Body:       convertBody(io.NopCloser(&buf)),
 		}
 	}
 }
@@ -819,7 +818,7 @@ func failRoundTripper() RoundTripFunc {
 		return &http.Response{
 			StatusCode: http.StatusInternalServerError,
 			Header:     make(http.Header),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	}
 }
@@ -827,11 +826,11 @@ func failRoundTripper() RoundTripFunc {
 func brokenBodyRoundTripper(t *testing.T, contents []byte, multiRange bool) RoundTripFunc {
 	breakReadCloser := func(r io.ReadCloser) io.ReadCloser {
 		defer r.Close()
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatalf("failed to break read closer faild to read original: %v", err)
 		}
-		return ioutil.NopCloser(bytes.NewReader(data[:len(data)/2]))
+		return io.NopCloser(bytes.NewReader(data[:len(data)/2]))
 	}
 	tr := multiRoundTripper(t, contents, allowMultiRange(multiRange), bodyConverter(breakReadCloser))
 	return func(req *http.Request) *http.Response {

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -27,7 +27,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"mime"
 	"mime/multipart"
@@ -331,7 +330,7 @@ func redirect(ctx context.Context, blobURL string, tr http.RoundTripper, timeout
 		return "", fmt.Errorf("failed to request: %w", err)
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, res.Body)
+		io.Copy(io.Discard, res.Body)
 		res.Body.Close()
 	}()
 
@@ -382,7 +381,7 @@ func getSize(ctx context.Context, url string, tr http.RoundTripper, timeout time
 		return 0, fmt.Errorf("failed to request: %w", err)
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, res.Body)
+		io.Copy(io.Discard, res.Body)
 		res.Body.Close()
 	}()
 
@@ -523,7 +522,7 @@ func (f *httpFetcher) check() error {
 		return fmt.Errorf("check failed: failed to request to registry: %w", err)
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, res.Body)
+		io.Copy(io.Discard, res.Body)
 		res.Body.Close()
 	}()
 	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusPartialContent {

--- a/fs/remote/resolver_test.go
+++ b/fs/remote/resolver_test.go
@@ -26,7 +26,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -199,7 +199,7 @@ func (tr *sampleRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			return &http.Response{
 				StatusCode: code,
 				Header:     make(http.Header),
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				Body:       io.NopCloser(bytes.NewReader([]byte{})),
 				Request:    req,
 			}, nil
 		}
@@ -211,7 +211,7 @@ func (tr *sampleRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			return &http.Response{
 				StatusCode: http.StatusMovedPermanently,
 				Header:     header,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				Body:       io.NopCloser(bytes.NewReader([]byte{})),
 				Request:    req,
 			}, nil
 		}
@@ -223,7 +223,7 @@ func (tr *sampleRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     header,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte{0})),
+				Body:       io.NopCloser(bytes.NewReader([]byte{0})),
 				Request:    req,
 			}, nil
 		}
@@ -231,7 +231,7 @@ func (tr *sampleRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	return &http.Response{
 		StatusCode: http.StatusNotFound,
 		Header:     make(http.Header),
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+		Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		Request:    req,
 	}, nil
 }
@@ -262,13 +262,13 @@ func (b *breakRoundTripper) RoundTrip(req *http.Request) (res *http.Response, er
 		res = &http.Response{
 			StatusCode: http.StatusPartialContent,
 			Header:     make(http.Header),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte("test"))),
+			Body:       io.NopCloser(bytes.NewReader([]byte("test"))),
 		}
 	} else {
 		res = &http.Response{
 			StatusCode: http.StatusInternalServerError,
 			Header:     make(http.Header),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	}
 	return
@@ -313,13 +313,13 @@ func (r *retryRoundTripper) RoundTrip(req *http.Request) (res *http.Response, er
 		res = &http.Response{
 			StatusCode: http.StatusTooManyRequests,
 			Header:     make(http.Header),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	case 2:
 		res = &http.Response{
 			StatusCode: http.StatusServiceUnavailable,
 			Header:     make(http.Header),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	default:
 		header := make(http.Header)
@@ -327,7 +327,7 @@ func (r *retryRoundTripper) RoundTrip(req *http.Request) (res *http.Response, er
 		res = &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     header,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte("test"))),
+			Body:       io.NopCloser(bytes.NewReader([]byte("test"))),
 		}
 	}
 	return

--- a/metadata/testutil.go
+++ b/metadata/testutil.go
@@ -20,7 +20,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -521,7 +520,7 @@ func hasFile(name, content string, size int64) check {
 			t.Errorf("cannot open file %q: %v", name, err)
 			return
 		}
-		data, err := ioutil.ReadAll(io.NewSectionReader(sr, 0, attr.Size))
+		data, err := io.ReadAll(io.NewSectionReader(sr, 0, attr.Size))
 		if err != nil {
 			t.Errorf("cannot read file %q: %v", name, err)
 			return

--- a/service/resolver/cri.go
+++ b/service/resolver/cri.go
@@ -29,10 +29,10 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -237,7 +237,7 @@ func getTLSConfig(registryTLSConfig TLSConfig) (*tls.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get system cert pool: %w", err)
 		}
-		caCert, err := ioutil.ReadFile(registryTLSConfig.CAFile)
+		caCert, err := os.ReadFile(registryTLSConfig.CAFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load CA file: %w", err)
 		}

--- a/snapshot/overlayutils/check.go
+++ b/snapshot/overlayutils/check.go
@@ -23,7 +23,6 @@ package overlayutils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -41,7 +40,7 @@ import (
 //
 // Ported from moby overlay2.
 func SupportsMultipleLowerDir(d string) error {
-	td, err := ioutil.TempDir(d, "multiple-lowerdir-check")
+	td, err := os.MkdirTemp(d, "multiple-lowerdir-check")
 	if err != nil {
 		return err
 	}
@@ -136,7 +135,7 @@ func NeedsUserXAttr(d string) (bool, error) {
 		}
 	}()
 
-	td, err := ioutil.TempDir(tdRoot, "")
+	td, err := os.MkdirTemp(tdRoot, "")
 	if err != nil {
 		return false, err
 	}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -19,7 +19,6 @@ package snapshot
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -552,7 +551,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 }
 
 func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
-	td, err := ioutil.TempDir(snapshotDir, "new-")
+	td, err := os.MkdirTemp(snapshotDir, "new-")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	_ "crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -55,7 +54,7 @@ func prepareWithTarget(t *testing.T, sn snapshots.Snapshotter, target, key, pare
 func TestRemotePrepare(t *testing.T) {
 	testutil.RequiresRoot(t)
 	ctx := context.TODO()
-	root, err := ioutil.TempDir("", "overlay")
+	root, err := os.MkdirTemp("", "overlay")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +105,7 @@ func TestRemotePrepare(t *testing.T) {
 func TestRemoteOverlay(t *testing.T) {
 	testutil.RequiresRoot(t)
 	ctx := context.TODO()
-	root, err := ioutil.TempDir("", "remote")
+	root, err := os.MkdirTemp("", "remote")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +152,7 @@ func TestRemoteOverlay(t *testing.T) {
 	}
 
 	// Validate the contents of the snapshot
-	data, err := ioutil.ReadFile(filepath.Join(getParents(ctx, sn, root, pKey)[0], remoteSampleFile))
+	data, err := os.ReadFile(filepath.Join(getParents(ctx, sn, root, pKey)[0], remoteSampleFile))
 	if err != nil {
 		t.Fatalf("failed to read a file in the remote snapshot: %v", err)
 	}
@@ -165,7 +164,7 @@ func TestRemoteOverlay(t *testing.T) {
 func TestRemoteCommit(t *testing.T) {
 	testutil.RequiresRoot(t)
 	ctx := context.TODO()
-	root, err := ioutil.TempDir("", "remote")
+	root, err := os.MkdirTemp("", "remote")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +186,7 @@ func TestRemoteCommit(t *testing.T) {
 	}
 
 	// Make a new active snapshot based on the remote snapshot.
-	snapshot, err := ioutil.TempDir("", "snapshot")
+	snapshot, err := os.MkdirTemp("", "snapshot")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +196,7 @@ func TestRemoteCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mount.Unmount(snapshot, 0)
-	if err := ioutil.WriteFile(filepath.Join(snapshot, "bar"), []byte("hi"), 0660); err != nil {
+	if err := os.WriteFile(filepath.Join(snapshot, "bar"), []byte("hi"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	mount.Unmount(snapshot, 0)
@@ -209,7 +208,7 @@ func TestRemoteCommit(t *testing.T) {
 	}
 
 	// Validate the committed snapshot
-	check, err := ioutil.TempDir("", "check")
+	check, err := os.MkdirTemp("", "check")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +222,7 @@ func TestRemoteCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mount.Unmount(check, 0)
-	data, err := ioutil.ReadFile(filepath.Join(check, "bar"))
+	data, err := os.ReadFile(filepath.Join(check, "bar"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,7 +306,7 @@ func TestFailureDetection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
-			root, err := ioutil.TempDir("", "remote")
+			root, err := os.MkdirTemp("", "remote")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -375,11 +374,11 @@ func TestFailureDetection(t *testing.T) {
 }
 
 func bindFileSystem(t *testing.T) FileSystem {
-	root, err := ioutil.TempDir("", "remote")
+	root, err := os.MkdirTemp("", "remote")
 	if err != nil {
 		t.Fatalf("failed to prepare working-space for bind filesystem: %q", err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(root, remoteSampleFile), []byte(remoteSampleFileContents), 0660); err != nil {
+	if err := os.WriteFile(filepath.Join(root, remoteSampleFile), []byte(remoteSampleFileContents), 0660); err != nil {
 		t.Fatalf("failed to write sample file of bind filesystem: %q", err)
 	}
 	return &bindFs{
@@ -454,7 +453,7 @@ func TestOverlay(t *testing.T) {
 
 func TestOverlayMounts(t *testing.T) {
 	ctx := context.TODO()
-	root, err := ioutil.TempDir("", "overlay")
+	root, err := os.MkdirTemp("", "overlay")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -488,7 +487,7 @@ func TestOverlayMounts(t *testing.T) {
 
 func TestOverlayCommit(t *testing.T) {
 	ctx := context.TODO()
-	root, err := ioutil.TempDir("", "overlay")
+	root, err := os.MkdirTemp("", "overlay")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -503,7 +502,7 @@ func TestOverlayCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	m := mounts[0]
-	if err := ioutil.WriteFile(filepath.Join(m.Source, "foo"), []byte("hi"), 0660); err != nil {
+	if err := os.WriteFile(filepath.Join(m.Source, "foo"), []byte("hi"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	if err := o.Commit(ctx, "base", key); err != nil {
@@ -513,7 +512,7 @@ func TestOverlayCommit(t *testing.T) {
 
 func TestOverlayOverlayMount(t *testing.T) {
 	ctx := context.TODO()
-	root, err := ioutil.TempDir("", "overlay")
+	root, err := os.MkdirTemp("", "overlay")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -597,7 +596,7 @@ func getParents(ctx context.Context, sn snapshots.Snapshotter, root, key string)
 func TestOverlayOverlayRead(t *testing.T) {
 	testutil.RequiresRoot(t)
 	ctx := context.TODO()
-	root, err := ioutil.TempDir("", "overlay")
+	root, err := os.MkdirTemp("", "overlay")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -612,7 +611,7 @@ func TestOverlayOverlayRead(t *testing.T) {
 		t.Fatal(err)
 	}
 	m := mounts[0]
-	if err := ioutil.WriteFile(filepath.Join(m.Source, "foo"), []byte("hi"), 0660); err != nil {
+	if err := os.WriteFile(filepath.Join(m.Source, "foo"), []byte("hi"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	if err := o.Commit(ctx, "base", key); err != nil {
@@ -629,7 +628,7 @@ func TestOverlayOverlayRead(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer syscall.Unmount(dest, 0)
-	data, err := ioutil.ReadFile(filepath.Join(dest, "foo"))
+	data, err := os.ReadFile(filepath.Join(dest, "foo"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -640,7 +639,7 @@ func TestOverlayOverlayRead(t *testing.T) {
 
 func TestOverlayView(t *testing.T) {
 	ctx := context.TODO()
-	root, err := ioutil.TempDir("", "overlay")
+	root, err := os.MkdirTemp("", "overlay")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -655,7 +654,7 @@ func TestOverlayView(t *testing.T) {
 		t.Fatal(err)
 	}
 	m := mounts[0]
-	if err := ioutil.WriteFile(filepath.Join(m.Source, "foo"), []byte("hi"), 0660); err != nil {
+	if err := os.WriteFile(filepath.Join(m.Source, "foo"), []byte("hi"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	if err := o.Commit(ctx, "base", key); err != nil {
@@ -667,7 +666,7 @@ func TestOverlayView(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(getParents(ctx, o, root, "/tmp/top")[0], "foo"), []byte("hi, again"), 0660); err != nil {
+	if err := os.WriteFile(filepath.Join(getParents(ctx, o, root, "/tmp/top")[0], "foo"), []byte("hi, again"), 0660); err != nil {
 		t.Fatal(err)
 	}
 	if err := o.Commit(ctx, "top", key); err != nil {

--- a/store/refs.go
+++ b/store/refs.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -252,7 +252,7 @@ func fetchManifestPlatform(ctx context.Context, fetcher remotes.Fetcher, desc oc
 	var manifest ocispec.Manifest
 	switch desc.MediaType {
 	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
-		p, err := ioutil.ReadAll(r)
+		p, err := io.ReadAll(r)
 		if err != nil {
 			return ocispec.Manifest{}, err
 		}
@@ -265,7 +265,7 @@ func fetchManifestPlatform(ctx context.Context, fetcher remotes.Fetcher, desc oc
 		return manifest, nil
 	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
 		var index ocispec.Index
-		p, err := ioutil.ReadAll(r)
+		p, err := io.ReadAll(r)
 		if err != nil {
 			return ocispec.Manifest{}, err
 		}

--- a/util/testutil/ensurehello.go
+++ b/util/testutil/ensurehello.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
@@ -57,7 +57,7 @@ func EnsureHello(ctx context.Context) (*ocispec.Descriptor, content.Store, error
 		return nil, nil, err
 	}
 
-	tempDir, err := ioutil.TempDir("", "test-estargz")
+	tempDir, err := os.MkdirTemp("", "test-estargz")
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
`ioutil` has been deprecated in go 1.16.