### PR TITLE
Prepare for v0.16.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/containerd/go-cni v1.1.10
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v0.2.1
-	github.com/containerd/stargz-snapshotter v0.15.2-0.20240622031358-6405f362966d
-	github.com/containerd/stargz-snapshotter/estargz v0.15.2-0.20240622031358-6405f362966d
-	github.com/containerd/stargz-snapshotter/ipfs v0.15.2-0.20240622031358-6405f362966d
+	github.com/containerd/stargz-snapshotter v0.16.0
+	github.com/containerd/stargz-snapshotter/estargz v0.16.0
+	github.com/containerd/stargz-snapshotter/ipfs v0.16.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.10.3

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v0.2.1
 	github.com/containerd/plugin v0.1.0
-	github.com/containerd/stargz-snapshotter/estargz v0.15.1
+	github.com/containerd/stargz-snapshotter/estargz v0.16.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v27.3.1+incompatible
 	github.com/docker/go-metrics v0.0.1


### PR DESCRIPTION
Needs #1823 and  #1723

```
Notable Changes

- Support for the latest CRI-O(>=v1.31.0) and Podman (>=v5.1.0) Additional Layer Store (#1673, #1674)
- Fix log message in refnode.Lookup (#1595), thanks to @iain-macdonald
- store: use OnForget API for checking if a node is reusable (#1808)
- Support for containerd v2 (#1722), thanks to @apostasie
- fs: Check connection only when image isn't fully cached (#1584)
```