### PR TITLE
go.mod: remove replace directive for github.com/urfave/cli

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     ignore:
       # We upgrade this manually on each release
       - dependency-name: "github.com/containerd/stargz-snapshotter/estargz"
-      # This forcefully points to v1.22.1. See go.mod.
-      - dependency-name: "github.com/urfave/cli"
 
   # Automatic upgrade for go modules of estargz package.
   - package-ecosystem: "gomod"

--- a/go.mod
+++ b/go.mod
@@ -114,13 +114,5 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace (
-	// Import local package for estargz.
-	github.com/containerd/stargz-snapshotter/estargz => ./estargz
-
-	// NOTE1: github.com/containerd/containerd v1.4.0 depends on github.com/urfave/cli v1.22.1
-	//        because of https://github.com/urfave/cli/issues/1092
-	// NOTE2: Automatic upgrade of this is disabled in denendabot.yml. When we remove this replace
-	//        directive, we must remove the corresponding "ignore" configuration from dependabot.yml
-	github.com/urfave/cli => github.com/urfave/cli v1.22.1
-)
+// Import local package for estargz.
+replace github.com/containerd/stargz-snapshotter/estargz => ./estargz

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.10 h1:p8Fspmz3iTctJstry1PYS3HVdllxnEzTEsgIgtxTrCk=
+github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlIME=
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=


### PR DESCRIPTION
Replace directive for this package has already been removed in containerd's go.mod. https://github.com/containerd/containerd/blob/v1.7.0-beta.2/go.mod

