### PR TITLE
labels: correctly propagate extra labels

### DIFF
--- a/script/integration/containerd/entrypoint.sh
+++ b/script/integration/containerd/entrypoint.sh
@@ -304,7 +304,7 @@ if [ "${BUILTIN_SNAPSHOTTER}" != "true" ] ; then
     ctr-remote i pull --user "${DUMMYUSER}:${DUMMYPASS}" "${REGISTRY_HOST}/ubuntu:22.04"
     CID=$(ctr-remote i ipfs-push "${REGISTRY_HOST}/ubuntu:22.04")
     reboot_containerd
-    run_and_check_remote_snapshots ctr-remote i rpull --containerd-labels --ipfs "${CID}"
+    run_and_check_remote_snapshots ctr-remote i rpull --use-containerd-labels --ipfs "${CID}"
     copy_out_dir "${CID}" "/usr" "${USR_STARGZSN_CTD_IPFS}" "stargz"
 
     # overlayfs snapshotter

--- a/service/cri.go
+++ b/service/cri.go
@@ -104,7 +104,7 @@ func sourceFromCRILabels(hosts source.RegistryHosts) source.GetSources {
 			{
 				Hosts:    hosts,
 				Name:     refspec,
-				Target:   ocispec.Descriptor{Digest: target},
+				Target:   targetDesc,
 				Manifest: ocispec.Manifest{Layers: append([]ocispec.Descriptor{targetDesc}, neighboringLayers...)},
 			},
 		}, nil


### PR DESCRIPTION
https://github.com/containerd/stargz-snapshotter/pull/1131 introduced containerd labels but stargz-snapshotter still fails to propagate some labels. This commit fixes this issue.