### PR TITLE
[Carry #1847] Fix zstd:chunked converter error on duplicated blobs

### DIFF
--- a/nativeconverter/zstdchunked/zstdchunked.go
+++ b/nativeconverter/zstdchunked/zstdchunked.go
@@ -141,7 +141,7 @@ func LayerConvertFuncWithCompressionLevel(compressionLevel zstd.EncoderLevel, op
 		}
 		defer blob.Close()
 		ref := fmt.Sprintf("convert-zstdchunked-from-%s", desc.Digest)
-		w, err := cs.Writer(ctx, content.WithRef(ref))
+		w, err := content.OpenWriter(ctx, cs, content.WithRef(ref))
 		if err != nil {
 			return nil, err
 		}

--- a/nativeconverter/zstdchunked/zstdchunked.go
+++ b/nativeconverter/zstdchunked/zstdchunked.go
@@ -109,11 +109,6 @@ func LayerConvertFuncWithCompressionLevel(compressionLevel zstd.EncoderLevel, op
 			if uncompressedDesc == nil {
 				return nil, fmt.Errorf("unexpectedly got the same blob after compression (%s, %q)", desc.Digest, desc.MediaType)
 			}
-			defer func() {
-				if err := cs.Delete(ctx, uncompressedDesc.Digest); err != nil {
-					log.G(ctx).WithError(err).WithField("uncompressedDesc", uncompressedDesc).Warn("failed to remove tmp uncompressed layer")
-				}
-			}()
 			log.G(ctx).Debugf("zstdchunked: uncompressed %s into %s", desc.Digest, uncompressedDesc.Digest)
 		}
 


### PR DESCRIPTION
Carry #1847

This PR fixes the following warning by zstd:chunked converter. This PR fixes that issue by not cleaning up of temporary resources by our own but we rely on containerd's GC instead.

```
WARN[0038] failed to remove tmp uncompressed layer       error="content digest sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef: not found" uncompressedDesc="&{application/vnd.oci.image.layer.v1.tar sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef 1024 [] map[] [] <nil> }"
```

reporoducer:

```
# ctr-remote i pull docker.io/library/tomcat:10.1-jdk21-temurin-noble
# ctr-remote image optimize --oci --period=30 --zstdchunked docker.io/library/tomcat:10.1-jdk21-temurin-noble test
````