### PR TITLE
Create a dependabot group for all go deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,17 @@ updates:
       k8s:
         patterns:
           - "k8s.io/*"
+      gomod:
+        # this pattern covers all go dependencies that are not in
+        # the above groups. dependabot doesn't seem to update sub-modules if
+        # a dependency doesn't belong to a group, so we define this group
+        # explicitly.
+        exclude-patterns:
+          - "golang.org/x/*"
+          - "google.golang.org/*"
+          - "github.com/containerd/*"
+          - "github.com/opencontainers/*"
+          - "k8s.io/*"
 
   # Automatic upgrade for base images used in the Dockerfile
   - package-ecosystem: "docker"


### PR DESCRIPTION
Dependabot seems to only update a dep in all go modoules, if it belongs to a group.

This new group will cover all deps that are not part of an existing group, so they get updated in all go.mod.

I think this will help avoid issues like https://github.com/containerd/stargz-snapshotter/pull/1939, and make dependabot work in most cases.