### PR TITLE
Prepare for v0.13.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/containerd/containerd v1.6.9
 	github.com/containerd/go-cni v1.1.7
-	github.com/containerd/stargz-snapshotter v0.12.1
-	github.com/containerd/stargz-snapshotter/estargz v0.12.1
-	github.com/containerd/stargz-snapshotter/ipfs v0.12.1
+	github.com/containerd/stargz-snapshotter v0.13.0
+	github.com/containerd/stargz-snapshotter/estargz v0.13.0
+	github.com/containerd/stargz-snapshotter/ipfs v0.13.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.9.11

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.9
 	github.com/containerd/continuity v0.3.0
-	github.com/containerd/stargz-snapshotter/estargz v0.12.1
+	github.com/containerd/stargz-snapshotter/estargz v0.13.0
 	github.com/docker/cli v20.10.21+incompatible
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect


### PR DESCRIPTION
- Should be merged after:
  - https://github.com/containerd/stargz-snapshotter/pull/994
  - https://github.com/containerd/stargz-snapshotter/pull/990
  - https://github.com/containerd/stargz-snapshotter/pull/987

```
This release enables to optionallly create smaller eStargz images using the following flags for `ctr-rmeote i convert` or `ctr-remote i optimize` (#956).

- `--estargz-external-toc`: Separates TOC JSON into another image (called "TOC image"). The result eStargz doesn't contain TOC so we can expect a smaller size than normal eStargz (refer to [`/docs/estargz.md`](https://github.com/containerd/stargz-snapshotter/blob/v0.13.0/docs/estargz.md#estargz-image-with-an-external-toc-optional) for the related eStargz spec).
- `--estargz-min-chunk-size`: Specifies the minimal number of bytes of data must be written in one gzip stream. If it's > 0, multiple files and chunks can be written into one gzip stream. Smaller number of gzip header and smaller size of the result blob can be expected (refer to [`/docs/estargz.md`](https://github.com/containerd/stargz-snapshotter/blob/v0.13.0/docs/estargz.md#details-about-inneroffset) for the related eStargz spec).

Please refer to [`/docs/smaller-estargz.md`](https://github.com/containerd/stargz-snapshotter/blob/v0.13.0/docs/smaller-estargz.md) for more details about the usage.

## Notable Changes

- eStargz
  -  Support creating smaller eStargz images (`--estargz-external-toc` and `--estargz-min-chunk-size`) (#956)
- stargz-snapshotter
  - fs: Try unmount without MNT_FORCE before force unmount (#978)
  - remote: Support per-registry request headers (#983)
  - Allow using fusermount3 (#970)
- converter
  - zstdchunked: allows specifying compression level (#984)
- Kind image ([`ghcr.io/containerd/stargz-snapshotter:${VERSION}-kind`](https://github.com/containerd/stargz-snapshotter/pkgs/container/stargz-snapshotter))
  - Revert clone3-workaround (#967)
- CI
  - Bump nerdctl to 1.0.0 (#969), thanks to @jenting
- Documents
  -  Add document about integrations of eStargz with other tools ([`/docs/integration.md`](https://github.com/containerd/stargz-snapshotter/blob/v0.13.0/docs/integration.md)) (#995, #997), thanks to @gaius-qi

```