### PR TITLE
Preserve TOC item IDs when cloning memory metadata reader.

### DIFF
--- a/metadata/memory/reader.go
+++ b/metadata/memory/reader.go
@@ -75,6 +75,9 @@ func NewReader(sr *io.SectionReader, opts ...metadata.Option) (metadata.Reader, 
 		return nil, fmt.Errorf("failed to get root node")
 	}
 	rootID, idMap, idOfEntry, err := assignIDs(er, root)
+	if err != nil {
+		return nil, err
+	}
 	r := newReader(er, rootID, idMap, idOfEntry, erOpts)
 	return r, nil
 }

--- a/metadata/testutil.go
+++ b/metadata/testutil.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -260,6 +261,65 @@ func TestReader(t *testing.T, factory ReaderFactory) {
 			}
 		}
 	}
+
+	t.Run("clone-id-stability", func(t *testing.T) {
+		var mapEntries func(r TestableReader, id uint32, m map[string]uint32) (map[string]uint32, error)
+		mapEntries = func(r TestableReader, id uint32, m map[string]uint32) (map[string]uint32, error) {
+			if m == nil {
+				m = make(map[string]uint32)
+			}
+			return m, r.ForeachChild(id, func(name string, id uint32, mode os.FileMode) bool {
+				m[name] = id
+				if _, err := mapEntries(r, id, m); err != nil {
+					t.Fatalf("could not map files: %s", err)
+					return false
+				}
+				return true
+			})
+		}
+
+		in := []testutil.TarEntry{
+			testutil.File("foo", "foofoo"),
+			testutil.Dir("bar/"),
+			testutil.File("bar/zzz.txt", "bazbazbaz"),
+			testutil.File("bar/aaa.txt", "bazbazbaz"),
+			testutil.File("bar/fff.txt", "bazbazbaz"),
+			testutil.File("xxx.txt", "xxxxx"),
+			testutil.File("y.txt", ""),
+		}
+
+		esgz, _, err := testutil.BuildEStargz(in)
+		if err != nil {
+			t.Fatalf("failed to build sample eStargz: %v", err)
+		}
+
+		r, err := factory(esgz)
+		if err != nil {
+			t.Fatalf("failed to create new reader: %v", err)
+		}
+
+		fileMap, err := mapEntries(r, r.RootID(), nil)
+		if err != nil {
+			t.Fatalf("could not map files: %s", err)
+		}
+		cr, err := r.Clone(esgz)
+		if err != nil {
+			t.Fatalf("could not clone reader: %s", err)
+		}
+		cloneFileMap, err := mapEntries(cr.(TestableReader), cr.RootID(), nil)
+		if err != nil {
+			t.Fatalf("could not map files in cloned reader: %s", err)
+		}
+		if !reflect.DeepEqual(fileMap, cloneFileMap) {
+			for f, id := range fileMap {
+				t.Logf("original mapping %s -> %d", f, id)
+			}
+			for f, id := range cloneFileMap {
+				t.Logf("clone mapping %s -> %d", f, id)
+			}
+			t.Fatal("file -> ID mappings did not match between original and cloned reader")
+		}
+	})
 }
 
 func newCalledTelemetry() (telemetry *Telemetry, check func() error) {


### PR DESCRIPTION
As the IDs are used for computing cache keys, it's important that they
do not change. Prior to this change, background fetching would clone the
reader and populate the cache with entries using possibly incorrect keys.

This patch changes the clone behavior to copy over the original ID
mappings.

Note that I also removed the locks around the ID maps as these maps are
never updated after the reader is created.

Fixes https://github.com/containerd/stargz-snapshotter/issues/842