### PR TITLE
Prepare for v0.12.1

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/containerd/containerd v1.6.8
 	github.com/containerd/go-cni v1.1.7
-	github.com/containerd/stargz-snapshotter v0.12.0
-	github.com/containerd/stargz-snapshotter/estargz v0.12.0
-	github.com/containerd/stargz-snapshotter/ipfs v0.12.0
+	github.com/containerd/stargz-snapshotter v0.12.1
+	github.com/containerd/stargz-snapshotter/estargz v0.12.1
+	github.com/containerd/stargz-snapshotter/ipfs v0.12.1
 	github.com/coreos/go-systemd/v22 v22.4.0
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.9.11

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.8
 	github.com/containerd/continuity v0.3.0
-	github.com/containerd/stargz-snapshotter/estargz v0.12.0
+	github.com/containerd/stargz-snapshotter/estargz v0.12.1
 	github.com/docker/cli v20.10.18+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect


### PR DESCRIPTION
```
This release publishes a container image usable as a Kind node to `ghcr.io/containerd/stargz-snapshotter:0.12.1-kind`

$ kind create cluster --name stargz-demo --image ghcr.io/containerd/stargz-snapshotter:0.12.1-kind

kind >= v0.16.0 is recommended as the image is based on `kindest/node:v1.25.2` supported by kind v0.16.0.
See also kind release note: https://github.com/kubernetes-sigs/kind/releases/tag/v0.16.0

## Notable Changes

- Allow manually remove invalid snapshots on restore (#901)
- ctr-remote: Allow analyzer waiting for a line from the container (#933)
- Build and push stargz-snapshotter image usable as a kind node (#940)
```