### PR TITLE
fix `gh` invocation release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,4 +66,4 @@ jobs:
         for A in "amd64" "arm-v7" "arm64" "ppc64le" "s390x" ; do
           ASSET_ARGS+=("${OUTPUT_DIR}/builds-${A}/*")
         done
-        gh release create -F ${GITHUB_WORKSPACE}/release-note.txt --draft --title "${RELEASE_TAG}" "${RELEASE_TAG}" "${ASSET_ARGS[@]}"
+        gh release create -F ${GITHUB_WORKSPACE}/release-note.txt --draft --title "${RELEASE_TAG}" "${RELEASE_TAG}" ${ASSET_ARGS[@]}


### PR DESCRIPTION
This fixes the error in the release ci.

I've just noticed this after tagging `v0.15.0`. I won't  remove that tag and I'll create another new release `v0.15.1` for releasing binaries on the github release page. `v0.15.0` will remain not having release page nor binaries.

```
Run RELEASE_TAG="${GITHUB_REF##*/}"
total 28
drwxr-xr-x  7 runner docker 4096 Oct 31 05:18 .
drwxr-xr-x 22 runner docker 4096 Oct 31 05:18 ..
drwxr-xr-x  2 runner docker 4096 Oct 31 05:17 builds-amd64
drwxr-xr-x  2 runner docker 4096 Oct 31 05:18 builds-arm-v7
drwxr-xr-x  2 runner docker 4096 Oct 31 05:18 builds-arm64
drwxr-xr-x  2 runner docker 4096 Oct 31 05:18 builds-ppc64le
drwxr-xr-x  2 runner docker 4096 Oct 31 05:18 builds-s390x
stat /home/runner/work/stargz-snapshotter/stargz-snapshotter/builds/builds-amd64/*: no such file or directory
```