### PR TITLE
Refactor metadata store

### DIFF
--- a/estargz/testutil.go
+++ b/estargz/testutil.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -1313,6 +1314,18 @@ func testWriteAndOpen(t *testing.T, controllers ...TestingController) {
 			),
 			wantFailOnLossLess: true,
 		},
+		{
+			name: "hardlink should be replaced to the destination entry",
+			in: tarOf(
+				dir("foo/"),
+				file("foo/foo1", "test"),
+				link("foolink", "foo/foo1"),
+			),
+			wantNumGz: 4, // dir, foo1 + link, TOC, footer
+			want: checks(
+				mustSameEntry("foo/foo1", "foolink"),
+			),
+		},
 	}
 
 	for _, tt := range tests {
@@ -1726,6 +1739,60 @@ func hasEntryOwner(entry string, owner owner) stargzCheck {
 		if ent.UID != owner.uid || ent.GID != owner.gid {
 			t.Errorf("entry %q has invalid owner (uid:%d, gid:%d) instead of (uid:%d, gid:%d)", entry, ent.UID, ent.GID, owner.uid, owner.gid)
 			return
+		}
+	})
+}
+
+func mustSameEntry(files ...string) stargzCheck {
+	return stargzCheckFn(func(t *testing.T, r *Reader) {
+		var first *TOCEntry
+		for _, f := range files {
+			if first == nil {
+				var ok bool
+				first, ok = r.Lookup(f)
+				if !ok {
+					t.Errorf("unknown first file on Lookup: %q", f)
+					return
+				}
+			}
+
+			// Test Lookup
+			e, ok := r.Lookup(f)
+			if !ok {
+				t.Errorf("unknown file on Lookup: %q", f)
+				return
+			}
+			if e != first {
+				t.Errorf("Lookup: %+v(%p) != %+v(%p)", e, e, first, first)
+				return
+			}
+
+			// Test LookupChild
+			pe, ok := r.Lookup(filepath.Dir(filepath.Clean(f)))
+			if !ok {
+				t.Errorf("failed to get parent of %q", f)
+				return
+			}
+			e, ok = pe.LookupChild(filepath.Base(filepath.Clean(f)))
+			if !ok {
+				t.Errorf("failed to get %q as the child of %+v", f, pe)
+				return
+			}
+			if e != first {
+				t.Errorf("LookupChild: %+v(%p) != %+v(%p)", e, e, first, first)
+				return
+			}
+
+			// Test ForeachChild
+			pe.ForeachChild(func(baseName string, e *TOCEntry) bool {
+				if baseName == filepath.Base(filepath.Clean(f)) {
+					if e != first {
+						t.Errorf("ForeachChild: %+v(%p) != %+v(%p)", e, e, first, first)
+						return false
+					}
+				}
+				return true
+			})
 		}
 	})
 }

--- a/metadata/testutil.go
+++ b/metadata/testutil.go
@@ -257,6 +257,24 @@ func TestReader(t *testing.T, factory ReaderFactory) {
 					if err := checkCalled(); err != nil {
 						t.Errorf("telemetry failure: %v", err)
 					}
+
+					// Test the cloned reader works correctly as well
+					esgz2, _, err := testutil.BuildEStargz(tt.in, opts...)
+					if err != nil {
+						t.Fatalf("failed to build sample eStargz: %v", err)
+					}
+					clonedR, err := r.Clone(esgz2)
+					if err != nil {
+						t.Fatalf("failed to clone reader: %v", err)
+					}
+					defer clonedR.Close()
+					t.Logf("vvvvv Node tree (cloned) vvvvv")
+					t.Logf("[%d] ROOT", clonedR.RootID())
+					dumpNodes(t, clonedR.(TestableReader), clonedR.RootID(), 1)
+					t.Logf("^^^^^^^^^^^^^^^^^^^^^")
+					for _, want := range tt.want {
+						want(t, clonedR.(TestableReader))
+					}
 				})
 			}
 		}


### PR DESCRIPTION
Following up #843

This commit refactors the code, adds NOTE, and adds tests to make sure the cloned `reader` works correctly.
There were some dead code paths related to hardlinks. So this commit removes them and added tests.
