### PR TITLE
[v0.16] Prepare for v0.16.3

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.0
 	github.com/containerd/stargz-snapshotter v0.15.2-0.20240622031358-6405f362966d
-	github.com/containerd/stargz-snapshotter/estargz v0.16.2
+	github.com/containerd/stargz-snapshotter/estargz v0.16.3
 	github.com/containerd/stargz-snapshotter/ipfs v0.15.2-0.20240622031358-6405f362966d
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/go-metrics v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.0
 	github.com/containerd/plugin v1.0.0
-	github.com/containerd/stargz-snapshotter/estargz v0.16.2
+	github.com/containerd/stargz-snapshotter/estargz v0.16.3
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v27.3.1+incompatible
 	github.com/docker/go-metrics v0.0.1


### PR DESCRIPTION
```
## Notable Changes

- Fix zstd:chunked converter error on duplicated blobs (#1894)
```