### PR TITLE
CI: Use go 1.19 for k3s tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18.x'
+        go-version: '1.19.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,7 +172,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18.x'
+        go-version: '1.19.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash
@@ -194,7 +194,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18.x'
+        go-version: '1.19.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash


### PR DESCRIPTION
k3s upgraded Go to 1.19 recently https://github.com/k3s-io/k3s/blob/ba62c79f9b501f7c5009fe0d3956009d2294d41d/Dockerfile.dapper#L1