### PR TITLE
fs: Check connection only when image isn't fully cached

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -382,10 +382,13 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[s
 		return fmt.Errorf("layer not registered")
 	}
 
-	// Check the blob connectivity and try to refresh the connection on failure
-	if err := fs.check(ctx, l, labels); err != nil {
-		log.G(ctx).WithError(err).Warn("check failed")
-		return err
+	if l.Info().FetchedSize < l.Info().Size {
+		// Image contents hasn't fully cached yet.
+		// Check the blob connectivity and try to refresh the connection on failure
+		if err := fs.check(ctx, l, labels); err != nil {
+			log.G(ctx).WithError(err).Warn("check failed")
+			return err
+		}
 	}
 
 	// Wait for prefetch compeletion

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -65,14 +65,20 @@ type breakableLayer struct {
 	success bool
 }
 
-func (l *breakableLayer) Info() layer.Info                                    { return layer.Info{} }
-func (l *breakableLayer) RootNode(uint32) (fusefs.InodeEmbedder, error)       { return nil, nil }
-func (l *breakableLayer) Verify(tocDigest digest.Digest) error                { return nil }
-func (l *breakableLayer) SkipVerify()                                         {}
-func (l *breakableLayer) Prefetch(prefetchSize int64) error                   { return fmt.Errorf("fail") }
-func (l *breakableLayer) ReadAt([]byte, int64, ...remote.Option) (int, error) { return 0, nil }
-func (l *breakableLayer) WaitForPrefetchCompletion() error                    { return fmt.Errorf("fail") }
-func (l *breakableLayer) BackgroundFetch() error                              { return fmt.Errorf("fail") }
+func (l *breakableLayer) Info() layer.Info {
+	return layer.Info{
+		Size: 1,
+	}
+}
+func (l *breakableLayer) RootNode(uint32) (fusefs.InodeEmbedder, error) { return nil, nil }
+func (l *breakableLayer) Verify(tocDigest digest.Digest) error          { return nil }
+func (l *breakableLayer) SkipVerify()                                   {}
+func (l *breakableLayer) Prefetch(prefetchSize int64) error             { return fmt.Errorf("fail") }
+func (l *breakableLayer) ReadAt([]byte, int64, ...remote.Option) (int, error) {
+	return 0, fmt.Errorf("fail")
+}
+func (l *breakableLayer) WaitForPrefetchCompletion() error { return fmt.Errorf("fail") }
+func (l *breakableLayer) BackgroundFetch() error           { return fmt.Errorf("fail") }
 func (l *breakableLayer) Check() error {
 	if !l.success {
 		return fmt.Errorf("failed")


### PR DESCRIPTION
Fixes: #1583

When the layer is fully cached on the node, registry connection won't happen so we can skip the checking.