### PR TITLE
Prepare for v0.10.2

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/containerd/containerd v1.6.0-beta.2.0.20211117185425-a776a27af54a
 	github.com/containerd/containerd/api v1.6.0-beta.2.0.20211117185425-a776a27af54a
 	github.com/containerd/go-cni v1.1.1-0.20211026134925-aa8bf14323a5
-	github.com/containerd/stargz-snapshotter v0.10.1
-	github.com/containerd/stargz-snapshotter/estargz v0.10.1
-	github.com/containerd/stargz-snapshotter/ipfs v0.10.1
+	github.com/containerd/stargz-snapshotter v0.10.2
+	github.com/containerd/stargz-snapshotter/estargz v0.10.2
+	github.com/containerd/stargz-snapshotter/ipfs v0.10.2
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/go-metrics v0.0.1
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.0-beta.2.0.20211117185425-a776a27af54a
 	github.com/containerd/continuity v0.2.1
-	github.com/containerd/stargz-snapshotter/estargz v0.10.1
+	github.com/containerd/stargz-snapshotter/estargz v0.10.2
 	github.com/docker/cli v20.10.10+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect


### PR DESCRIPTION
```
This release is provided only for environments where Go 1.17+ isn't available to build binaries (e.g. Fedora 35).
Use v0.11+ releases.

## Notable Change

- Upgrades github.com/prometheus/client_golang from v1.11.0 to v1.11.1 and addresses CVE-2022-21698 (#724).
```

