### PR TITLE
doc: Rootless lazy pulling with Podman, nerdctl and BuildKit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,6 +166,14 @@ jobs:
         METADATA_STORE: ${{ matrix.metadata-store }}
       run: make test-cri-o
 
+  test-podman:
+    runs-on: ubuntu-22.04
+    name: PodmanRootless
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Podman (rootless)
+      run: make test-podman
+
   test-k3s:
     runs-on: ubuntu-22.04
     name: K3S

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,9 @@ test-cri-containerd:
 test-cri-o:
 	@./script/cri-o/test.sh
 
+test-podman:
+	@./script/podman/test.sh
+
 test-criauth:
 	@./script/criauth/test.sh
 

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -1,0 +1,56 @@
+# Rootless execution of stargz snapshotter
+
+This document lists links and information about how to run Stargz Snapshotter and Stargz Store from the non-root user.
+
+## nerdctl (Stargz Snapshotter)
+
+Rootless Stargz Snapshotter for nerdctl can be installed via `containerd-rootless-setuptool.sh install-stargz` command.
+Please see [the doc in nerdctl repo](https://github.com/containerd/nerdctl/blob/v1.1.0/docs/rootless.md#stargz-snapshotter) for details.
+
+## Podman (Stargz Store)
+
+> NOTE: This is an experimental configuration leveraging [`podman unshare`](https://docs.podman.io/en/latest/markdown/podman-unshare.1.html). Limitation: `--uidmap` of `podman run` doesn't work.
+
+First, allow podman using Stargz Store by adding the following store configuration.
+Put the configuration file to [`/etc/containers/storage.conf` or `$HOME/.config/containers/storage.conf`](https://github.com/containers/podman/blob/v4.3.1/docs/tutorials/rootless_tutorial.md#storageconf).
+
+> NOTE: Replace `/path/to/home` to the actual home directory.
+
+```
+[storage]
+driver = "overlay"
+
+[storage.options]
+additionallayerstores = ["/path/to/homedir/.local/share/stargz-store/store:ref"]
+```
+
+Start Stargz Store in the namespace managed by podman via [`podman unshare`](https://docs.podman.io/en/latest/markdown/podman-unshare.1.html) command.
+
+```
+$ podman unshare stargz-store --root $HOME/.local/share/stargz-store/data $HOME/.local/share/stargz-store/store &
+```
+
+Podman performs lazy pulling when it pulls eStargz images.
+
+```
+$ podman pull ghcr.io/stargz-containers/python:3.9-esgz
+```
+
+<details>
+<summary>Creating systemd unit file for Stargz Store</summary>
+
+It's possible to create systemd unit file of Stargz Store for easily managing it.
+An example systemd unit file can be found [here](../script/podman/config/podman-rootless-stargz-store.service)
+
+After installing that file (e.g. to `$HOME/.config/systemd/user/`), start the service using `systemctl`.
+
+```
+$ systemctl --user start podman-rootless-stargz-store
+```
+
+</details>
+
+## BuildKit (Stargz Snapshotter)
+
+BuildKit supports running Stargz Snapshotter from the non-root user.
+Please see [the doc in BuildKit repo](https://github.com/moby/buildkit/blob/8b132188aa7af944c813d02da63c93308d83cf75/docs/stargz-estargz.md) (unmerged 2023/1/18) for details.

--- a/script/podman/config/podman-rootless-stargz-store.service
+++ b/script/podman/config/podman-rootless-stargz-store.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Stargz Store service for Podman
+
+[Service]
+# This pipes stargz-store's IO to the shell otherwise they are lost and can't be managed by systemd.
+# TODO: fix this and do not use pipe
+ExecStart=/bin/bash -c "podman unshare stargz-store --log-level=debug --root %h/.local/share/stargz-store/data %h/.local/share/stargz-store/store 2>&1 | cat"
+ExecStopPost=podman unshare umount %h/.local/share/stargz-store/store
+
+[Install]
+WantedBy=default.target

--- a/script/podman/config/storage.conf
+++ b/script/podman/config/storage.conf
@@ -1,0 +1,4 @@
+[storage]
+  driver = "overlay"
+[storage.options]
+  additionallayerstores = ["/home/rootless/.local/share/stargz-store/store:ref"]

--- a/script/podman/config/test-podman-rootless.sh
+++ b/script/podman/config/test-podman-rootless.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eux -o pipefail
+if [[ "$(id -u)" = "0" ]]; then
+	# Switch to the rootless user via SSH; This is the same approach as done in nerdctl CI
+	systemctl start sshd
+	exec ssh -o StrictHostKeyChecking=no rootless@localhost "$0" "$@"
+else
+	systemctl --user start podman-rootless-stargz-store
+	exec "$@"
+fi

--- a/script/podman/run_test.sh
+++ b/script/podman/run_test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+STARGZ_STORE_SERVICE=podman-rootless-stargz-store
+
+# Lazy pulling and run
+podman pull ghcr.io/stargz-containers/alpine:3.10.2-esgz
+podman run --rm ghcr.io/stargz-containers/alpine:3.10.2-esgz echo hello
+
+# Run (includes lazy pulling)
+podman run --rm ghcr.io/stargz-containers/python:3.9-esgz echo hello
+
+# Print store log to be checked by the host
+LOG_REMOTE_SNAPSHOT="remote-snapshot-prepared"
+journalctl --user -u "${STARGZ_STORE_SERVICE}" | grep "${LOG_REMOTE_SNAPSHOT}"
+
+# Non-lazy pulling
+podman run --rm ghcr.io/stargz-containers/ubuntu:22.04-org echo hello
+
+systemctl --user stop "${STARGZ_STORE_SERVICE}"

--- a/script/podman/test.sh
+++ b/script/podman/test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+CONTEXT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/"
+REPO="${CONTEXT}../../"
+
+source "${REPO}/script/util/utils.sh"
+
+NODE_IMAGE_NAME_BASE=test-podman-rootless-node-base
+NODE_IMAGE_NAME=test-podman-rootless-node
+
+if [ "${PODMAN_NO_RECREATE:-}" != "true" ] ; then
+    echo "Preparing node image..."
+    docker build ${DOCKER_BUILD_ARGS:-} --progress=plain -t "${NODE_IMAGE_NAME_BASE}" --target podman-rootless "${REPO}"
+fi
+
+TEST_LOG=$(mktemp)
+STORE_LOG=$(mktemp)
+TMP_CONTEXT=$(mktemp -d)
+function cleanup {
+    local ORG_EXIT_CODE="${1}"
+    rm -rf "${TMP_CONTEXT}" || true
+    rm "${TEST_LOG}" || true
+    rm "${STORE_LOG}" || true
+    exit "${ORG_EXIT_CODE}"
+}
+trap 'cleanup "$?"' EXIT SIGHUP SIGINT SIGQUIT SIGTERM
+
+cp "${CONTEXT}/run_test.sh" "${TMP_CONTEXT}/run_test.sh"
+cat <<EOF > "${TMP_CONTEXT}/Dockerfile"
+FROM ${NODE_IMAGE_NAME_BASE}
+
+COPY run_test.sh /run_test.sh
+CMD ["/bin/bash", "--login", "/run_test.sh"]
+EOF
+
+docker build ${DOCKER_BUILD_ARGS:-} --progress=plain -t "${NODE_IMAGE_NAME}" "${TMP_CONTEXT}"
+docker run -t --rm --privileged "${NODE_IMAGE_NAME}" | tee "${TEST_LOG}"
+cat "${TEST_LOG}" | grep "${LOG_REMOTE_SNAPSHOT}" | sed -E 's/^[^\{]*(\{.*)$/\1/g' > "${STORE_LOG}"
+check_remote_snapshots "${STORE_LOG}"


### PR DESCRIPTION
This commit adds docs about rootless lazy pulling of eStargz with Podman, nerdctl and BuildKit.

Experimental configuration of Podman + rootless Stargz Store is currently implemented using [`podman unshare`](https://docs.podman.io/en/latest/markdown/podman-unshare.1.html) for putting both of them into the same namespace.

```console
$ podman unshare stargz-store --root $HOME/.local/share/stargz-store/data $HOME/.local/share/stargz-store/store &
$ podman pull ghcr.io/stargz-containers/python:3.9-esgz
```

Current limitation of this approach is `--uidmap` flag of `podman run` doesn't work.
So we mark this configuration as "experimental" and will work on further investigation and improvement for eliminating the limitation.

```console
 $ podman run -d --uidmap 0:10000:5000 --rm ghcr.io/stargz-containers/alpine:3.10.2-esgz sleep 10000
 Error: creating container storage: creating an ID-mapped copy of layer "9e0573c62127729a89b3e728371ebe4bd4a77996ea57c8f06bf8760bac3cf16d": error during chown: storage-chown-by-maps: lchown bin/arch: no such device or address: exit status 1
```
