### PR TITLE
fusemanager: fix container fail after ttl timeout in detach mode

### DIFF
--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -181,7 +181,7 @@ func main() {
 		if err != nil {
 			log.G(ctx).WithError(err).Fatalf("failed to configure fusemanager")
 		}
-		rs, err = snbase.NewSnapshotter(ctx, filepath.Join(*rootDir, "snapshotter"), fs, snbase.AsynchronousRemove)
+		rs, err = snbase.NewSnapshotter(ctx, filepath.Join(*rootDir, "snapshotter"), fs, snbase.AsynchronousRemove, snbase.SetDetachFlag)
 		if err != nil {
 			log.G(ctx).WithError(err).Fatalf("failed to configure snapshotter")
 		}
@@ -213,10 +213,6 @@ func main() {
 		log.G(ctx).WithError(err).Fatalf("failed to serve snapshotter")
 	}
 
-	// TODO: In detach mode, rs is taken over by fusemanager,
-	// but client will send unmount request to fusemanager,
-	// and fusemanager need get mount info from local db to
-	//  determine its behavior
 	if cleanup {
 		log.G(ctx).Debug("Closing the snapshotter")
 		rs.Close()

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -118,6 +118,18 @@ When upgrading the fuse manager, it's recommended to follow these steps:
 
 This ensures a clean upgrade without impacting running containers.
 
+### Important Considerations
+
+Before restarting the `containerd-stargz-grpc` process, it is essential to consider the state of any running containers.
+
+1. **When to Use SIGKILL** :
+
+If there are running containers, it is crucial to terminate the `containerd-stargz-grpc` process using `SIGKILL`. This approach prevents the normal shutdown sequence from attempting to clean up the mount points of the running containers, which could disrupt their availability. By using `SIGKILL`, you ensure that the process is forcefully terminated without affecting the ongoing operations of the containers.
+
+2. **When to Use SIGTERM** :
+
+If there are no running containers, you should use `SIGTERM` to terminate the `containerd-stargz-grpc` process. This allows the process to follow its normal shutdown sequence, ensuring that it properly cleans up resources and mount points.
+
 ## Registry-related configuration
 
 You can configure stargz snapshotter for accessing registries with custom configurations.


### PR DESCRIPTION
In detach mode, when `containerd-stargz-grpc` exits normally, it sends an Unmount request to the fuse manager. Additionally, during the startup of `containerd-stargz-grpc`, the `restoreRemoteSnapshot` function cleans up previous mountpoints. If there are still running containers at this time, it can lead to issues when the TTL cache expires, resulting in abnormal behavior of the containers.

I considered several solutions:

1. The approach in the current PR, where users should restart `containerd-stargz-grpc` using `SIGKILL`, and then skip the cleanup step in `restoreRemoteSnapshot`.
2. Setting `ResolveResultEntryTTLSec` to an infinitely large value to leverage the TTL cache for ensuring the normal operation of containers. However, this would still lead to failures if the containers attempt to access uncached content.
3. Implementing a complex mechanism to determine if any running containers are using the mountpoints, and if so, skipping the cleanup.

After careful consideration, I have decided to proceed with the first approach.