### PR TITLE
ctr-remote: ensure cancel cleanly when recieves signals during conversion

### DIFF
--- a/nativeconverter/estargz/estargz.go
+++ b/nativeconverter/estargz/estargz.go
@@ -77,7 +77,7 @@ func LayerConvertFunc(opts ...estargz.Option) converter.ConvertFunc {
 		}
 		defer ra.Close()
 		sr := io.NewSectionReader(ra, 0, desc.Size)
-		blob, err := estargz.Build(sr, opts...)
+		blob, err := estargz.Build(sr, append(opts, estargz.WithContext(ctx))...)
 		if err != nil {
 			return nil, err
 		}

--- a/nativeconverter/zstdchunked/zstdchunked.go
+++ b/nativeconverter/zstdchunked/zstdchunked.go
@@ -114,7 +114,7 @@ func LayerConvertFunc(opts ...estargz.Option) converter.ConvertFunc {
 				Metadata:         metadata,
 			},
 		}))
-		blob, err := estargz.Build(uncompressedSR, opts...)
+		blob, err := estargz.Build(uncompressedSR, append(opts, estargz.WithContext(ctx))...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When ctr-remote receives signals during conversion, it currently cannot cancel cleanly and leaves some temp files.
This commit fixes this issue.

### main version

cannot cancel cleanly.

```console
# ctr-remote i optimize registry:5000/ubuntu:20.04-org foo
INFO[0000] analyzing blob "sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe" 
INFO[0000] analyzing blob "sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3" 
INFO[0000] analyzing blob "sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709" 
INFO[0000] waiting for 10s ...                          
INFO[0000] container exit with code 0                   
INFO[2022-04-08T02:24:50.396344056Z] shim disconnected                             id=c97ppsfe2ibaaiirntm0
WARN[2022-04-08T02:24:50.396455621Z] cleaning up after shim disconnected           id=c97ppsfe2ibaaiirntm0 namespace=default
INFO[2022-04-08T02:24:50.396466611Z] cleaning up dead shim                        
WARN[2022-04-08T02:24:50.420887043Z] cleanup warnings time="2022-04-08T02:24:50Z" level=info msg="starting signal loop" namespace=default pid=104129 
INFO[0000] converting...                                 digest="sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe"
INFO[0000] converting...                                 digest="sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3"
INFO[0000] converting...                                 digest="sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709"
  C-c C-c^C
# ls /tmp/
uncompresseddata499525600
```

```console
# ctr-remote i convert --estargz --oci registry:5000/ubuntu:20.04-org foo
  C-c C-c^C
# ls /tmp/
esgzdata1041668335  esgzdata1108552712	esgzdata2609414019  esgzdata2787121175	esgzdata3750809904  esgzdata524932944  esgzdata600126681  esgzdata778947561  esgzdata874216793	uncompresseddata3151736297
```

### PR version

cancels cleanly.

```console
# ctr-remote i optimize registry:5000/ubuntu:20.04-org foo
INFO[0000] analyzing blob "sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe" 
INFO[0000] analyzing blob "sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3" 
INFO[0000] analyzing blob "sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709" 
INFO[0000] waiting for 10s ...                          
INFO[0000] container exit with code 0                   
INFO[2022-04-08T02:27:23.281296239Z] shim disconnected                             id=c97pr2ne2ibanqjvcoeg
WARN[2022-04-08T02:27:23.281342827Z] cleaning up after shim disconnected           id=c97pr2ne2ibanqjvcoeg namespace=default
INFO[2022-04-08T02:27:23.281355320Z] cleaning up dead shim                        
WARN[2022-04-08T02:27:23.308342504Z] cleanup warnings time="2022-04-08T02:27:23Z" level=info msg="starting signal loop" namespace=default pid=104738 
INFO[0000] converting...                                 digest="sha256:345e3491a907bb7c6f1bdddcf4a94284b8b6ddd77eb7d93f09432b17b20f2bbe"
INFO[0000] converting...                                 digest="sha256:57671312ef6fdbecf340e5fed0fb0863350cd806c92b1fdd7978adbd02afc5c3"
INFO[0000] converting...                                 digest="sha256:5e9250ddb7d0fa6d13302c7c3e6a0aa40390e42424caed1e5289077ee4054709"
  C-c C-c^CINFO[0002] Got interrupt                                
ctr-remote: error from context "context canceled": error copying "usr/lib/x86_64-linux-gnu/perl-base/Exporter/Heavy.pm": Failed to write tar payload: read /tmp/uncompresseddata782059284: file already closed
# ls /tmp/
```

```console
# ctr-remote i convert --estargz --oci registry:5000/ubuntu:20.04-org foo
  C-c C-c^CINFO[0001] Got interrupt                                
ctr-remote: error from context "context canceled": write /tmp/uncompresseddata620393635: file already closed
```
