### PR TITLE
Protect node.ents and node.entsCached with a mutex in fs/layer/node.go

### DIFF
--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -127,11 +127,13 @@ func (fs *fs) inodeOfID(id uint32) (uint64, error) {
 // node is a filesystem inode abstraction.
 type node struct {
 	fusefs.Inode
-	fs         *fs
-	id         uint32
-	attr       metadata.Attr
+	fs   *fs
+	id   uint32
+	attr metadata.Attr
+
 	ents       []fuse.DirEntry
 	entsCached bool
+	entsMu     sync.Mutex
 }
 
 func (n *node) isRootNode() bool {
@@ -162,9 +164,13 @@ func (n *node) readdir() ([]fuse.DirEntry, syscall.Errno) {
 	start := time.Now() // set start time
 	defer commonmetrics.MeasureLatencyInMicroseconds(commonmetrics.NodeReaddir, n.fs.layerDigest, start)
 
+	n.entsMu.Lock()
 	if n.entsCached {
-		return n.ents, 0
+		ents := n.ents
+		n.entsMu.Unlock()
+		return ents, 0
 	}
+	n.entsMu.Unlock()
 
 	isRoot := n.isRootNode()
 
@@ -228,6 +234,8 @@ func (n *node) readdir() ([]fuse.DirEntry, syscall.Errno) {
 	sort.Slice(ents, func(i, j int) bool {
 		return ents[i].Name < ents[j].Name
 	})
+	n.entsMu.Lock()
+	defer n.entsMu.Unlock()
 	n.ents, n.entsCached = ents, true // cache it
 
 	return ents, 0
@@ -279,6 +287,7 @@ func (n *node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fu
 	}
 
 	// early return if this entry doesn't exist
+	n.entsMu.Lock()
 	if n.entsCached {
 		var found bool
 		for _, e := range n.ents {
@@ -287,9 +296,11 @@ func (n *node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fu
 			}
 		}
 		if !found {
+			n.entsMu.Unlock()
 			return nil, syscall.ENOENT
 		}
 	}
+	n.entsMu.Unlock()
 
 	id, ce, err := n.fs.r.Metadata().GetChild(n.id, name)
 	if err != nil {


### PR DESCRIPTION
We run a modified version of the soci-snapshotter (which is based on the stargz-snapshotter) in production at BuildBuddy and recently enabled the golang race detector in our dev environment. It flagged racy accesses to node.ents and node.entsCached, here are the [logs](https://github.com/containerd/stargz-snapshotter/files/12591490/datarace.txt) (line numbers should be the same). This commit protects access to those two fields with a mutex.