### PR TITLE
Fix CI failures

### DIFF
--- a/script/cri-containerd/mirror.sh
+++ b/script/cri-containerd/mirror.sh
@@ -45,6 +45,7 @@ function retry {
 }
 
 cd "${SS_REPO}"
+git config --global --add safe.directory "${SS_REPO}"
 PREFIX=/out/ make ctr-remote
 mv /out/ctr-remote /bin/ctr-remote
 

--- a/script/cri-o/mirror.sh
+++ b/script/cri-o/mirror.sh
@@ -45,6 +45,7 @@ function retry {
 }
 
 cd "${SS_REPO}"
+git config --global --add safe.directory "${SS_REPO}"
 PREFIX=/out/ make ctr-remote
 mv /out/ctr-remote /bin/ctr-remote
 

--- a/script/criauth/mirror.sh
+++ b/script/criauth/mirror.sh
@@ -43,6 +43,7 @@ function retry {
 update-ca-certificates
 
 cd "${SS_REPO}"
+git config --global --add safe.directory "${SS_REPO}"
 PREFIX=/out/ make ctr-remote
 
 containerd &

--- a/script/k3s-argo-workflow/run.sh
+++ b/script/k3s-argo-workflow/run.sh
@@ -132,6 +132,17 @@ echo "replace github.com/containerd/stargz-snapshotter/estargz => $(realpath ${R
 # We use older version of typeurl which the both of the above are compatible to.
 # We can remove this directive once k3s upgrades typeurl version to newer than v1.0.3-0.20220324183432-6193a0e03259.
 echo "replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.2" >> "${TMP_K3S_REPO}/go.mod"
+
+# Suppress the following import error
+# github.com/k3s-io/k3s/pkg/daemons/executor imports
+# 	k8s.io/kubernetes/cmd/kube-controller-manager/app imports
+# 	k8s.io/kubernetes/pkg/cloudprovider/providers imports
+# 	k8s.io/legacy-cloud-providers/gce imports
+# 	cloud.google.com/go/compute/metadata: ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules:
+# 	cloud.google.com/go/compute v1.7.0 (/home/ktock/go/pkg/mod/cloud.google.com/go/compute@v1.7.0/metadata)
+# 	cloud.google.com/go/compute/metadata v0.2.0 (/home/ktock/go/pkg/mod/cloud.google.com/go/compute/metadata@v0.2.0)
+echo "require cloud.google.com/go/compute/metadata v0.2.0 // indirect" >> "${TMP_K3S_REPO}/go.mod"
+
 cat "${TMP_K3S_REPO}/go.mod"
 
 sed -i -E 's|(ENV DAPPER_RUN_ARGS .*)|\1 -v '"$(realpath ${REPO})":"$(realpath ${REPO})"':ro|g' "${TMP_K3S_REPO}/Dockerfile.dapper"

--- a/script/k3s/mirror.sh
+++ b/script/k3s/mirror.sh
@@ -42,6 +42,7 @@ function retry {
 
 update-ca-certificates
 
+git config --global --add safe.directory "${SS_REPO}"
 cd "${SS_REPO}"
 PREFIX=/out/ make ctr-remote
 

--- a/script/k3s/run-k3s.sh
+++ b/script/k3s/run-k3s.sh
@@ -61,6 +61,17 @@ echo "replace github.com/containerd/stargz-snapshotter/estargz => $(realpath ${R
 # We use older version of typeurl which the both of the above are compatible to.
 # We can remove this directive once k3s upgrades typeurl version to newer than v1.0.3-0.20220324183432-6193a0e03259.
 echo "replace github.com/containerd/typeurl => github.com/containerd/typeurl v1.0.2" >> "${TMP_K3S_REPO}/go.mod"
+
+# Suppress the following import error
+# github.com/k3s-io/k3s/pkg/daemons/executor imports
+# 	k8s.io/kubernetes/cmd/kube-controller-manager/app imports
+# 	k8s.io/kubernetes/pkg/cloudprovider/providers imports
+# 	k8s.io/legacy-cloud-providers/gce imports
+# 	cloud.google.com/go/compute/metadata: ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules:
+# 	cloud.google.com/go/compute v1.7.0 (/home/ktock/go/pkg/mod/cloud.google.com/go/compute@v1.7.0/metadata)
+# 	cloud.google.com/go/compute/metadata v0.2.0 (/home/ktock/go/pkg/mod/cloud.google.com/go/compute/metadata@v0.2.0)
+echo "require cloud.google.com/go/compute/metadata v0.2.0 // indirect" >> "${TMP_K3S_REPO}/go.mod"
+
 cat "${TMP_K3S_REPO}/go.mod"
 
 sed -i -E 's|(ENV DAPPER_RUN_ARGS .*)|\1 -v '"$(realpath ${REPO})":"$(realpath ${REPO})"':ro|g' "${TMP_K3S_REPO}/Dockerfile.dapper"

--- a/script/kind/mirror.sh
+++ b/script/kind/mirror.sh
@@ -42,6 +42,7 @@ function retry {
 
 update-ca-certificates
 
+git config --global --add safe.directory "${SS_REPO}"
 cd "${SS_REPO}"
 PREFIX=/out/ make ctr-remote
 

--- a/script/optimize/optimize/entrypoint.sh
+++ b/script/optimize/optimize/entrypoint.sh
@@ -203,6 +203,7 @@ nerdctl pull "${ORG_IMAGE_TAG}"
 
 echo "Checking optimized image..."
 WORKING_DIR=$(mktemp -d)
+git config --global --add safe.directory '/go/src/github.com/containerd/stargz-snapshotter'
 PREFIX=/tmp/out/ make clean
 PREFIX=/tmp/out/ GO_BUILD_FLAGS="-race" make ctr-remote # Check data race
 /tmp/out/ctr-remote ${OPTIMIZE_COMMAND} -entrypoint='[ "/accessor" ]' "${ORG_IMAGE_TAG}" "${OPT_IMAGE_TAG}"

--- a/script/util/make.sh
+++ b/script/util/make.sh
@@ -36,10 +36,11 @@ cat <<EOF > "${TMP_CONTEXT}/Dockerfile"
 FROM golang:${GOBASE_VERSION}
 RUN apt-get update -y && apt-get --no-install-recommends install -y fuse3
 EOF
+MAKECMD="make ${@} PREFIX=/tmp/out/"
 docker build -t "${IMAGE_NAME}" ${DOCKER_BUILD_ARGS:-} "${TMP_CONTEXT}"
 docker run --rm --privileged \
        --device /dev/fuse \
        --tmpfs /tmp:exec,mode=777 \
        -w /go/src/github.com/containerd/stargz-snapshotter \
        -v "${REPO}:/go/src/github.com/containerd/stargz-snapshotter:ro" \
-       "${IMAGE_NAME}" make ${@} PREFIX=/tmp/out/
+       "${IMAGE_NAME}" /bin/sh -c "git config --global --add safe.directory '/go/src/github.com/containerd/stargz-snapshotter' && ${MAKECMD}"


### PR DESCRIPTION
This commit fixes recent CI failures

https://github.com/containerd/stargz-snapshotter/actions/runs/4110931069/jobs/7094202458#step:3:687

Fixed via 26d8c703b1a44b74a0de32c15fbb1c46cb217baf

```
fatal: detected dubious ownership in repository at '/go/src/github.com/containerd/stargz-snapshotter'
To add an exception for this directory, call:

	git config --global --add safe.directory /go/src/github.com/containerd/stargz-snapshotter
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

https://github.com/containerd/stargz-snapshotter/actions/runs/4075472322/jobs/7021914415#step:7:1816

Fixed via 312c5732f8a75353d5e648c4cc17e59374a4f931

```
github.com/k3s-io/k3s/pkg/daemons/executor imports
	k8s.io/kubernetes/cmd/kube-controller-manager/app imports
	k8s.io/kubernetes/pkg/cloudprovider/providers imports
	k8s.io/legacy-cloud-providers/gce imports
	cloud.google.com/go/compute/metadata: ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules:
	cloud.google.com/go/compute v1.7.0 (/home/runner/go/pkg/mod/cloud.google.com/go/compute@v1.7.0/metadata)
	cloud.google.com/go/compute/metadata v0.2.0 (/home/runner/go/pkg/mod/cloud.google.com/go/compute/metadata@v0.2.0)
```