### PR TITLE
Prepare for v0.12.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/containerd/containerd v1.6.6
 	github.com/containerd/go-cni v1.1.6
-	github.com/containerd/stargz-snapshotter v0.11.4
-	github.com/containerd/stargz-snapshotter/estargz v0.11.4
-	github.com/containerd/stargz-snapshotter/ipfs v0.11.4
+	github.com/containerd/stargz-snapshotter v0.12.0
+	github.com/containerd/stargz-snapshotter/estargz v0.12.0
+	github.com/containerd/stargz-snapshotter/ipfs v0.12.0
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.9.8

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.6
 	github.com/containerd/continuity v0.3.0
-	github.com/containerd/stargz-snapshotter/estargz v0.11.4
+	github.com/containerd/stargz-snapshotter/estargz v0.12.0
 	github.com/docker/cli v20.10.17+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect


### PR DESCRIPTION
```
## Notable Changes

- metadata: Preserve TOC item IDs when cloning memory metadata reader (#843), thanks to @vadimberezniker
- Refactor metadata store (#844)
- Add docs about how to build eStargz (#845)
- Drop support for containerd 1.4.x (EOL) (#832)
- Docs: fix broken link in estargz.md (#823), thanks to @liubin
- Remove typo in comment (#805), thanks to @fatelei
```