### PR TITLE
fix required kunalkushwaha error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -273,7 +273,7 @@ jobs:
         with:
           path: src/github.com/containerd/stargz-snapshotter
           fetch-depth: 25
-      - uses: containerd/project-checks@v1.1.0
+      - uses: containerd/project-checks@v1.2.1
         with:
           working-directory: src/github.com/containerd/stargz-snapshotter
       - name: Check proto generated code


### PR DESCRIPTION
update project-checks to v1.2.0 to fix this error in CI

```
  github.com/hashicorp/go-version
  github.com/sirupsen/logrus
  github.com/vbatts/git-validation/git
  github.com/vbatts/git-validation/validate
  github.com/vbatts/git-validation/rules/danglingwhitespace
  github.com/vbatts/git-validation/rules/dco
  github.com/vbatts/git-validation/rules/shortsubject
  github.com/vbatts/git-validation/rules/messageregexp
  github.com/vbatts/git-validation
  go: downloading github.com/kunalkushwaha/ltag v0.3.0
  go: github.com/kunalkushwaha/ltag@latest: version constraints conflict:
  	github.com/kunalkushwaha/ltag@v0.3.0: parsing go.mod:
  	module declares its path as: github.com/containerd/ltag
  	        but was required as: github.com/kunalkushwaha/ltag
  Error: Process completed with exit code 1.
```