### PR TITLE
CI: Fix K3SArgoWorkflow 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -230,6 +230,11 @@ jobs:
         gunzip argo-linux-amd64.gz
         sudo mv argo-linux-amd64 /usr/local/bin/argo
         sudo chmod +x /usr/local/bin/argo
+    - name: Workaround for freeing up more disk space
+      # https://github.com/actions/runner-images/issues/2606
+      run: |
+        sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+        sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
     - uses: actions/checkout@v4
     - name: Prepare directories
       run: mkdir "${RESULT_DIR}"


### PR DESCRIPTION
Recently K3SArgoWorkflow fails and it seems to be because of disk pressure on the ubuntu runner (`Warning  FailedScheduling  4m1s  default-scheduler  0/1 nodes are available: 1 node(s) had untolerated taint {node.kubernetes.io/disk-pressure: }. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..`).
This commit fixes this issue by freeing up more spaces on the runner before running the test.