### PR TITLE
fix: rollback snapshot to prevent bolt deadlock

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -316,8 +316,9 @@ func (o *snapshotter) commit(ctx context.Context, isRemote bool, name, key strin
 		return err
 	}
 
+	rollback := true
 	defer func() {
-		if err != nil {
+		if rollback {
 			if rerr := t.Rollback(); rerr != nil {
 				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
 			}
@@ -342,6 +343,7 @@ func (o *snapshotter) commit(ctx context.Context, isRemote bool, name, key strin
 		return fmt.Errorf("failed to commit snapshot: %w", err)
 	}
 
+	rollback = false
 	return t.Commit()
 }
 


### PR DESCRIPTION
The defer function above checks for the err in the outer scope to determine if it should rollback.
The error in the inner-scope of isRemote is a shadow and when it is an error will not cause a rollback of the transaction.

This causes the bolt transaction to keep the write lock open forever.  Any other attempts at taking a write lock will never succeed.

It is not uncommon for `fs.DiskUsage` to be context canceled as it can take a long time to walk the filesystem.