### PR TITLE
Go 1.19

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.17.x'
+        go-version: '1.18.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,14 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
-    - name: Run Linter
-      run: ./script/util/make.sh install-check-tools check
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.19.x'
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3.2.0
+      with:
+        version: v1.48.0
+        args: --verbose
 
   integration:
     runs-on: ubuntu-20.04
@@ -166,7 +172,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.17.x'
+        go-version: '1.18.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash
@@ -188,7 +194,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.17.x'
+        go-version: '1.18.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash
@@ -228,7 +234,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18.x'
+          go-version: '1.19.x'
       - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/stargz-snapshotter

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ARG CRI_TOOLS_VERSION=v1.24.2
 # Legacy builder that doesn't support TARGETARCH should set this explicitly using --build-arg.
 # If TARGETARCH isn't supported by the builder, the default value is "amd64".
 
-FROM golang:1.18-bullseye AS golang-base
+FROM golang:1.19-bullseye AS golang-base
 
 # Build containerd
 FROM golang-base AS containerd-dev

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ CMD=containerd-stargz-grpc ctr-remote stargz-store
 
 CMD_BINARIES=$(addprefix $(PREFIX),$(CMD))
 
-.PHONY: all build check install-check-tools install uninstall clean test test-root test-all integration test-optimize benchmark test-kind test-cri-containerd test-cri-o test-criauth generate validate-generated test-k3s test-k3s-argo-workflow vendor
+.PHONY: all build check install uninstall clean test test-root test-all integration test-optimize benchmark test-kind test-cri-containerd test-cri-o test-criauth generate validate-generated test-k3s test-k3s-argo-workflow vendor
 
 all: build
 
@@ -50,9 +50,6 @@ check:
 	@cd ./estargz ; GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
 	@cd ./cmd ; GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
 	@cd ./ipfs ; GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
-
-install-check-tools:
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.46.2/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.46.2
 
 install:
 	@echo "$@"

--- a/script/cri-containerd/test.sh
+++ b/script/cri-containerd/test.sh
@@ -131,7 +131,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 ENV GOPATH=/go
 # Do not install git and its dependencies here which will cause failure of building the image
 RUN apt-get update && apt-get install -y --no-install-recommends make && \
-    curl -Ls https://dl.google.com/go/go1.18.linux-\${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local -xz && \
+    curl -Ls https://dl.google.com/go/go1.19.linux-\${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local -xz && \
     go install github.com/onsi/ginkgo/ginkgo@${GINKGO_VERSION} && \
     mkdir -p \${GOPATH}/src/github.com/kubernetes-sigs/cri-tools /tmp/cri-tools && \
     curl -sL https://github.com/kubernetes-sigs/cri-tools/archive/refs/tags/v${CRI_TOOLS_VERSION}.tar.gz | tar -C /tmp/cri-tools -xz && \

--- a/script/cri-o/test.sh
+++ b/script/cri-o/test.sh
@@ -59,7 +59,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 ENV GOPATH=/go
 # Do not install git and its dependencies here which will cause failure of building the image
 RUN apt-get update && apt-get install -y --no-install-recommends make && \
-    curl -Ls https://dl.google.com/go/go1.18.linux-\${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local -xz && \
+    curl -Ls https://dl.google.com/go/go1.19.linux-\${TARGETARCH:-amd64}.tar.gz | tar -C /usr/local -xz && \
     go install github.com/onsi/ginkgo/ginkgo@${GINKGO_VERSION} && \
     mkdir -p \${GOPATH}/src/github.com/kubernetes-sigs/cri-tools /tmp/cri-tools && \
     curl -sL https://github.com/kubernetes-sigs/cri-tools/archive/refs/tags/v${CRI_TOOLS_VERSION}.tar.gz | tar -C /tmp/cri-tools -xz && \


### PR DESCRIPTION
- https://github.com/containerd/stargz-snapshotter/pull/871
- keep go1.18 in k3s CI following k3s project
-  bump up golangci-lint to v1.48.0 which supports go 1.19