### PR TITLE
fix required kunalkushwaha error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -273,9 +273,29 @@ jobs:
         with:
           path: src/github.com/containerd/stargz-snapshotter
           fetch-depth: 25
-      - uses: containerd/project-checks@v1.1.0
+      - uses: containerd/project-checks@v1.2.2
         with:
           working-directory: src/github.com/containerd/stargz-snapshotter
+          # go-licenses-ignore is set because go-licenses cannot correctly detect the license of the following packages:
+          # * estargz packages: Apache-2.0 and BSD-3-Clause dual license
+          #   (https://github.com/containerd/stargz-snapshotter/blob/main/NOTICE.md)
+          #
+          # The list of the CNCF-approved licenses can be found here:
+          # https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md
+          #
+          # hashicorp packages: MPL-2.0
+          # (https://github.com/hashicorp/go-cleanhttp/blob/master/LICENSE,
+          #  https://github.com/hashicorp/go-retryablehttp/blob/master/LICENSE)
+          # Note: MPL-2.0 is not in the CNCF-approved licenses list, but these packages are allowed as exceptions.
+          # See CNCF licensing exceptions:
+          # https://github.com/cncf/foundation/blob/main/license-exceptions/CNCF-licensing-exceptions.csv
+          go-licenses-ignore: |
+            github.com/containerd/stargz-snapshotter/estargz
+            github.com/containerd/stargz-snapshotter/estargz/errorutil
+            github.com/containerd/stargz-snapshotter/estargz/externaltoc
+            github.com/containerd/stargz-snapshotter/estargz/zstdchunked
+            github.com/hashicorp/go-cleanhttp
+            github.com/hashicorp/go-retryablehttp
       - name: Check proto generated code
         run: make validate-generated
         working-directory: src/github.com/containerd/stargz-snapshotter


### PR DESCRIPTION
update project-checks to v1.2.2 to fix this error in CI, It seems to be the same issue as https://github.com/containerd/nerdctl/pull/3976,
cc @AkihiroSuda 

- before updating to v1.2.2
```
  github.com/hashicorp/go-version
  github.com/sirupsen/logrus
  github.com/vbatts/git-validation/git
  github.com/vbatts/git-validation/validate
  github.com/vbatts/git-validation/rules/danglingwhitespace
  github.com/vbatts/git-validation/rules/dco
  github.com/vbatts/git-validation/rules/shortsubject
  github.com/vbatts/git-validation/rules/messageregexp
  github.com/vbatts/git-validation
  go: downloading github.com/kunalkushwaha/ltag v0.3.0
  go: github.com/kunalkushwaha/ltag@latest: version constraints conflict:
  	github.com/kunalkushwaha/ltag@v0.3.0: parsing go.mod:
  	module declares its path as: github.com/containerd/ltag
  	        but was required as: github.com/kunalkushwaha/ltag
  Error: Process completed with exit code 1.
```

- after updating to v1.2.2 and not go-licenses-ignore
```
Not allowed license  found for library github.com/containerd/stargz-snapshotter/estargz
Not allowed license  found for library github.com/containerd/stargz-snapshotter/estargz/errorutil
Not allowed license  found for library github.com/containerd/stargz-snapshotter/estargz/externaltoc
Not allowed license  found for library github.com/containerd/stargz-snapshotter/estargz/zstdchunked
Not allowed license MPL-2.0 found for library github.com/hashicorp/go-cleanhttp
Not allowed license MPL-2.0 found for library github.com/hashicorp/go-retryablehttp
```