### PR TITLE
v0.10: Bump up github.com/prometheus/client_golang to v1.11.1

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,6 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  DOCKER_BUILD_ARGS: --build-arg=CONTAINERD_VERSION=main # do tests with the latest containerd
 
 jobs:
   integration:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: [""]
         builtin: ["true", "false"]
         metadata-store: ["memory", "db"]
         exclude:
@@ -56,8 +56,6 @@ jobs:
           builtin: "true"
         - metadata-store: "db"
           builtin: "true"
-        - metadata-store: "db"
-          buildargs: "--build-arg=CONTAINERD_VERSION=main"
     steps:
     - name: Install htpasswd for setting up private registry
       run: sudo apt-get update -y && sudo apt-get --no-install-recommends install -y apache2-utils
@@ -75,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: [""]
     steps:
     - name: Install htpasswd for setting up private registry
       run: sudo apt-get update -y && sudo apt-get --no-install-recommends install -y apache2-utils
@@ -91,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: [""]
         builtin: ["true", "false"]
         exclude:
         - buildargs: ""
@@ -112,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: [""]
         builtin: ["true", "false"]
         exclude:
         - buildargs: ""
@@ -133,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: [""]
         builtin: ["true", "false"]
         metadata-store: ["memory", "db"]
         exclude:
@@ -141,8 +139,6 @@ jobs:
           builtin: "true"
         - metadata-store: "db"
           builtin: "true"
-        - metadata-store: "db"
-          buildargs: "--build-arg=CONTAINERD_VERSION=main"
     steps:
     - uses: actions/checkout@v2
     - name: Validate containerd through CRI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,17 @@ jobs:
     - name: Build all
       run: ./script/util/make.sh build -j2
 
+  build-go116:
+    runs-on: ubuntu-20.04
+    name: Check if binaries can be built with Go 1.16
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.16.x'
+    - name: Build all
+      run: make build
+
   test:
     runs-on: ubuntu-20.04
     name: Test

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -1316,8 +1316,9 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
+github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_golang v1.11.1
 	github.com/rs/xid v1.3.0
 	github.com/sirupsen/logrus v1.8.1
 	go.etcd.io/bbolt v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -680,8 +680,9 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
+github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/script/k3s-argo-workflow/run.sh
+++ b/script/k3s-argo-workflow/run.sh
@@ -138,7 +138,6 @@ echo "result to ${RESULT_FILE}"
 wget -O "${ORG_ARGOYAML}" https://raw.githubusercontent.com/argoproj/argo-workflows/stable/manifests/quick-start-minimal.yaml
 
 git clone -b ${K3S_VERSION} --depth 1 "${K3S_REPO}" "${TMP_K3S_REPO}"
-( cd "${TMP_K3S_REPO}" && make generate )
 cat <<EOF >> "${TMP_K3S_REPO}/go.mod"
 replace github.com/containerd/stargz-snapshotter => "$(realpath ${REPO})"
 replace github.com/containerd/stargz-snapshotter/estargz => "$(realpath ${REPO}/estargz)"

--- a/script/k3s/run-k3s.sh
+++ b/script/k3s/run-k3s.sh
@@ -51,7 +51,6 @@ trap 'cleanup "$?"' EXIT SIGHUP SIGINT SIGQUIT SIGTERM
 
 echo "Preparing node image..."
 git clone -b ${K3S_VERSION} --depth 1 "${K3S_REPO}" "${TMP_K3S_REPO}"
-( cd "${TMP_K3S_REPO}" && make generate )
 cat <<EOF >> "${TMP_K3S_REPO}/go.mod"
 replace github.com/containerd/stargz-snapshotter => "$(realpath ${REPO})"
 replace github.com/containerd/stargz-snapshotter/estargz => "$(realpath ${REPO}/estargz)"


### PR DESCRIPTION
Needed to close: https://bugzilla.redhat.com/show_bug.cgi?id=2067450
Prometheus relase note (Addresses CVE-2022-21698): https://github.com/prometheus/client_golang/releases/tag/v1.11.1

It seems that we need to start maintaining v0.10 because of the following reason:

[Kubernetes v1.23+ can only be built with Go 1.17+](https://github.com/kubernetes/kubernetes/commit/434ce4336ab06b3c34208822d558c0432ada3ad3#r60634685) because `sigs.k8s.io/json` uses functionalities available Go 1.17+.
Stargz snapshotter v0.11+ (depends on k8s.io/* 1.23) also depends on `sigs.k8s.io/json` so it can only be built with Go 1.17+.
This makes it impossible to provide stargz-snapshotter fedora packages for Fedora 35 where [Go 1.16 is the latest available Go compiler](https://src.fedoraproject.org/rpms/golang).

We address this issue by starting to maintain v0.10 branch which is built with Kubernetes v1.22.
We don't add any new features to this branch but apply only important dependency upgrades.
We'll maintain this branch until Fedora 35 EOL ([four weeks after the release of Fedora 37](https://docs.fedoraproject.org/en-US/releases/lifecycle/#_maintenance_schedule)).
