### PR TITLE
replace harshicorp/multierror with errors.Join

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.10.4
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/klauspost/compress v1.17.11
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
@@ -72,7 +71,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hanwen/go-fuse/v2 v2.7.2 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/hanwen/go-fuse/v2 v2.7.2
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/klauspost/compress v1.17.11
 	github.com/moby/sys/mountinfo v0.7.2

--- a/metadata/testutil/testutil.go
+++ b/metadata/testutil/testutil.go
@@ -18,6 +18,7 @@ package testutil
 
 import (
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -31,7 +32,6 @@ import (
 	"github.com/containerd/stargz-snapshotter/estargz"
 	"github.com/containerd/stargz-snapshotter/metadata"
 	tutil "github.com/containerd/stargz-snapshotter/util/testutil"
-	"github.com/hashicorp/go-multierror"
 	"github.com/klauspost/compress/zstd"
 	digest "github.com/opencontainers/go-digest"
 )
@@ -412,17 +412,17 @@ func newCalledTelemetry() (telemetry *metadata.Telemetry, check func() error) {
 			GetTocLatency:         func(time.Time) { getTocLatencyCalled = true },
 			DeserializeTocLatency: func(time.Time) { deserializeTocLatencyCalled = true },
 		}, func() error {
-			var allErr error
+			var errs []error
 			if !getFooterLatencyCalled {
-				allErr = multierror.Append(allErr, fmt.Errorf("metrics GetFooterLatency isn't called"))
+				errs = append(errs, fmt.Errorf("metrics GetFooterLatency isn't called"))
 			}
 			if !getTocLatencyCalled {
-				allErr = multierror.Append(allErr, fmt.Errorf("metrics GetTocLatency isn't called"))
+				errs = append(errs, fmt.Errorf("metrics GetTocLatency isn't called"))
 			}
 			if !deserializeTocLatencyCalled {
-				allErr = multierror.Append(allErr, fmt.Errorf("metrics DeserializeTocLatency isn't called"))
+				errs = append(errs, fmt.Errorf("metrics DeserializeTocLatency isn't called"))
 			}
-			return allErr
+			return errors.Join(errs...)
 		}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -33,7 +34,6 @@ import (
 	"github.com/containerd/stargz-snapshotter/service/resolver"
 	"github.com/containerd/stargz-snapshotter/snapshot"
 	snbase "github.com/containerd/stargz-snapshotter/snapshot"
-	"github.com/hashicorp/go-multierror"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -136,14 +136,15 @@ func fsRoot(root string) string {
 
 func sources(ps ...source.GetSources) source.GetSources {
 	return func(labels map[string]string) (source []source.Source, allErr error) {
+		var errs []error
 		for _, p := range ps {
 			src, err := p(labels)
 			if err == nil {
 				return src, nil
 			}
-			allErr = multierror.Append(allErr, err)
+			errs = append(errs, err)
 		}
-		return
+		return nil, errors.Join(errs...)
 	}
 }
 


### PR DESCRIPTION
As titled. The replacement is done by:

1. a `multierror` error (`allErr`) -> `var errs []error`
2. `multierror.Append(allErr, err)` -> `errs = append(errs, err)`
3. `return allErr` -> `return errors.Join(errs)`

And if `errs` is empty slice or if every `error` in `errs` are nil, `return errors.Join(errs)` will also return a nil error.