### PR TITLE
Fix an error in .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ linters-settings:
             desc: The containerd log package was migrated to a separate module. Use github.com/containerd/log instead.
 
 run:
-  deadline: 4m
+  timeout: 4m
 
 issues:
   exclude-rules:


### PR DESCRIPTION
This PR fixes an error in .golangci.yml checked by golangci-lint config verify.

```
jsonschema: "run" does not validate with "/properties/run/additionalProperties": additional properties 'deadline' not allowed
Failed executing command with error: the configuration contains invalid elements
```