### PR TITLE
CI: golangci-lint v1.63.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6.1.1
       with:
-        version: v1.61.0
+        version: v1.63.4
         args: --verbose --timeout=10m
         working-directory: ${{ matrix.targetdir }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,9 @@ issues:
     - linters:
         - revive
       text: "unused-parameter"
+    - linters:
+        - revive
+      text: "redefines-builtin-id"
   exclude-dirs:
     - docs
     - images


### PR DESCRIPTION
- Release note: https://github.com/golangci/golangci-lint/releases/tag/v1.63.4

This PR also disables `redefines-builtin-id` which is already disabled in containerd/containerd.