### PR TITLE
Fix GC failure of CRI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ version = 2
   disable_snapshot_annotations = false
 ```
 
-**Note that `disable_snapshot_annotations = false` is required since containerd > v1.4.2**
-
 You can try our [prebuilt](/Dockerfile) [KinD](https://github.com/kubernetes-sigs/kind) node image that contains the above configuration.
 
 ```console

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ version = 2
   [proxy_plugins.stargz]
     type = "snapshot"
     address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+  [proxy_plugins.stargz.exports]
+    root = "/var/lib/containerd-stargz-grpc/"
 
 # Use stargz snapshotter through CRI
 [plugins."io.containerd.grpc.v1.cri".containerd]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -44,6 +44,8 @@ We assume that you are using containerd (> v1.4.2) as a CRI runtime.
     [proxy_plugins.stargz]
       type = "snapshot"
       address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+    [proxy_plugins.stargz.exports]
+      root = "/var/lib/containerd-stargz-grpc/"
 
   ```
 
@@ -145,6 +147,8 @@ We assume that you are using CRI-O newer than https://github.com/cri-o/cri-o/pul
     [proxy_plugins.stargz]
       type = "snapshot"
       address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+    [proxy_plugins.stargz.exports]
+      root = "/var/lib/containerd-stargz-grpc/"
   ```
 
 - Install fuse

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -44,12 +44,16 @@ version = 2
   [proxy_plugins.stargz]
     type = "snapshot"
     address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+  [proxy_plugins.stargz.exports]
+    root = "/var/lib/containerd-stargz-grpc/"
 
 # Use stargz snapshotter through CRI
 [plugins."io.containerd.grpc.v1.cri".containerd]
   snapshotter = "stargz"
   disable_snapshot_annotations = false
 ```
+
+> NOTE: `root` field of `proxy_plugins` is needed for the CRI plugin to recognize stargz snapshotter's root directory.
 
 This repo contains [a Dockerfile as a KinD node image](/Dockerfile) which includes the above configuration.
 

--- a/script/benchmark/config-containerd/etc/containerd/config.toml
+++ b/script/benchmark/config-containerd/etc/containerd/config.toml
@@ -4,3 +4,5 @@ version = 2
   [proxy_plugins.stargz]
     type = "snapshot"
     address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+  [proxy_plugins.stargz.exports]
+    root = "/var/lib/containerd-stargz-grpc/"

--- a/script/config/etc/containerd/config.toml
+++ b/script/config/etc/containerd/config.toml
@@ -22,3 +22,5 @@ version = 2
   [proxy_plugins.stargz]
     type = "snapshot"
     address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+  [proxy_plugins.stargz.exports]
+    root = "/var/lib/containerd-stargz-grpc/"

--- a/script/demo/config.containerd.toml
+++ b/script/demo/config.containerd.toml
@@ -4,3 +4,5 @@ version = 2
   [proxy_plugins.stargz]
     type = "snapshot"
     address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+  [proxy_plugins.stargz.exports]
+    root = "/var/lib/containerd-stargz-grpc/"

--- a/script/integration/containerd/entrypoint.sh
+++ b/script/integration/containerd/entrypoint.sh
@@ -250,6 +250,7 @@ if [ "${BUILTIN_SNAPSHOTTER}" != "true" ] ; then
     type = "snapshot"
     address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"
   [proxy_plugins.stargz.exports]
+    root = "/var/lib/containerd-stargz-grpc/"
     enable_remote_snapshot_annotations = "true"
 EOF
 fi


### PR DESCRIPTION
Fix #1349

CRI plugins fails to perform GC because it fails to find root direcotry of stargz snapshotter. 
Recent containerd added `proxy_plugins.stargz.exports.root` field to config.toml for solving this issue so this PR leverages that feature.

```
Dec 09 01:25:33 testkind-control-plane kubelet[2645]: E1209 01:25:33.155930    2645 kubelet.go:1467] "Image garbage collection failed once. Stats initialization may not have completed yet" err="get filesystem info: Failed to get the info of the filesystem with mountpoint: failed to get device for dir \"/var/lib/containerd/io.containerd.snapshotter.v1.stargz\": stat failed on /var/lib/containerd/io.containerd.snapshotter.v1.stargz with error: no such file or directory"
```