### PR TITLE
Bump up kindest/node to v1.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,7 +196,7 @@ RUN apt-get update && apt-get install -y iptables && \
     curl -Ls https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-${TARGETARCH:-amd64}-${CNI_PLUGINS_VERSION}.tgz | tar xzv -C /opt/cni/bin
 
 # Image which can be used as a node image for KinD (containerd with builtin snapshotter)
-FROM kindest/node:v1.23.5 AS kind-builtin-snapshotter
+FROM kindest/node:v1.24.0 AS kind-builtin-snapshotter
 # see https://medium.com/nttlabs/ubuntu-21-10-and-fedora-35-do-not-work-on-docker-20-10-9-1cd439d9921
 ADD https://github.com/AkihiroSuda/clone3-workaround/releases/download/v1.0.0/clone3-workaround.x86_64 /clone3-workaround
 RUN chmod 755 /clone3-workaround
@@ -237,7 +237,7 @@ COPY ./script/config-cri-o/ /
 ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
 
 # Image which can be used as a node image for KinD
-FROM kindest/node:v1.23.5
+FROM kindest/node:v1.24.0
 # see https://medium.com/nttlabs/ubuntu-21-10-and-fedora-35-do-not-work-on-docker-20-10-9-1cd439d9921
 ADD https://github.com/AkihiroSuda/clone3-workaround/releases/download/v1.0.0/clone3-workaround.x86_64 /clone3-workaround
 RUN chmod 755 /clone3-workaround


### PR DESCRIPTION
https://github.com/containerd/stargz-snapshotter/pull/783

This commit includes the fix for tests codes to make it work on Kubernetes v1.24.
Since this version, secret for service account needs to be manually created.
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token
