### PR TITLE
Prepare for v0.15.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/containerd/containerd v1.7.8
 	github.com/containerd/go-cni v1.1.9
 	github.com/containerd/log v0.1.0
-	github.com/containerd/stargz-snapshotter v0.14.3
-	github.com/containerd/stargz-snapshotter/estargz v0.14.3
-	github.com/containerd/stargz-snapshotter/ipfs v0.14.3
+	github.com/containerd/stargz-snapshotter v0.15.0
+	github.com/containerd/stargz-snapshotter/estargz v0.15.0
+	github.com/containerd/stargz-snapshotter/ipfs v0.15.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.10.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/containerd/containerd v1.7.8
 	github.com/containerd/continuity v0.4.3
 	github.com/containerd/log v0.1.0
-	github.com/containerd/stargz-snapshotter/estargz v0.14.3
+	github.com/containerd/stargz-snapshotter/estargz v0.15.0
 	github.com/docker/cli v24.0.7+incompatible
 	github.com/docker/go-metrics v0.0.1
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da


### PR DESCRIPTION
```
## Notable Changes

- Removed support for CRI v1alpha2 API that was deprecated in containerd v1.7 (#1175)
- Make timeout per-request (#1181), thanks to @Kern--
- fix: rollback snapshot to prevent bolt deadlock (#1326), thanks to @goller
- Protect node.ents and node.entsCached with a mutex (#1381), thanks to @iain-macdonald
- Fixed the snapshotter reported incorrect number blocks for a file (#1387), thanks to @Kern--
- chore: pkg imported more than once (#1363), thanks to @testwill
```