### PR TITLE
Add FUSE Passthrough Support in Stargz-Snapshotter #1867

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -82,6 +82,7 @@ type BlobCache interface {
 type Reader interface {
 	io.ReaderAt
 	Close() error
+	GetReaderAt() io.ReaderAt
 }
 
 // Writer enables the client to cache byte data. Commit() must be
@@ -413,6 +414,10 @@ type reader struct {
 }
 
 func (r *reader) Close() error { return r.closeFunc() }
+
+func (r *reader) GetReaderAt() io.ReaderAt {
+	return r.ReaderAt
+}
 
 type writer struct {
 	io.WriteCloser

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -82,6 +82,8 @@ type BlobCache interface {
 type Reader interface {
 	io.ReaderAt
 	Close() error
+
+	// If a blob is backed by a file, it should return *os.File so that it can be used for FUSE passthrough
 	GetReaderAt() io.ReaderAt
 }
 

--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -26,8 +27,10 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"time"
 
 	snapshotsapi "github.com/containerd/containerd/api/services/snapshots/v1"
@@ -132,6 +135,11 @@ func main() {
 	// Create a gRPC server
 	rpc := grpc.NewServer()
 
+	// Configure FUSE passthrough
+	if config.Config.Config.FuseConfig.PassThrough, err = isFusePthEnable(); err != nil {
+		log.G(ctx).Warnf("failed to check FUSE passthrough support")
+	}
+
 	// Configure keychain
 	credsFuncs := []resolver.Credential{dockerconfig.NewDockerconfigKeychain(ctx)}
 	if config.Config.KubeconfigKeychainConfig.EnableKeychain {
@@ -183,6 +191,18 @@ func main() {
 		rs.Close()
 	}
 	log.G(ctx).Info("Exiting")
+}
+
+// isFusePthEnable prevents users from enabling passthrough mode on unsupported kernel versions
+func isFusePthEnable() (bool, error) {
+	cmd := exec.Command("sh", "-c", "grep 'CONFIG_FUSE_PASSTHROUGH=y' /boot/config-$(uname -r)")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return false, err
+	}
+	return strings.Contains(out.String(), "CONFIG_FUSE_PASSTHROUGH=y"), nil
 }
 
 func serve(ctx context.Context, rpc *grpc.Server, addr string, rs snapshots.Snapshotter, config snapshotterConfig) (bool, error) {

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -148,4 +148,7 @@ type FuseConfig struct {
 
 	// EntryTimeout defines TTL for directory, name lookup in seconds.
 	EntryTimeout int64 `toml:"entry_timeout"`
+
+	// PassThrough indicates whether to enable FUSE passthrough mode to improve local file read performance. Default is false.
+	PassThrough bool `toml:"passthrough"`
 }

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -150,5 +150,5 @@ type FuseConfig struct {
 	EntryTimeout int64 `toml:"entry_timeout"`
 
 	// PassThrough indicates whether to enable FUSE passthrough mode to improve local file read performance. Default is false.
-	PassThrough bool `toml:"passthrough"`
+	PassThrough bool `toml:"passthrough" default:"false"`
 }

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -356,10 +356,11 @@ func (n *node) Open(ctx context.Context, flags uint32) (fh fusefs.FileHandle, fu
 		if getter, ok := ra.(reader.PassthroughFdGetter); ok {
 			fd, err := getter.GetPassthroughFd()
 			if err != nil {
-				n.fs.s.report(fmt.Errorf("node.Open: %v", err))
-				return nil, 0, syscall.EIO
+				n.fs.s.report(fmt.Errorf("passThrough model failed due to node.Open: %v", err))
+				n.fs.passThrough = false
+			} else {
+				f.InitFd(int(fd))
 			}
-			f.InitFd(int(fd))
 		}
 	}
 

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -76,7 +76,7 @@ var opaqueXattrs = map[OverlayOpaqueType][]string{
 	OverlayOpaqueUser:    {"user.overlay.opaque"},
 }
 
-func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseInode uint32, opaque OverlayOpaqueType) (fusefs.InodeEmbedder, error) {
+func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseInode uint32, opaque OverlayOpaqueType, pth bool) (fusefs.InodeEmbedder, error) {
 	rootID := r.Metadata().RootID()
 	rootAttr, err := r.Metadata().GetAttr(rootID)
 	if err != nil {
@@ -92,6 +92,7 @@ func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseIno
 		baseInode:    baseInode,
 		rootID:       rootID,
 		opaqueXattrs: opq,
+		passThrough:  pth,
 	}
 	ffs.s = ffs.newState(layerDgst, blob)
 	return &node{
@@ -109,6 +110,7 @@ type fs struct {
 	baseInode    uint32
 	rootID       uint32
 	opaqueXattrs []string
+	passThrough  bool
 }
 
 func (fs *fs) inodeOfState() uint64 {
@@ -344,10 +346,24 @@ func (n *node) Open(ctx context.Context, flags uint32) (fh fusefs.FileHandle, fu
 		n.fs.s.report(fmt.Errorf("node.Open: %v", err))
 		return nil, 0, syscall.EIO
 	}
-	return &file{
+
+	f := &file{
 		n:  n,
 		ra: ra,
-	}, fuse.FOPEN_KEEP_CACHE, 0
+	}
+
+	if n.fs.passThrough {
+		if getter, ok := ra.(reader.PassthroughFdGetter); ok {
+			fd, err := getter.GetPassthroughFd()
+			if err != nil {
+				n.fs.s.report(fmt.Errorf("node.Open: %v", err))
+				return nil, 0, syscall.EIO
+			}
+			f.InitFd(int(fd))
+		}
+	}
+
+	return f, fuse.FOPEN_KEEP_CACHE, 0
 }
 
 var _ = (fusefs.NodeGetattrer)((*node)(nil))
@@ -424,6 +440,7 @@ func (n *node) Statfs(ctx context.Context, out *fuse.StatfsOut) syscall.Errno {
 type file struct {
 	n  *node
 	ra io.ReaderAt
+	fd int
 }
 
 var _ = (fusefs.FileReader)((*file)(nil))
@@ -449,6 +466,17 @@ func (f *file) Getattr(ctx context.Context, out *fuse.AttrOut) syscall.Errno {
 	}
 	entryToAttr(ino, f.n.attr, &out.Attr)
 	return 0
+}
+
+// Implement PassthroughFd to enable go-fuse passthrough
+var _ = (fusefs.FilePassthroughFder)((*file)(nil))
+
+func (f *file) PassthroughFd() (int, bool) {
+	return f.fd, true
+}
+
+func (f *file) InitFd(fd int) {
+	f.fd = fd
 }
 
 // whiteout is a whiteout abstraction compliant to overlayfs.

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -74,6 +74,7 @@ var srcCompressions = map[string]tutil.CompressionFactory{
 func TestSuiteLayer(t *testing.T, store metadata.Store) {
 	testPrefetch(t, store)
 	testNodeRead(t, store)
+	testPassThroughRead(t, store)
 	testNodes(t, store)
 }
 
@@ -380,7 +381,15 @@ const (
 	lastChunkOffset1   = sampleChunkSize * (int64(len(sampleData1)) / sampleChunkSize)
 )
 
+func testPassThroughRead(t *testing.T, factory metadata.Store) {
+	nodeRead(t, factory, true)
+}
+
 func testNodeRead(t *testing.T, factory metadata.Store) {
+	nodeRead(t, factory, false)
+}
+
+func nodeRead(t *testing.T, factory metadata.Store, pth bool) {
 	sizeCond := map[string]int64{
 		"single_chunk": sampleChunkSize - sampleMiddleOffset,
 		"multi_chunks": sampleChunkSize + sampleMiddleOffset,
@@ -429,7 +438,7 @@ func testNodeRead(t *testing.T, factory metadata.Store) {
 							}
 
 							// data we get from the file node.
-							f, closeFn := makeNodeReader(t, []byte(sampleData1)[:filesize], sampleChunkSize, factory, cl)
+							f, closeFn := makeNodeReader(t, []byte(sampleData1)[:filesize], sampleChunkSize, factory, cl, pth)
 							defer closeFn()
 							tmpbuf := make([]byte, size) // fuse library can request bigger than remain
 							rr, errno := f.Read(context.Background(), tmpbuf, offset)
@@ -460,7 +469,7 @@ func testNodeRead(t *testing.T, factory metadata.Store) {
 	}
 }
 
-func makeNodeReader(t *testing.T, contents []byte, chunkSize int, factory metadata.Store, cl tutil.Compression) (_ *file, closeFn func() error) {
+func makeNodeReader(t *testing.T, contents []byte, chunkSize int, factory metadata.Store, cl tutil.Compression, pth bool) (_ *file, closeFn func() error) {
 	testName := "test"
 	sr, tocDgst, err := tutil.BuildEStargz(
 		[]tutil.TarEntry{tutil.File(testName, string(contents))},
@@ -473,7 +482,7 @@ func makeNodeReader(t *testing.T, contents []byte, chunkSize int, factory metada
 	if err != nil {
 		t.Fatalf("failed to create reader: %v", err)
 	}
-	rootNode := getRootNode(t, r, OverlayOpaqueAll, tocDgst, cache.NewMemoryCache())
+	rootNode := getRootNode(t, r, OverlayOpaqueAll, tocDgst, cache.NewMemoryCache(), pth)
 	var eo fuse.EntryOut
 	inode, errno := rootNode.Lookup(context.Background(), testName, &eo)
 	if errno != 0 {
@@ -725,7 +734,7 @@ func testNodesWithOpaque(t *testing.T, factory metadata.Store, opaque OverlayOpa
 				}
 				defer r.Close()
 				mcache := cache.NewMemoryCache()
-				rootNode := getRootNode(t, r, opaque, tocDgst, mcache)
+				rootNode := getRootNode(t, r, opaque, tocDgst, mcache, false)
 				for _, want := range tt.want {
 					want(t, rootNode, mcache, testR)
 				}
@@ -734,7 +743,7 @@ func testNodesWithOpaque(t *testing.T, factory metadata.Store, opaque OverlayOpa
 	}
 }
 
-func getRootNode(t *testing.T, r metadata.Reader, opaque OverlayOpaqueType, tocDgst digest.Digest, cc cache.BlobCache) *node {
+func getRootNode(t *testing.T, r metadata.Reader, opaque OverlayOpaqueType, tocDgst digest.Digest, cc cache.BlobCache, pth bool) *node {
 	vr, err := reader.NewReader(r, cc, digest.FromString(""))
 	if err != nil {
 		t.Fatalf("failed to create reader: %v", err)
@@ -743,7 +752,7 @@ func getRootNode(t *testing.T, r metadata.Reader, opaque OverlayOpaqueType, tocD
 	if err != nil {
 		t.Fatalf("failed to verify reader: %v", err)
 	}
-	rootNode, err := newNode(testStateLayerDigest, rr, &testBlobState{10, 5}, 100, opaque, false)
+	rootNode, err := newNode(testStateLayerDigest, rr, &testBlobState{10, 5}, 100, opaque, pth)
 	if err != nil {
 		t.Fatalf("failed to get root node: %v", err)
 	}

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -218,6 +218,7 @@ func testPrefetch(t *testing.T, factory metadata.Store) {
 					ocispec.Descriptor{Digest: testStateLayerDigest},
 					&blobRef{blob, func() {}},
 					vr,
+					false,
 				)
 				if err := l.Verify(dgst); err != nil {
 					t.Errorf("failed to verify reader: %v", err)
@@ -742,7 +743,7 @@ func getRootNode(t *testing.T, r metadata.Reader, opaque OverlayOpaqueType, tocD
 	if err != nil {
 		t.Fatalf("failed to verify reader: %v", err)
 	}
-	rootNode, err := newNode(testStateLayerDigest, rr, &testBlobState{10, 5}, 100, opaque)
+	rootNode, err := newNode(testStateLayerDigest, rr, &testBlobState{10, 5}, 100, opaque, false)
 	if err != nil {
 		t.Fatalf("failed to get root node: %v", err)
 	}

--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -53,6 +53,10 @@ type Reader interface {
 	LastOnDemandReadTime() time.Time
 }
 
+type PassthroughFdGetter interface {
+	GetPassthroughFd() (uintptr, error)
+}
+
 // VerifiableReader produces a Reader with a given verifier.
 type VerifiableReader struct {
 	r *reader
@@ -490,18 +494,101 @@ func (sf *file) ReadAt(p []byte, offset int64) (int, error) {
 	return nr, nil
 }
 
-func (gr *reader) verifyAndCache(entryID uint32, ip []byte, chunkDigestStr string, cacheID string) error {
-	// We can end up doing on demand registry fetch when aligning the chunk
-	commonmetrics.IncOperationCount(commonmetrics.OnDemandRemoteRegistryFetchCount, gr.layerSha) // increment the number of on demand file fetches from remote registry
-	commonmetrics.AddBytesCount(commonmetrics.OnDemandBytesFetched, gr.layerSha, int64(len(ip))) // record total bytes fetched
-	gr.setLastReadTime(time.Now())
+func (sf *file) GetPassthroughFd() (uintptr, error) {
+	var (
+		offset           int64 = 0
+		firstChunkOffset int64 = -1
+		totalSize        int64 = 0
+	)
 
-	// Verify this chunk
+	for {
+		chunkOffset, chunkSize, _, ok := sf.fr.ChunkEntryForOffset(offset)
+		if !ok {
+			break
+		}
+		if firstChunkOffset == -1 {
+			firstChunkOffset = chunkOffset
+		}
+		totalSize += chunkSize
+		offset = chunkOffset + chunkSize
+	}
+
+	id := genID(sf.id, firstChunkOffset, totalSize)
+
+	for {
+		r, err := sf.gr.cache.Get(id)
+		if err != nil {
+			if err := sf.prefetchEntireFile(); err != nil {
+				return 0, err
+			}
+			continue
+		}
+
+		readerAt := r.GetReaderAt()
+		if file, ok := readerAt.(*os.File); ok {
+			fd := file.Fd()
+			r.Close()
+			return fd, nil
+		} else {
+			r.Close()
+			return 0, fmt.Errorf("The cached ReaderAt is not of type *os.File, fd obtain failed")
+		}
+	}
+}
+
+func (sf *file) prefetchEntireFile() error {
+	var (
+		offset           int64 = 0
+		firstChunkOffset int64 = -1
+		totalSize        int64 = 0
+	)
+	combinedBuffer := sf.gr.bufPool.Get().(*bytes.Buffer)
+	combinedBuffer.Reset()
+	defer sf.gr.putBuffer(combinedBuffer)
+
+	for {
+		chunkOffset, chunkSize, chunkDigestStr, ok := sf.fr.ChunkEntryForOffset(offset)
+		if !ok {
+			break
+		}
+		if firstChunkOffset == -1 {
+			firstChunkOffset = chunkOffset
+		}
+		b := sf.gr.bufPool.Get().(*bytes.Buffer)
+		b.Reset()
+		b.Grow(int(chunkSize))
+		ip := b.Bytes()[:chunkSize]
+		if _, err := sf.fr.ReadAt(ip, chunkOffset); err != nil && err != io.EOF {
+			sf.gr.putBuffer(b)
+			return fmt.Errorf("failed to read data: %w", err)
+		}
+		if err := sf.gr.verifyOneChunk(sf.id, ip, chunkDigestStr); err != nil {
+			sf.gr.putBuffer(b)
+			return err
+		}
+		combinedBuffer.Write(ip)
+		totalSize += chunkSize
+		offset = chunkOffset + chunkSize
+		sf.gr.putBuffer(b)
+	}
+	combinedIp := combinedBuffer.Bytes()
+	id := genID(sf.id, firstChunkOffset, totalSize)
+	sf.gr.cacheData(combinedIp, id)
+	return nil
+}
+
+func (gr *reader) verifyOneChunk(entryID uint32, ip []byte, chunkDigestStr string) error {
+	// We can end up doing on demand registry fetch when aligning the chunk
+	commonmetrics.IncOperationCount(commonmetrics.OnDemandRemoteRegistryFetchCount, gr.layerSha)
+	commonmetrics.AddBytesCount(commonmetrics.OnDemandBytesFetched, gr.layerSha, int64(len(ip)))
+	gr.setLastReadTime(time.Now())
 	if err := gr.verifyChunk(entryID, ip, chunkDigestStr); err != nil {
 		return fmt.Errorf("invalid chunk: %w", err)
 	}
+	return nil
+}
 
-	// Cache this chunk
+func (gr *reader) cacheData(ip []byte, cacheID string) {
 	if w, err := gr.cache.Add(cacheID); err == nil {
 		if cn, err := w.Write(ip); err != nil || cn != len(ip) {
 			w.Abort()
@@ -510,7 +597,13 @@ func (gr *reader) verifyAndCache(entryID uint32, ip []byte, chunkDigestStr strin
 		}
 		w.Close()
 	}
+}
 
+func (gr *reader) verifyAndCache(entryID uint32, ip []byte, chunkDigestStr string, cacheID string) error {
+	if err := gr.verifyOneChunk(entryID, ip, chunkDigestStr); err != nil {
+		return err
+	}
+	gr.cacheData(ip, cacheID)
 	return nil
 }
 


### PR DESCRIPTION
Here’s a proposed implementation plan for FUSE passthrough:

1. During the Open phase, attempt to pre-read the entire file instead of reading it in chunks.
2. Utilize the existing cache's Get method to retrieve the fd of the cached file that has been written to local storage.
3. Implement the FilePassthroughFder interface in node.file, allowing the fd from step 2 to be registered with the kernel via go-fuse.

By following this approach, subsequent Read operations would not need to return to user space, and go-fuse would release the registered information when necessary.

for details,
https://github.com/containerd/stargz-snapshotter/issues/1867