### PR TITLE
Use golangci-lint v1.58.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       uses: golangci/golangci-lint-action@v4.0.0
       with:
         version: v1.58.0
-        args: --verbose
+        args: --verbose --timeout=10m
         working-directory: ${{ matrix.targetdir }}
 
   integration:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v4.0.0
       with:
-        version: v1.56.2
+        version: v1.58.0
         args: --verbose
         working-directory: ${{ matrix.targetdir }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,15 +3,13 @@
 
 linters:
   enable:
-    - structcheck
-    - varcheck
     - staticcheck
     - unconvert
     - gofmt
     - goimports
     - revive
     - ineffassign
-    - vet
+    - govet
     - unused
     - misspell
   disable:
@@ -19,14 +17,14 @@ linters:
 
 run:
   deadline: 4m
-  skip-dirs:
-    - docs
-    - images
-    - out
-    - script
 
 issues:
   exclude-rules:
     - linters:
         - revive
       text: "unused-parameter"
+  exclude-dirs:
+    - docs
+    - images
+    - out
+    - script


### PR DESCRIPTION
This also fixes the following linter warnings and errors.

```
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`. 
WARN [lintersdb] The name "vet" is deprecated. The linter has been renamed to: govet. 
WARN The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
WARN The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
ERRO [linters_context] structcheck: This linter is fully inactivated: it will not produce any reports. 
ERRO [linters_context] varcheck: This linter is fully inactivated: it will not produce any reports. 

```