### PR TITLE
Prepare for v0.14.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -5,9 +5,9 @@ go 1.19
 require (
 	github.com/containerd/containerd v1.7.0-beta.2
 	github.com/containerd/go-cni v1.1.7
-	github.com/containerd/stargz-snapshotter v0.13.0
-	github.com/containerd/stargz-snapshotter/estargz v0.13.0
-	github.com/containerd/stargz-snapshotter/ipfs v0.13.0
+	github.com/containerd/stargz-snapshotter v0.14.0
+	github.com/containerd/stargz-snapshotter/estargz v0.14.0
+	github.com/containerd/stargz-snapshotter/ipfs v0.14.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.10.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.7.0-beta.2
 	github.com/containerd/continuity v0.3.0
-	github.com/containerd/stargz-snapshotter/estargz v0.13.0
+	github.com/containerd/stargz-snapshotter/estargz v0.14.0
 	github.com/docker/cli v20.10.23+incompatible
 	github.com/docker/go-metrics v0.0.1
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da


### PR DESCRIPTION
Should be merged after #1075 and  #1074

```
## Notable Changes

- stargz-snapshotter
  - Refactored IPFS-related logic not to depend on `github.com/ipfs/go-ipfs-http-client` (#1034, #1067)
  - Added support for CRI v1 API (#1011, #1075)
- docs
  - Added docs about rootless lazy pulling with Podman, nerdctl and BuildKit (#1061)

```