### PR TITLE
*/go.mod: use go1.22.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/stargz-snapshotter/cmd
 
-go 1.22.7
+go 1.22.0
 
 require (
 	github.com/containerd/containerd/api v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/stargz-snapshotter
 
-go 1.22.7
+go 1.22.0
 
 require (
 	github.com/containerd/console v1.0.4

--- a/ipfs/go.mod
+++ b/ipfs/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/stargz-snapshotter/ipfs
 
-go 1.22.7
+go 1.22.0
 
 require (
 	github.com/containerd/containerd/v2 v2.0.2


### PR DESCRIPTION
Noticed that 985b021b414ae5b26a8709a45d711ac61da324c0 caused buildkit to have to update its go.mod to go1.22.7, and we're trying to keep it stable at 1.22.0 as minimum.