### PR TITLE
Prepare for v0.11.4

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/containerd/containerd v1.6.2
 	github.com/containerd/go-cni v1.1.4
-	github.com/containerd/stargz-snapshotter v0.11.3
-	github.com/containerd/stargz-snapshotter/estargz v0.11.3
-	github.com/containerd/stargz-snapshotter/ipfs v0.11.3
+	github.com/containerd/stargz-snapshotter v0.11.4
+	github.com/containerd/stargz-snapshotter/estargz v0.11.4
+	github.com/containerd/stargz-snapshotter/ipfs v0.11.4
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.9.6

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.2
 	github.com/containerd/continuity v0.3.0
-	github.com/containerd/stargz-snapshotter/estargz v0.11.3
+	github.com/containerd/stargz-snapshotter/estargz v0.11.4
 	github.com/docker/cli v20.10.14+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect


### PR DESCRIPTION
```
## Notable Changes

- ctr-remote: ensure cancel cleanly when recieves signals during conversion (#733)
- dependencies: Bump up github.com/ipld/go-codec-dagpb from v1.3.0 to v1.3.2 to address https://github.com/advisories/GHSA-g3vv-g2j5-45f2 (#736)
```