### PR TITLE
Make timeout per-request

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -215,15 +215,16 @@ func newHTTPFetcher(ctx context.Context, fc *fetcherConfig) (*httpFetcher, int64
 		// Prepare transport with authorization functionality
 		tr := host.Client.Transport
 
+		timeout := host.Client.Timeout
 		if rt, ok := tr.(*rhttp.RoundTripper); ok {
 			rt.Client.RetryMax = fc.maxRetries
 			rt.Client.RetryWaitMin = fc.minWaitMSec
 			rt.Client.RetryWaitMax = fc.maxWaitMSec
 			rt.Client.Backoff = backoffStrategy
 			rt.Client.CheckRetry = retryStrategy
+			timeout = rt.Client.HTTPClient.Timeout
 		}
 
-		timeout := host.Client.Timeout
 		if host.Authorizer != nil {
 			tr = &transport{
 				inner: tr,

--- a/script/integration/containerd/config.stargz.toml
+++ b/script/integration/containerd/config.stargz.toml
@@ -3,6 +3,7 @@ ipfs = true
 
 [blob]
 check_always = true
+max_retries = 1
 
 [[resolver.host."registry-integration.test".mirrors]]
 host = "registry-alt.test:5000"

--- a/service/resolver/registry.go
+++ b/service/resolver/registry.go
@@ -66,14 +66,14 @@ func RegistryHostsFromConfig(cfg Config, credsFuncs ...Credential) source.Regist
 		}) {
 			client := rhttp.NewClient()
 			client.Logger = nil // disable logging every request
-			tr := client.StandardClient()
 			if h.RequestTimeoutSec >= 0 {
 				if h.RequestTimeoutSec == 0 {
-					tr.Timeout = defaultRequestTimeoutSec * time.Second
+					client.HTTPClient.Timeout = defaultRequestTimeoutSec * time.Second
 				} else {
-					tr.Timeout = time.Duration(h.RequestTimeoutSec) * time.Second
+					client.HTTPClient.Timeout = time.Duration(h.RequestTimeoutSec) * time.Second
 				}
 			} // h.RequestTimeoutSec < 0 means "no timeout"
+			tr := client.StandardClient()
 			var header http.Header
 			var err error
 			if h.Header != nil {


### PR DESCRIPTION
Part of https://github.com/containerd/stargz-snapshotter/issues/1180

When setting up an rhttp client, the structure looks like this:
```
http.Client {
    Transport: rhttp.Transport {
        Client: rhttp.Client {
            HTTPClient: http.Client{}
        }
    }
}
```

Before this change, the timeout was set on the outer client. When the timeout was reached, the request context was cancelled and no more retries would be attempted by the retryable client. Effectively the timeout was being set for the entire retryable request.

This change moves the timeout to the inner client, making the timeout per-request and the timeout of the entire retryable request is governed by the retry policy.