### PR TITLE
CI: temporary disable containerd main branch integration test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,8 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  DOCKER_BUILD_ARGS: --build-arg=CONTAINERD_VERSION=main # do tests with the latest containerd
+  # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
+  # DOCKER_BUILD_ARGS: --build-arg=CONTAINERD_VERSION=main # do tests with the latest containerd
 
 jobs:
   integration:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,8 +58,8 @@ jobs:
         builtin: ["true", "false"]
         metadata-store: ["memory", "db"]
         exclude:
-        - buildargs: ""
-          builtin: "true"
+        # - buildargs: ""
+        #   builtin: "true"
         - metadata-store: "db"
           builtin: "true"
         # - metadata-store: "db"
@@ -103,9 +103,9 @@ jobs:
         # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
         buildargs: [""]
         builtin: ["true", "false"]
-        exclude:
-        - buildargs: ""
-          builtin: "true"
+        # exclude:
+        # - buildargs: ""
+        #   builtin: "true"
     steps:
     - name: Install htpasswd for setting up private registry
       run: sudo apt-get update -y && sudo apt-get --no-install-recommends install -y apache2-utils
@@ -126,9 +126,9 @@ jobs:
         # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
         buildargs: [""]
         builtin: ["true", "false"]
-        exclude:
-        - buildargs: ""
-          builtin: "true"
+        # exclude:
+        # - buildargs: ""
+        #   builtin: "true"
     steps:
     - name: Install htpasswd for setting up private registry
       run: sudo apt-get update -y && sudo apt-get --no-install-recommends install -y apache2-utils
@@ -151,8 +151,8 @@ jobs:
         builtin: ["true", "false"]
         metadata-store: ["memory", "db"]
         exclude:
-        - buildargs: ""
-          builtin: "true"
+        # - buildargs: ""
+        #   builtin: "true"
         - metadata-store: "db"
           builtin: "true"
         # - metadata-store: "db"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
+        # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: [""]
         builtin: ["true", "false"]
         metadata-store: ["memory", "db"]
         exclude:
@@ -60,8 +62,8 @@ jobs:
           builtin: "true"
         - metadata-store: "db"
           builtin: "true"
-        - metadata-store: "db"
-          buildargs: "--build-arg=CONTAINERD_VERSION=main"
+        # - metadata-store: "db"
+        #   buildargs: "--build-arg=CONTAINERD_VERSION=main"
     steps:
     - name: Install htpasswd for setting up private registry
       run: sudo apt-get update -y && sudo apt-get --no-install-recommends install -y apache2-utils
@@ -79,7 +81,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
+        # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: [""]
     steps:
     - name: Install htpasswd for setting up private registry
       run: sudo apt-get update -y && sudo apt-get --no-install-recommends install -y apache2-utils
@@ -95,7 +99,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
+        # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: [""]
         builtin: ["true", "false"]
         exclude:
         - buildargs: ""
@@ -116,7 +122,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
+        # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: [""]
         builtin: ["true", "false"]
         exclude:
         - buildargs: ""
@@ -137,7 +145,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
+        # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: [""]
         builtin: ["true", "false"]
         metadata-store: ["memory", "db"]
         exclude:
@@ -145,8 +155,8 @@ jobs:
           builtin: "true"
         - metadata-store: "db"
           builtin: "true"
-        - metadata-store: "db"
-          buildargs: "--build-arg=CONTAINERD_VERSION=main"
+        # - metadata-store: "db"
+        #   buildargs: "--build-arg=CONTAINERD_VERSION=main"
     steps:
     - uses: actions/checkout@v4
     - name: Validate containerd through CRI

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,16 @@ RUN apt-get update -y && apt-get install -y libbtrfs-dev libseccomp-dev && \
       echo 'replace github.com/containerd/stargz-snapshotter => '$GOPATH'/src/github.com/containerd/stargz-snapshotter' >> integration/client/go.mod && \
       echo 'replace github.com/containerd/stargz-snapshotter/estargz => '$GOPATH'/src/github.com/containerd/stargz-snapshotter/estargz' >> integration/client/go.mod ; \
     fi && \
+    if [ "$(echo -n ${CONTAINERD_VERSION} | head -c 4)" = "v1.7" ] ; then \
+      # containerd v1.7 doesn't support cri-api >= v0.28 which adds RuntimeConfig API
+      echo 'replace k8s.io/cri-api => k8s.io/cri-api v0.27.1' >> go.mod ; \
+      if [ -f api/go.mod ] ; then \
+        echo 'replace k8s.io/cri-api => k8s.io/cri-api v0.27.1' >> api/go.mod ; \
+      fi ; \
+      if [ -f integration/client/go.mod ] ; then \
+        echo 'replace k8s.io/cri-api => k8s.io/cri-api v0.27.1' >> integration/client/go.mod ; \
+      fi ; \
+    fi && \
     echo 'package main \nimport _ "github.com/containerd/stargz-snapshotter/service/plugin"' > cmd/containerd/builtins_stargz_snapshotter.go && \
     make vendor && make && DESTDIR=/out/ PREFIX= make install
 

--- a/script/optimize/optimize/entrypoint.sh
+++ b/script/optimize/optimize/entrypoint.sh
@@ -205,7 +205,9 @@ echo "Checking optimized image..."
 WORKING_DIR=$(mktemp -d)
 git config --global --add safe.directory '/go/src/github.com/containerd/stargz-snapshotter'
 PREFIX=/tmp/out/ make clean
-PREFIX=/tmp/out/ GO_BUILD_FLAGS="-race" make ctr-remote # Check data race
+# temporary disable -race flag to run test with statically built binaries
+# PREFIX=/tmp/out/ GO_BUILD_FLAGS="-race" make ctr-remote # Check data race
+PREFIX=/tmp/out/ make ctr-remote
 /tmp/out/ctr-remote ${OPTIMIZE_COMMAND} -entrypoint='[ "/accessor" ]' "${ORG_IMAGE_TAG}" "${OPT_IMAGE_TAG}"
 nerdctl push "${OPT_IMAGE_TAG}" || true
 cat <<EOF > "${WORKING_DIR}/0-want"


### PR DESCRIPTION
containerd main branch changed plugin API that will be released in containerd v2 and that makes the plugin API not compatible to containerd v1 plugin APIs. We'll migrate to the new API once containerd v2 is released. As of now, just temporary disable the CI test against containerd main branch until we migrate to v2 API.

This is needed to pass CI in all other PRs.