### PR TITLE
Update gomod dependabot to use directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,30 +3,32 @@ updates:
 
   # Automatic upgrade for go modules.
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "/estargz"
+      - "/ipfs"
+      - "/"
+      - "/cmd"
     schedule:
       interval: "daily"
     ignore:
       # We upgrade this manually on each release
       - dependency-name: "github.com/containerd/stargz-snapshotter/estargz"
-
-  # Automatic upgrade for go modules of estargz package.
-  - package-ecosystem: "gomod"
-    directory: "/estargz"
-    schedule:
-      interval: "daily"
-
-  # Automatic upgrade for go modules of ipfs package.
-  - package-ecosystem: "gomod"
-    directory: "/ipfs"
-    schedule:
-      interval: "daily"
-
-  # Automatic upgrade for go modules of cmd package.
-  - package-ecosystem: "gomod"
-    directory: "/cmd"
-    schedule:
-      interval: "daily"
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      google-golang:
+        patterns:
+          - "google.golang.org/*"
+      containerd:
+        patterns:
+          - "github.com/containerd/*"
+      opencontainers:
+        patterns:
+          - "github.com/opencontainers/*"
+      k8s:
+        patterns:
+          - "k8s.io/*"
 
   # Automatic upgrade for base images used in the Dockerfile
   - package-ecosystem: "docker"


### PR DESCRIPTION
1. Move repeated `gomod` sections to a single one by using [`directories`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--) instead of `directory`.
2. Add a few `groups`: update deps matching the `groups` pattern in a single PR.
  a. One benefit of this is dependabot will update the deps in all `go.mod`s, thus the CI can pass (otherwise it may fail due to requiring `go mod tidy`.
  b. I think a should be true regardless if `groups` is used or not. But from my experience, it seems dependabot only do this for `groups`ed deps, and still open different PRs for different modules if a dep is not part of a group.