### PR TITLE
CI: build with Go 1.18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -228,7 +228,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.x'
+          go-version: '1.18.x'
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/stargz-snapshotter

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ARG CRI_TOOLS_VERSION=v1.23.0
 # Legacy builder that doesn't support TARGETARCH should set this explicitly using --build-arg.
 # If TARGETARCH isn't supported by the builder, the default value is "amd64".
 
-FROM golang:1.17-bullseye AS golang-base
+FROM golang:1.18-bullseye AS golang-base
 
 # Build containerd
 FROM golang-base AS containerd-dev

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ check:
 	@cd ./ipfs ; GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
 
 install-check-tools:
-	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.42.1
+	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.45.2
 
 install:
 	@echo "$@"

--- a/script/benchmark/test.sh
+++ b/script/benchmark/test.sh
@@ -71,11 +71,7 @@ FROM ${BENCHMARKING_BASE_IMAGE_NAME}
 
 RUN apt-get update -y && \
     apt-get --no-install-recommends install -y python jq && \
-    git clone https://github.com/google/go-containerregistry \
-              \${GOPATH}/src/github.com/google/go-containerregistry && \
-    cd \${GOPATH}/src/github.com/google/go-containerregistry && \
-    git checkout 4b1985e5ea2104672636879e1694808f735fd214 && \
-    GO111MODULE=on go get github.com/google/go-containerregistry/cmd/crane
+    go install github.com/google/go-containerregistry/cmd/crane@v0.8.0
 
 COPY ./config /
 

--- a/script/cri-containerd/test.sh
+++ b/script/cri-containerd/test.sh
@@ -131,7 +131,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 ENV GOPATH=/go
 # Do not install git and its dependencies here which will cause failure of building the image
 RUN apt-get update && apt-get install -y --no-install-recommends make && \
-    curl -Ls https://dl.google.com/go/go1.17.linux-\${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local -xz && \
+    curl -Ls https://dl.google.com/go/go1.18.linux-\${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local -xz && \
     go install github.com/onsi/ginkgo/ginkgo@${GINKGO_VERSION} && \
     mkdir -p \${GOPATH}/src/github.com/kubernetes-sigs/cri-tools /tmp/cri-tools && \
     curl -sL https://github.com/kubernetes-sigs/cri-tools/archive/refs/tags/v${CRI_TOOLS_VERSION}.tar.gz | tar -C /tmp/cri-tools -xz && \

--- a/script/cri-o/test.sh
+++ b/script/cri-o/test.sh
@@ -59,7 +59,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 ENV GOPATH=/go
 # Do not install git and its dependencies here which will cause failure of building the image
 RUN apt-get update && apt-get install -y --no-install-recommends make && \
-    curl -Ls https://dl.google.com/go/go1.17.linux-\${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local -xz && \
+    curl -Ls https://dl.google.com/go/go1.18.linux-\${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local -xz && \
     go install github.com/onsi/ginkgo/ginkgo@${GINKGO_VERSION} && \
     mkdir -p \${GOPATH}/src/github.com/kubernetes-sigs/cri-tools /tmp/cri-tools && \
     curl -sL https://github.com/kubernetes-sigs/cri-tools/archive/refs/tags/v${CRI_TOOLS_VERSION}.tar.gz | tar -C /tmp/cri-tools -xz && \

--- a/script/integration/test.sh
+++ b/script/integration/test.sh
@@ -82,10 +82,7 @@ FROM ${INTEGRATION_BASE_IMAGE_NAME}
 
 RUN apt-get update -y && \
     apt-get --no-install-recommends install -y iptables jq && \
-    git clone https://github.com/google/crfs \${GOPATH}/src/github.com/google/crfs && \
-    cd \${GOPATH}/src/github.com/google/crfs && \
-    git checkout 71d77da419c90be7b05d12e59945ac7a8c94a543 && \
-    GO111MODULE=on go get github.com/google/crfs/stargz/stargzify && \
+    go install github.com/google/crfs/stargz/stargzify@71d77da419c90be7b05d12e59945ac7a8c94a543 && \
     wget https://dist.ipfs.io/go-ipfs/${IPFS_VERSION}/go-ipfs_${IPFS_VERSION}_linux-amd64.tar.gz && \
     tar -xvzf go-ipfs_${IPFS_VERSION}_linux-amd64.tar.gz && \
     cd go-ipfs && \

--- a/script/optimize/test.sh
+++ b/script/optimize/test.sh
@@ -83,7 +83,7 @@ ARG TARGETARCH
 
 RUN apt-get update -y && \
     apt-get --no-install-recommends install -y jq iptables zstd && \
-    GO111MODULE=on go get github.com/google/go-containerregistry/cmd/crane && \
+    go install github.com/google/go-containerregistry/cmd/crane@v0.8.0 && \
     mkdir -p /opt/tmp/cni/bin /etc/tmp/cni/net.d && \
     curl -Ls https://github.com/containernetworking/plugins/releases/download/v${CNI_PLUGINS_VERSION}/cni-plugins-linux-\${TARGETARCH:-amd64}-v${CNI_PLUGINS_VERSION}.tgz | tar xzv -C /opt/tmp/cni/bin && \
     curl -sSL https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-full-${NERDCTL_VERSION}-linux-\${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local -zx bin/buildkitd bin/buildctl


### PR DESCRIPTION
We'll update go.mod to Go 1.18 after k3s updates go.mod to Go 1.18.