### PR TITLE
Ignore `NumLink` field when encoding TOC

### DIFF
--- a/estargz/types.go
+++ b/estargz/types.go
@@ -159,7 +159,8 @@ type TOCEntry struct {
 
 	// NumLink is the number of entry names pointing to this entry.
 	// Zero means one name references this entry.
-	NumLink int
+	// This field is calculated during runtime and not recorded in TOC JSON.
+	NumLink int `json:"-"`
 
 	// Xattrs are the extended attribute for the entry.
 	Xattrs map[string][]byte `json:"xattrs,omitempty"`


### PR DESCRIPTION
`NumLink` is used during mounting the layer but is not defined in estargz spec. This field doesn't need to be encoded to JSON.

main:

```
# ctr-remote content get sha256:ededda63bf170fd64c2b19834aa00b44b66736f445c40e62234cf5adcaf3d338 | tar -O -xz stargz.index.json | head -n 10
{
	"version": 1,
	"entries": [
		{
			"name": "bin/",
			"type": "dir",
			"modtime": "2022-04-13T00:24:58Z",
			"mode": 16877,
			"NumLink": 0
		},
```

PR:

```
# ctr-remote content get sha256:f97ef2203c1a840b4484740fa36a1f7a8b4b42ab28e905ecdd24cdc5d00c66dd | tar -O -xz stargz.index.json | head -n 10
{
	"version": 1,
	"entries": [
		{
			"name": "bin/",
			"type": "dir",
			"modtime": "2022-04-13T00:24:58Z",
			"mode": 16877
		},
		{
```
