### PR TITLE
CI: Bump golangci-lint to 1.59.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6.0.1
       with:
-        version: v1.59.0
+        version: v1.59.1
         args: --verbose --timeout=10m
         working-directory: ${{ matrix.targetdir }}
 


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.59.1