### PR TITLE
Build and push stargz-snapshotter image usable as a kind node

### DIFF
--- a/.github/workflows/kind-image.yml
+++ b/.github/workflows/kind-image.yml
@@ -1,0 +1,41 @@
+name: Kind image
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  kind-image:
+    runs-on: ubuntu-22.04
+    name: Kind image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}-kind
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
#715

This commit adds a CI to push Kind node image to ~~`ghcr.io/stargz-containers/${VERSION}-kind`~~ `ghcr.io/containerd/stargz-snapshotter:${VERSION}-kind`namespace on each release.

- Example: [`ghcr.io/ktock/stargz-snapshotter:0.0.0-kind`](https://github.com/ktock/stargz-snapshotter/pkgs/container/stargz-snapshotter/45373809?tag=0.0.0-kind)
  - https://github.com/ktock/stargz-snapshotter/actions/runs/3234126466/jobs/5296849182

```console
$ cat /tmp/kindconfig.yaml 
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
- role: worker
- role: worker
- role: worker
$ kind create cluster --config=/tmp/kindconfig.yaml --name stargz-demo --image ghcr.io/ktock/stargz-snapshotter:0.0.0-kind
```
