### PR TITLE
CI: Re-enable builtin tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,8 +17,7 @@ on:
 
 env:
   DOCKER_BUILDKIT: 1
-  # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
-  # DOCKER_BUILD_ARGS: --build-arg=CONTAINERD_VERSION=main # do tests with the latest containerd
+  DOCKER_BUILD_ARGS: --build-arg=CONTAINERD_VERSION=main # do tests with the latest containerd
 
 jobs:
   integration:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,18 +52,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Temporary disable containerd main branch test and migrate to containerd v2 after it's released.
-        # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
         buildargs: [""]
         builtin: ["true", "false"]
         metadata-store: ["memory", "db"]
         exclude:
-        # - buildargs: ""
-        #   builtin: "true"
+        - buildargs: ""
+          builtin: "true"
         - metadata-store: "db"
           builtin: "true"
-        # - metadata-store: "db"
-        #   buildargs: "--build-arg=CONTAINERD_VERSION=main"
+        - metadata-store: "db"
+          buildargs: "--build-arg=CONTAINERD_VERSION=main"
     steps:
     - name: Install htpasswd for setting up private registry
       run: sudo apt-get update -y && sudo apt-get --no-install-recommends install -y apache2-utils
@@ -81,8 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
-        # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
         buildargs: [""]
     steps:
     - name: Install htpasswd for setting up private registry
@@ -99,13 +97,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
-        # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
         buildargs: [""]
         builtin: ["true", "false"]
-        # exclude:
-        # - buildargs: ""
-        #   builtin: "true"
+        exclude:
+        - buildargs: ""
+          builtin: "true"
     steps:
     - name: Install htpasswd for setting up private registry
       run: sudo apt-get update -y && sudo apt-get --no-install-recommends install -y apache2-utils
@@ -122,13 +119,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
-        # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
         buildargs: [""]
         builtin: ["true", "false"]
-        # exclude:
-        # - buildargs: ""
-        #   builtin: "true"
+        exclude:
+        - buildargs: ""
+          builtin: "true"
     steps:
     - name: Install htpasswd for setting up private registry
       run: sudo apt-get update -y && sudo apt-get --no-install-recommends install -y apache2-utils
@@ -145,18 +141,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Temporary disable contaienrd main branch test and migrate to containerd v2 after it's released.
-        # buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
+        buildargs: ["", "--build-arg=CONTAINERD_VERSION=main"] # released version & main version
         buildargs: [""]
         builtin: ["true", "false"]
         metadata-store: ["memory", "db"]
         exclude:
-        # - buildargs: ""
-        #   builtin: "true"
+        - buildargs: ""
+          builtin: "true"
         - metadata-store: "db"
           builtin: "true"
-        # - metadata-store: "db"
-        #   buildargs: "--build-arg=CONTAINERD_VERSION=main"
+        - metadata-store: "db"
+          buildargs: "--build-arg=CONTAINERD_VERSION=main"
     steps:
     - uses: actions/checkout@v4
     - name: Validate containerd through CRI

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,16 +66,6 @@ RUN apt-get update -y && apt-get install -y libbtrfs-dev libseccomp-dev && \
       echo 'replace github.com/containerd/stargz-snapshotter => '$GOPATH'/src/github.com/containerd/stargz-snapshotter' >> integration/client/go.mod && \
       echo 'replace github.com/containerd/stargz-snapshotter/estargz => '$GOPATH'/src/github.com/containerd/stargz-snapshotter/estargz' >> integration/client/go.mod ; \
     fi && \
-    if [ "$(echo -n ${CONTAINERD_VERSION} | head -c 4)" = "v1.7" ] ; then \
-      # containerd v1.7 doesn't support cri-api >= v0.28 which adds RuntimeConfig API
-      echo 'replace k8s.io/cri-api => k8s.io/cri-api v0.27.1' >> go.mod ; \
-      if [ -f api/go.mod ] ; then \
-        echo 'replace k8s.io/cri-api => k8s.io/cri-api v0.27.1' >> api/go.mod ; \
-      fi ; \
-      if [ -f integration/client/go.mod ] ; then \
-        echo 'replace k8s.io/cri-api => k8s.io/cri-api v0.27.1' >> integration/client/go.mod ; \
-      fi ; \
-    fi && \
     echo 'package main \nimport _ "github.com/containerd/stargz-snapshotter/service/plugin"' > cmd/containerd/builtins_stargz_snapshotter.go && \
     make vendor && make && DESTDIR=/out/ PREFIX= make install
 

--- a/script/optimize/optimize/entrypoint.sh
+++ b/script/optimize/optimize/entrypoint.sh
@@ -204,9 +204,7 @@ echo "Checking optimized image..."
 WORKING_DIR=$(mktemp -d)
 git config --global --add safe.directory '/go/src/github.com/containerd/stargz-snapshotter'
 PREFIX=/tmp/out/ make clean
-# temporary disable -race flag to run test with statically built binaries
-# PREFIX=/tmp/out/ GO_BUILD_FLAGS="-race" make ctr-remote # Check data race
-PREFIX=/tmp/out/ make ctr-remote
+PREFIX=/tmp/out/ GO_BUILD_FLAGS="-race" make ctr-remote # Check data race
 /tmp/out/ctr-remote ${OPTIMIZE_COMMAND} -entrypoint='[ "/accessor" ]' "${ORG_IMAGE_TAG}" "${OPT_IMAGE_TAG}"
 nerdctl push "${OPT_IMAGE_TAG}" || true
 cat <<EOF > "${WORKING_DIR}/0-want"


### PR DESCRIPTION
We're now using containerd v2 so tests disabled in #1448 can be reenabled.