### PR TITLE
CI: Fix k3s test faliure

### DIFF
--- a/script/k3s/run-k3s.sh
+++ b/script/k3s/run-k3s.sh
@@ -79,6 +79,11 @@ sed -i -E 's|DAPPER_ENV="([^"]*)"|DAPPER_ENV="\1 DOCKER_BUILDKIT"|g' "${TMP_K3S_
         REPO="${K3S_NODE_REPO}" IMAGE_NAME="${K3S_NODE_IMAGE_NAME}" TAG="${K3S_NODE_TAG}" SKIP_VALIDATE=1 make
 )
 cat <<EOF > "${TMP_BUILTIN_CONF}"
+mirrors:
+  ${REGISTRY_HOST}:5000:
+    endpoint:
+      - ${REGISTRY_HOST}:5000
+      - ${REGISTRY_HOST}:5001 # dummy
 configs:
   ${REGISTRY_HOST}:5000:
     tls:

--- a/script/optimize/optimize/entrypoint.sh
+++ b/script/optimize/optimize/entrypoint.sh
@@ -128,8 +128,7 @@ function check_uncompressed_size {
 function check_optimization {
     local TARGET=${1}
 
-    LOCAL_WORKING_DIR="${WORKING_DIR}/$(date '+%H%M%S')"
-    mkdir "${LOCAL_WORKING_DIR}"
+    LOCAL_WORKING_DIR="$(mktemp -d --tmpdir=${WORKING_DIR}/)"
     nerdctl pull "${TARGET}" && nerdctl save "${TARGET}" | tar xv -C "${LOCAL_WORKING_DIR}"
     LAYERS="$(cat "${LOCAL_WORKING_DIR}/manifest.json" | jq -r '.[0].Layers[]')"
 


### PR DESCRIPTION
When no mirror is configured for recent k3s, it generates [containerd's hosts configuration](https://github.com/k3s-io/k3s/blob/364dfd8b89e62bc7816aa4843db8deb6f6fd2978/pkg/agent/templates/templates.go#L43) (hosts.toml) that seems to be treated as invalid by containerd (w/ error `failed to decode hosts.toml" error="invalid host tree`).
This commit is a quick temporary fix for unblocking other PRs but in the future, fixes on k3s should be done.