### PR TITLE
Run CRI-O test with the latest docker

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,14 +69,21 @@ jobs:
       run: make test-cri-containerd
 
   test-cri-o:
-    runs-on: ubuntu-18.04
+    runs-on: macos-12
+    timeout-minutes: 40
     name: CRIValidationCRIO
     steps:
     - uses: actions/checkout@v3
-    - name: Varidate the runtime through CRI with CRI-O
+    - name: Start vagrant
+      env:
+        VAGRANT_EXPERIMENTAL: "disks"
+      run: vagrant up
+    - name: Setup environment
       env:
         DOCKER_BUILD_ARGS: "--build-arg=RUNC_VERSION=v1.0.3"
-      run: make test-cri-o
+      run: vagrant ssh default -c "echo export DOCKER_BUILD_ARGS=$DOCKER_BUILD_ARGS >> ~/.runenv"
+    - name: Validate CRI-O through CRI
+      run: vagrant ssh default -c "source ~/.runenv && cd /vagrant && make test-cri-o"
 
   test-k3s:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.19.x'
+        go-version: '1.20.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,7 +194,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.19.x'
+        go-version: '1.20.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash
@@ -224,7 +224,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.19.x'
+        go-version: '1.20.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.0.0/install.sh | bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,8 @@ jobs:
       run: make test-cri-containerd
 
   test-cri-cri-o:
-    runs-on: ubuntu-18.04
+    runs-on: macos-12
+    timeout-minutes: 40
     name: CRIValidationCRIO
     strategy:
       fail-fast: false
@@ -165,11 +166,19 @@ jobs:
         metadata-store: ["memory", "db"]
     steps:
     - uses: actions/checkout@v3
-    - name: Validate CRI-O through CRI
+    - name: Start vagrant
+      env:
+        VAGRANT_EXPERIMENTAL: "disks"
+      run: vagrant up
+    - name: Setup environment
       env:
         DOCKER_BUILD_ARGS: "--build-arg=RUNC_VERSION=v1.0.3"
         METADATA_STORE: ${{ matrix.metadata-store }}
-      run: make test-cri-o
+      run: |
+        vagrant ssh default -c "echo export DOCKER_BUILD_ARGS=$DOCKER_BUILD_ARGS >> ~/.runenv"
+        vagrant ssh default -c "echo export METADATA_STORE=$METADATA_STORE >> ~/.runenv"
+    - name: Validate CRI-O through CRI
+      run: vagrant ssh default -c "source ~/.runenv && cd /vagrant && make test-cri-o"
 
   test-podman:
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /out
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,33 @@
+#   Copyright The containerd Authors.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/jammy64"
+  memory = 4096
+  cpus = 2
+  disk_size = 60
+  config.vm.provider :virtualbox do |v, o|
+    v.memory = memory
+    v.cpus = cpus
+    # Needs env var VAGRANT_EXPERIMENTAL="disks"
+    o.vm.disk :disk, size: "#{disk_size}GB", primary: true
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = memory
+    v.cpus = cpus
+    v.machine_virtual_size = disk_size
+  end
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.provision "shell", path: "./script/cri-o/vagrant/setup.sh"
+end

--- a/script/cri-o/vagrant/setup.sh
+++ b/script/cri-o/vagrant/setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+# Install docker and docker-compose https://docs.docker.com/engine/install/ubuntu/
+
+sudo apt-get update
+sudo apt-get install -y \
+    ca-certificates \
+    curl \
+    gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo usermod -aG docker vagrant
+sudo service docker restart
+newgrp docker
+sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
+# Tools needed for tests
+sudo apt-get install -y make jq


### PR DESCRIPTION
To fix CRI-O CI, test it with the latest docker (v23) that fixed the issue described in https://github.com/containerd/stargz-snapshotter/pull/622 .
Ubuntu runner doesn't distribute that version of docker yet so we run the test in a VM with manually configured for Docker v23. Vagrantfile is based on the one used in containerd (https://github.com/containerd/containerd/blob/v1.7.0/Vagrantfile).

This PR contains a commit to bump up golang version used in k3s CI. This is also needed to pass the CI.