### PR TITLE
Resolve GitHub actions workflow warnings

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,13 +69,13 @@ jobs:
       run: make test-cri-containerd
 
   test-cri-o:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: CRIValidationCRIO
     steps:
     - uses: actions/checkout@v3
     - name: Varidate the runtime through CRI with CRI-O
       env:
-        DOCKER_BUILD_ARGS: "--build-arg=RUNC_VERSION=v1.0.3"
+        DOCKER_BUILD_ARGS: "--build-arg=RUNC_VERSION=v1.1.0"
       run: make test-cri-o
 
   test-k3s:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -239,7 +239,7 @@ jobs:
         with:
           path: src/github.com/containerd/stargz-snapshotter
           fetch-depth: 25
-      - uses: containerd/project-checks@v1
+      - uses: containerd/project-checks@v1.1.0
         with:
           working-directory: src/github.com/containerd/stargz-snapshotter
       - name: Check proto generated code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,7 @@ jobs:
       run: make test-cri-containerd
 
   test-cri-cri-o:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: CRIValidationCRIO
     strategy:
       fail-fast: false
@@ -162,7 +162,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Validate CRI-O through CRI
       env:
-        DOCKER_BUILD_ARGS: "--build-arg=RUNC_VERSION=v1.0.3"
+        DOCKER_BUILD_ARGS: "--build-arg=RUNC_VERSION=v1.1.0"
         METADATA_STORE: ${{ matrix.metadata-store }}
       run: make test-cri-o
 


### PR DESCRIPTION
Small CI updates to run cri-o tests on Ubuntu 22.04 to resolve warnings in GitHub actions workflows.

Also updated containerd/project-checks to latest `@v1` will not grab latest in this case because containerd/project-checks has `v1` tag.

Signed-off by: Austin Vazquez <macedonv@amazon.com>