### PR TITLE
snapshots: add metadata.db for serve cleanup

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -425,6 +425,15 @@ func (o *snapshotter) cleanup(ctx context.Context, cleanupCommitted bool) error 
 	return nil
 }
 
+func (o *snapshotter) cleanupMetadataDB() error {
+	metadataDBPath := filepath.Join(o.root, "metadata.db")
+	err := os.Remove(metadataDBPath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (o *snapshotter) cleanupDirectories(ctx context.Context, cleanupCommitted bool) ([]string, error) {
 	// Get a write transaction to ensure no other write transaction can be entered
 	// while the cleanup is scanning.
@@ -658,6 +667,11 @@ func (o *snapshotter) Close() error {
 	if err := o.cleanup(ctx, cleanupCommitted); err != nil {
 		log.G(ctx).WithError(err).Warn("failed to cleanup")
 	}
+
+	if err := o.cleanupMetadataDB(); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to cleanup metadata.db")
+	}
+
 	return o.ms.Close()
 }
 


### PR DESCRIPTION
This pr fix err report like this：
```
$ containerd-stargz-grpc
# do something
# kill containerd-stargz-grpc
# re-open containerd-stargz-grpc
$ containerd-stargz-grpc
{"level":"info","msg":"preparing filesystem mount at mountpoint=/var/lib/containerd-stargz-grpc/snapshotter/snapshots/6/fs","time":"2024-12-03T06:42:13.989308992Z"}
{"level":"info","mountpoint":"/var/lib/containerd-stargz-grpc/snapshotter/snapshots/6/fs","msg":"Received status code: 401 Unauthorized. Refreshing creds...","src":"docker.io/abushwang/ocs9:read-esgz-lit/sha256:afac68f614f687aed660fdc2dffd9825d7024936940879386365b52a99f6d794","time":"2024-12-03T06:42:14.675377841Z"}
{"layer_sha":"sha256:afac68f614f687aed660fdc2dffd9825d7024936940879386365b52a99f6d794","level":"info","metrics":"latency","msg":"value=0.035318 milliseconds; prefetch_size=0 bytes","operation":"prefetch_total","time":"2024-12-03T06:42:16.872140920Z"}
{"level":"info","mountpoint":"/var/lib/containerd-stargz-grpc/snapshotter/snapshots/6/fs","msg":"fusermount detected","time":"2024-12-03T06:42:16.872196198Z"}
/usr/bin/fusermount: bad mount point /var/lib/containerd-stargz-grpc/snapshotter/snapshots/6/fs: No such file or directory
{"error":"failed to restore remote snapshot: failed to prepare remote snapshot: sha256:559caaaf071fc6fc34f4eeadc390a3baec7f1107ce323d9c9e52d6347d3950cf: fusermount exited with code 256\n","level":"fatal","msg":"failed to create new snapshotter","time":"2024-12-03T06:42:16.875240744Z"}
```

The old mountpoint has been cleanup but containerd-stargz-grpc still try to read path from old metadata.db, which should be cleaned at last cleanup