### PR TITLE
ctr-remote: allow analyzer waiting for a line from the container

### DIFF
--- a/analyzer/option.go
+++ b/analyzer/option.go
@@ -30,6 +30,7 @@ type analyzerOpts struct {
 	specOpts     SpecOpts
 	terminal     bool
 	stdin        bool
+	waitLineOut  string
 }
 
 // Option is runtime configuration of analyzer container
@@ -77,5 +78,13 @@ func WithWaitOnSignal() Option {
 func WithSnapshotter(snapshotter string) Option {
 	return func(opts *analyzerOpts) {
 		opts.snapshotter = snapshotter
+	}
+}
+
+// WithWaitLineOut specifies a substring of a stdout line to be waited.
+// When this line is detected, the container will be killed.
+func WithWaitLineOut(s string) Option {
+	return func(opts *analyzerOpts) {
+		opts.waitLineOut = s
 	}
 }

--- a/cmd/ctr-remote/commands/optimize.go
+++ b/cmd/ctr-remote/commands/optimize.go
@@ -70,6 +70,10 @@ var OptimizeCommand = cli.Command{
 			Name:  "wait-on-signal",
 			Usage: "ignore context cancel and keep the container running until it receives SIGINT (Ctrl + C) sent manually",
 		},
+		cli.StringFlag{
+			Name:  "wait-on-line",
+			Usage: "Substring of a stdout line to be waited. When this string is detected, the container will be killed.",
+		},
 		cli.BoolFlag{
 			Name:  "no-optimize",
 			Usage: "convert image without optimization",
@@ -231,7 +235,8 @@ func analyze(ctx context.Context, clicontext *cli.Context, client *containerd.Cl
 		aOpts = append(aOpts, analyzer.WithWaitOnSignal())
 	} else {
 		aOpts = append(aOpts,
-			analyzer.WithPeriod(time.Duration(clicontext.Int("period"))*time.Second))
+			analyzer.WithPeriod(time.Duration(clicontext.Int("period"))*time.Second),
+			analyzer.WithWaitLineOut(clicontext.String("wait-on-line")))
 	}
 	if clicontext.Bool("terminal") {
 		if !clicontext.Bool("i") {


### PR DESCRIPTION
This commit allows analyzer waiting for substring of a stdout line printed from the container.
When that string is detected by the analyzer, it kills the container without waiting for the timeout period.
This would be useful for optimizing server applications that print messages like `up and running` when it becomes ready.

```console
# ctr-remote i optimize --wait-on-line="Ready to accept connections" ghcr.io/stargz-containers/redis:6.2.6-org test
INFO[0000] analyzing blob "sha256:c229119241af7b23b121052a1cae4c03e0a477a72ea6a7f463ad7623ff8f274b" 
INFO[0000] analyzing blob "sha256:bed41eb8190afeec5847d65441aff83eb0458be472cbdafe21ef03a8fb190b85" 
INFO[0000] analyzing blob "sha256:5e59eaa723f193c889435d757b05fcc030596d2f075c7fecbbd538a53200aa40" 
INFO[0000] analyzing blob "sha256:fd5ad76698193c47aa7a5711c08dc24d97c5cc9d1a40e22a6647f45a6e1389a7" 
INFO[0000] analyzing blob "sha256:566c064eef6ecee5bd235b1dfd83e3cfc2d6b02aaeeef0e0afabd192cc5ba471" 
INFO[0000] analyzing blob "sha256:20c7cfac25def2fd70cd656ea241e4c65cf930402c9ac5f724424a71c83889df" 
INFO[0000] waiting for 10s ...                          
1:C 28 Sep 2022 12:39:12.507 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 28 Sep 2022 12:39:12.507 # Redis version=6.2.6, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 28 Sep 2022 12:39:12.507 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
1:M 28 Sep 2022 12:39:12.507 # You requested maxclients of 10000 requiring at least 10032 max file descriptors.
1:M 28 Sep 2022 12:39:12.507 # Server can't set maximum open files to 10032 because of OS error: Operation not permitted.
1:M 28 Sep 2022 12:39:12.507 # Current maximum open files is 1024. maxclients has been reduced to 992 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.
1:M 28 Sep 2022 12:39:12.507 * monotonic clock: POSIX clock_gettime
1:M 28 Sep 2022 12:39:12.508 * Running mode=standalone, port=6379.
1:M 28 Sep 2022 12:39:12.508 # Server initialized
1:M 28 Sep 2022 12:39:12.508 * Ready to accept connections
INFO[0000] Waiting line detected "Ready to accept connections"; killing task 
INFO[0000] container exit with code 137                 
INFO[2022-09-28T12:39:12.559608859Z] shim disconnected                             id=ccq40rvgiqio9isbu6mg
WARN[2022-09-28T12:39:12.559655136Z] cleaning up after shim disconnected           id=ccq40rvgiqio9isbu6mg namespace=default
INFO[2022-09-28T12:39:12.559667928Z] cleaning up dead shim                        
WARN[2022-09-28T12:39:12.565058717Z] cleanup warnings time="2022-09-28T12:39:12Z" level=info msg="starting signal loop" namespace=default pid=15189 runtime=io.containerd.runc.v2 
INFO[0000] converting...                                 digest="sha256:c229119241af7b23b121052a1cae4c03e0a477a72ea6a7f463ad7623ff8f274b"
INFO[0000] converting...                                 digest="sha256:bed41eb8190afeec5847d65441aff83eb0458be472cbdafe21ef03a8fb190b85"
INFO[0000] converting...                                 digest="sha256:5e59eaa723f193c889435d757b05fcc030596d2f075c7fecbbd538a53200aa40"
INFO[0000] converting...                                 digest="sha256:fd5ad76698193c47aa7a5711c08dc24d97c5cc9d1a40e22a6647f45a6e1389a7"
INFO[0000] converting...                                 digest="sha256:566c064eef6ecee5bd235b1dfd83e3cfc2d6b02aaeeef0e0afabd192cc5ba471"
INFO[0000] converting...                                 digest="sha256:20c7cfac25def2fd70cd656ea241e4c65cf930402c9ac5f724424a71c83889df"
sha256:f190d521eddc73850c24900fe07cb83e45e64d4f307b627965499bebc99aebdb
```
