### PR TITLE
Refactor code and bump up golangci-lint to v1.53.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.6.0
       with:
-        version: v1.49.0
+        version: v1.53.3
         args: --verbose
         working-directory: ${{ matrix.targetdir }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,3 +24,9 @@ run:
     - images
     - out
     - script
+
+issues:
+  exclude-rules:
+    - linters:
+        - revive
+      text: "unused-parameter"

--- a/estargz/build.go
+++ b/estargz/build.go
@@ -436,9 +436,8 @@ func importTar(in io.ReaderAt) (*tarFile, error) {
 		if err != nil {
 			if err == io.EOF {
 				break
-			} else {
-				return nil, fmt.Errorf("failed to parse tar file, %w", err)
 			}
+			return nil, fmt.Errorf("failed to parse tar file, %w", err)
 		}
 		switch cleanEntryName(h.Name) {
 		case PrefetchLandmark, NoPrefetchLandmark:

--- a/estargz/build_test.go
+++ b/estargz/build_test.go
@@ -412,9 +412,8 @@ func TestSort(t *testing.T) {
 							if err != nil {
 								if err == io.EOF {
 									break
-								} else {
-									t.Fatalf("Failed to parse tar file: %v", err)
 								}
+								t.Fatalf("Failed to parse tar file: %v", err)
 							}
 
 							if !reflect.DeepEqual(gotH, wantH) {

--- a/fs/reader/testutil.go
+++ b/fs/reader/testutil.go
@@ -304,10 +304,8 @@ func testCacheVerify(t *testing.T, factory metadata.Store) {
 						if err != nil {
 							t.Fatalf("failed to make new reader: %v", err)
 						}
-						if verifier != nil {
-							vr.verifier = verifier.verifier
-							vr.r.verifier = verifier.verifier
-						}
+						vr.verifier = verifier.verifier
+						vr.r.verifier = verifier.verifier
 
 						off2id, id2path, err := prepareMap(vr.Metadata(), vr.Metadata().RootID(), "")
 						if err != nil || off2id == nil || id2path == nil {


### PR DESCRIPTION
This refactors code and bumps up golangci-lint to v1.53.3: https://github.com/golangci/golangci-lint/releases/tag/v1.53.3

This PR also refactors code to fix the following linter errors:

```
fs/reader/testutil.go:307:10: SA4031: this nil check is always true (staticcheck)
						if verifier != nil {
						   ^
fs/reader/testutil.go:297:20: SA4031(related information): this is the value of verifier (staticcheck)
						verifier := &failIDVerifier{}
						             ^
build.go:439:11: superfluous-else: if block ends with a break statement, so drop this else and outdent its block (revive)
			} else {
				return nil, fmt.Errorf("failed to parse tar file, %w", err)
			}
build_test.go:415:16: superfluous-else: if block ends with a break statement, so drop this else and outdent its block (revive)
								} else {
									t.Fatalf("Failed to parse tar file: %v", err)
								}
```

`unused-parameter` is disabled because it seems too strict (e.g. unused ctx context.Context argument isn't allowed by that rule).
