### PR TITLE
concurrent file merging in passthrough mode to reduce initial pull time

### DIFF
--- a/docs/passthrough.md
+++ b/docs/passthrough.md
@@ -18,6 +18,8 @@ When a user-defined file implements the `FilePassthroughFder` interface, `go-fus
 
 # Configuration
 
+## Basic Configuration
+
 To enable FUSE passthrough mode, first verify that your host's kernel supports this feature. You can check this by running the following command:
 
 ```bash
@@ -37,6 +39,14 @@ After updating the configuration, specify the `config.toml` file when starting `
 ```bash
 $ containerd-stargz-grpc -config config.toml
 ```
+
+## Advanced Configuration
+
+In passthrough mode, the initial pull of an image requires merging chunks into a file. This process can be time-consuming, especially for large files.
+
+To optimize the time taken for the initial image pull, you can use the `merge_buffer_size` and `merge_worker_count` configuration options. The `merge_buffer_size` specifies the size of the buffer used for reading the image, with a default value of 400MB. The `merge_worker_count` determines the level of concurrency for reading the image, with a default value of 10.
+
+By concurrently reading chunks and caching them for batch writing, you can significantly enhance the performance of the initial image pull in passthrough mode.
 
 # Important Considerations
 

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -151,4 +151,10 @@ type FuseConfig struct {
 
 	// PassThrough indicates whether to enable FUSE passthrough mode to improve local file read performance. Default is false.
 	PassThrough bool `toml:"passthrough" default:"false"`
+
+	// MergeBufferSize is the size of the buffer to merge chunks (in bytes) for passthrough mode. Default is 400MB.
+	MergeBufferSize int64 `toml:"merge_buffer_size" default:"419430400"`
+
+	// MergeWorkerCount is the number of workers to merge chunks for passthrough mode. Default is 10.
+	MergeWorkerCount int `toml:"merge_worker_count" default:"10"`
 }

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -219,7 +219,9 @@ func testPrefetch(t *testing.T, factory metadata.Store) {
 					ocispec.Descriptor{Digest: testStateLayerDigest},
 					&blobRef{blob, func() {}},
 					vr,
-					false,
+					passThroughConfig{
+						enable: false,
+					},
 				)
 				if err := l.Verify(dgst); err != nil {
 					t.Errorf("failed to verify reader: %v", err)
@@ -752,7 +754,11 @@ func getRootNode(t *testing.T, r metadata.Reader, opaque OverlayOpaqueType, tocD
 	if err != nil {
 		t.Fatalf("failed to verify reader: %v", err)
 	}
-	rootNode, err := newNode(testStateLayerDigest, rr, &testBlobState{10, 5}, 100, opaque, pth)
+	rootNode, err := newNode(testStateLayerDigest, rr, &testBlobState{10, 5}, 100, opaque, passThroughConfig{
+		enable:           pth,
+		mergeBufferSize:  419430400,
+		mergeWorkerCount: 10,
+	})
 	if err != nil {
 		t.Fatalf("failed to get root node: %v", err)
 	}


### PR DESCRIPTION
In passthrough mode, the initial pull of an image requires merging chunks into a file. This process can be time-consuming, especially for large files.

This pr optimizes the merging process by introducing two configuration options: `merge_buffer_size` and `merge_worker_count`. By concurrently reading chunks and caching them for batch writing, we enhance the performance of the initial image pull in passthrough mode.

The principle of concurrent reading is illustrated in the diagram below. 
The `merge_worker_count` corresponds to the number of workers in the diagram, while `merge_buffer_size` corresponds to the size of the buffer in the diagram. Before concurrent reading begins, the buffer area is divided, and each worker is assigned a specific region. This approach allows all workers to concurrently read the contents of the chunks into the buffer.
![image](https://github.com/user-attachments/assets/2b837895-b4d0-4c59-bc10-6515fd110023)
