### PR TITLE
Bump up golangci-lint to 1.55.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.7.0
       with:
-        version: v1.54.2
+        version: v1.55.2
         args: --verbose
         working-directory: ${{ matrix.targetdir }}
 

--- a/estargz/testutil.go
+++ b/estargz/testutil.go
@@ -920,9 +920,11 @@ func checkVerifyInvalidTOCEntryFail(filename string) check {
 				}
 				if sampleEntry == nil {
 					t.Fatalf("TOC must contain at least one regfile or chunk entry other than the rewrite target")
+					return
 				}
 				if targetEntry == nil {
 					t.Fatalf("rewrite target not found")
+					return
 				}
 				targetEntry.Offset = sampleEntry.Offset
 			},


### PR DESCRIPTION
Fixes the following linter errors as well 

```
testutil.go:927:17: SA5011: possible nil pointer dereference (staticcheck)
				targetEntry.Offset = sampleEntry.Offset
				            ^
testutil.go:924:8: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
				if targetEntry == nil {
				   ^
testutil.go:921:8: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
				if sampleEntry == nil {
				   ^
```