### PR TITLE
fs/reader: use chunk digest as cache ID instead of genID

### DIFF
--- a/cmd/containerd-stargz-grpc/db/db.go
+++ b/cmd/containerd-stargz-grpc/db/db.go
@@ -97,7 +97,8 @@ type chunkEntry struct {
 	chunkOffset int64
 	chunkSize   int64
 	chunkDigest string
-	innerOffset int64 // -1 indicates that no following chunks in the stream.
+	fileDigest  string // the whole file digest
+	innerOffset int64  // -1 indicates that no following chunks in the stream.
 }
 
 type metadataEntry struct {

--- a/cmd/containerd-stargz-grpc/db/reader.go
+++ b/cmd/containerd-stargz-grpc/db/reader.go
@@ -359,6 +359,7 @@ func (r *reader) initNodes(tr io.Reader) error {
 		var lastEntSize int64
 		var attr metadata.Attr
 		var ent estargz.TOCEntry
+		var fileDigest string
 		for dec.More() {
 			resetEnt(&ent)
 			if err := dec.Decode(&ent); err != nil {
@@ -449,14 +450,19 @@ func (r *reader) initNodes(tr io.Reader) error {
 					wantNextOffsetID = append(wantNextOffsetID, id)
 				}
 
+				if ent.Type == "reg" {
+					fileDigest = ent.Digest
+				}
+
 				lastEntSize = ent.Size
 				lastEntBucketID = id
 			}
+
 			if (ent.Type == "reg" && ent.Size > 0) || (ent.Type == "chunk" && ent.ChunkSize > 0) {
 				if md[lastEntBucketID] == nil {
 					md[lastEntBucketID] = &metadataEntry{}
 				}
-				ce := chunkEntry{ent.Offset, ent.ChunkOffset, ent.ChunkSize, ent.ChunkDigest, ent.InnerOffset}
+				ce := chunkEntry{ent.Offset, ent.ChunkOffset, ent.ChunkSize, ent.ChunkDigest, fileDigest, ent.InnerOffset}
 				md[lastEntBucketID].chunks = append(md[lastEntBucketID].chunks, ce)
 				if _, ok := st[ent.Offset]; !ok {
 					st[ent.Offset] = make(map[int64]uint32)
@@ -880,16 +886,16 @@ type file struct {
 	ents []chunkEntry
 }
 
-func (fr *file) ChunkEntryForOffset(offset int64) (off int64, size int64, dgst string, ok bool) {
+func (fr *file) ChunkEntryForOffset(offset int64) (off int64, size int64, dgst, fileDigest string, ok bool) {
 	i := sort.Search(len(fr.ents), func(i int) bool {
 		e := fr.ents[i]
 		return e.chunkOffset >= offset || (offset > e.chunkOffset && offset < e.chunkOffset+e.chunkSize)
 	})
 	if i == len(fr.ents) {
-		return 0, 0, "", false
+		return 0, 0, "", "", false
 	}
 	ci := fr.ents[i]
-	return ci.chunkOffset, ci.chunkSize, ci.chunkDigest, true
+	return ci.chunkOffset, ci.chunkSize, ci.chunkDigest, ci.fileDigest, true
 }
 
 type fileReader struct {

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -153,7 +153,7 @@ func testPrefetch(t *testing.T, factory metadata.Store) {
 			},
 			// NOTE: we assume that the compressed "data64KB" is still larger than 8KB
 			// landmark+dir+foo1, foo2+foo22+dir+bar.txt+foo3, TOC, footer
-			wantNum:          5, // foo1 + foo2 + foo22 + bar.txt + foo3
+			wantNum:          4, // foo1 + foo2 + foo22 + bar.txt + foo3
 			wants:            []string{"foo/foo1", "foo2", "foo22", "bar/bar.txt", "foo3"},
 			prefetchSize:     landmarkPosition,
 			prioritizedFiles: []string{"foo/", "foo/foo1", "foo2", "foo22", "bar/", "bar/bar.txt", "foo3"},
@@ -671,7 +671,6 @@ func testNodesWithOpaque(t *testing.T, factory metadata.Store, opaque OverlayOpa
 				hasFileContentsOffset("bar/bar.txt", 2, "a", true),
 				hasFileContentsOffset("foo3", 0, data64KB, true),
 				hasFileContentsOffset("foo22", 0, "ccc", true),
-				hasFileContentsOffset("foo/foo1", 0, data64KB, false),
 				hasFileContentsOffset("foo/foo1", 0, data64KB, true),
 				hasFileContentsOffset("foo/foo1", 1, data64KB[1:], true),
 				hasFileContentsOffset("foo/foo1", 2, data64KB[2:], true),
@@ -700,7 +699,6 @@ func testNodesWithOpaque(t *testing.T, factory metadata.Store, opaque OverlayOpa
 				hasFileContentsOffset("foo3", 2, data64KB[2:len(data64KB)/2], true),
 				hasFileContentsOffset("foo3", int64(len(data64KB)/2), data64KB[len(data64KB)/2:], false),
 				hasFileContentsOffset("foo3", int64(len(data64KB)-1), data64KB[len(data64KB)-1:], true),
-				hasFileContentsOffset("foo/foo1", 0, data64KB, false),
 				hasFileContentsOffset("foo/foo1", 1, data64KB[1:], true),
 				hasFileContentsOffset("foo/foo1", 2, data64KB[2:], true),
 				hasFileContentsOffset("foo/foo1", int64(len(data64KB)/2), data64KB[len(data64KB)/2:], true),

--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -26,12 +26,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -201,7 +201,7 @@ func (vr *VerifiableReader) cacheWithReader(ctx context.Context, currentDepth in
 
 		var nr int64
 		for nr < e.Size {
-			chunkOffset, chunkSize, chunkDigestStr, ok := fr.ChunkEntryForOffset(nr)
+			chunkOffset, chunkSize, chunkDigestStr, _, ok := fr.ChunkEntryForOffset(nr)
 			if !ok {
 				break
 			}
@@ -236,7 +236,7 @@ func (vr *VerifiableReader) readAndCache(id uint32, fr io.Reader, chunkOffset, c
 	}
 
 	// Check if it already exists in the cache
-	cacheID := genID(id, chunkOffset, chunkSize)
+	cacheID := genID(id, chunkOffset, chunkSize, chunkDigest)
 	if r, err := gr.cache.Get(cacheID); err == nil {
 		r.Close()
 		return nil
@@ -361,7 +361,7 @@ func (gr *reader) OpenFile(id uint32) (io.ReaderAt, error) {
 	var fr metadata.File
 	fr, err := gr.r.OpenFileWithPreReader(id, func(nid uint32, chunkOffset, chunkSize int64, chunkDigest string, r io.Reader) error {
 		// Check if it already exists in the cache
-		cacheID := genID(nid, chunkOffset, chunkSize)
+		cacheID := genID(nid, chunkOffset, chunkSize, chunkDigest)
 		if r, err := gr.cache.Get(cacheID); err == nil {
 			r.Close()
 			return nil
@@ -430,12 +430,12 @@ type file struct {
 func (sf *file) ReadAt(p []byte, offset int64) (int, error) {
 	nr := 0
 	for nr < len(p) {
-		chunkOffset, chunkSize, chunkDigestStr, ok := sf.fr.ChunkEntryForOffset(offset + int64(nr))
+		chunkOffset, chunkSize, chunkDigestStr, _, ok := sf.fr.ChunkEntryForOffset(offset + int64(nr))
 		if !ok {
 			break
 		}
 		var (
-			id           = genID(sf.id, chunkOffset, chunkSize)
+			id           = genID(sf.id, chunkOffset, chunkSize, chunkDigestStr)
 			lowerDiscard = positive(offset - chunkOffset)
 			upperDiscard = positive(chunkOffset + chunkSize - (offset + int64(len(p))))
 			expectedSize = chunkSize - upperDiscard - lowerDiscard
@@ -500,21 +500,21 @@ func (sf *file) GetPassthroughFd() (uintptr, error) {
 		offset           int64
 		firstChunkOffset int64 = -1
 		totalSize        int64
+		fileDigest       string
 	)
-
 	for {
-		chunkOffset, chunkSize, _, ok := sf.fr.ChunkEntryForOffset(offset)
+		chunkOffset, chunkSize, _, digest, ok := sf.fr.ChunkEntryForOffset(offset)
 		if !ok {
 			break
 		}
 		if firstChunkOffset == -1 {
 			firstChunkOffset = chunkOffset
+			fileDigest = digest
 		}
 		totalSize += chunkSize
 		offset = chunkOffset + chunkSize
 	}
-
-	id := genID(sf.id, firstChunkOffset, totalSize)
+	id := genID(sf.id, firstChunkOffset, totalSize, fileDigest)
 
 	// cache.PassThrough() is necessary to take over files
 	r, err := sf.gr.cache.Get(id, cache.PassThrough())
@@ -522,7 +522,6 @@ func (sf *file) GetPassthroughFd() (uintptr, error) {
 		if err := sf.prefetchEntireFile(id); err != nil {
 			return 0, err
 		}
-
 		// just retry once to avoid exception stuck
 		r, err = sf.gr.cache.Get(id, cache.PassThrough())
 		if err != nil {
@@ -556,7 +555,7 @@ func (sf *file) prefetchEntireFile(entireCacheID string) error {
 	defer w.Close()
 
 	for {
-		chunkOffset, chunkSize, chunkDigestStr, ok := sf.fr.ChunkEntryForOffset(offset)
+		chunkOffset, chunkSize, chunkDigestStr, _, ok := sf.fr.ChunkEntryForOffset(offset)
 		if !ok {
 			break
 		}
@@ -564,7 +563,7 @@ func (sf *file) prefetchEntireFile(entireCacheID string) error {
 			firstChunkOffset = chunkOffset
 		}
 
-		id := genID(sf.id, chunkOffset, chunkSize)
+		id := genID(sf.id, chunkOffset, chunkSize, chunkDigestStr)
 		b := sf.gr.bufPool.Get().(*bytes.Buffer)
 		b.Reset()
 		b.Grow(int(chunkSize))
@@ -589,7 +588,6 @@ func (sf *file) prefetchEntireFile(entireCacheID string) error {
 			}
 			r.Close()
 		}
-
 		// cache miss, prefetch the whole chunk
 		if _, err := sf.fr.ReadAt(ip, chunkOffset); err != nil && err != io.EOF {
 			sf.gr.putBuffer(b)
@@ -606,6 +604,7 @@ func (sf *file) prefetchEntireFile(entireCacheID string) error {
 			w.Abort()
 			return fmt.Errorf("failed to write fetched data: %w", err)
 		}
+
 		totalSize += chunkSize
 		offset = chunkOffset + chunkSize
 		sf.gr.putBuffer(b)
@@ -662,11 +661,11 @@ func (gr *reader) verifyChunk(id uint32, p []byte, chunkDigestStr string) error 
 	return nil
 }
 
-func genID(id uint32, offset, size int64) string {
-	sum := sha256.Sum256([]byte(fmt.Sprintf("%d-%d-%d", id, offset, size)))
-	return fmt.Sprintf("%x", sum)
+func genID(id uint32, offset, size int64, digest string) string {
+	// Extract just the hash part if the digest has a prefix like "sha256:"
+	hash := strings.TrimPrefix(digest, "sha256:")
+	return hash
 }
-
 func positive(n int64) int64 {
 	if n < 0 {
 		return 0

--- a/fs/reader/testutil.go
+++ b/fs/reader/testutil.go
@@ -25,6 +25,7 @@ package reader
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"os"
@@ -131,7 +132,14 @@ func testFileReadAt(t *testing.T, factory metadata.Store) {
 								defer closeFn()
 								f.fr = newExceptFile(t, f.fr, cacheExcept...)
 								for _, reg := range cacheExcept {
-									id := genID(f.id, reg.b, reg.e-reg.b+1)
+									// get chunk digest
+									tmpData := make([]byte, reg.e-reg.b+1)
+									tmpn, err := want.ReadAt(tmpData, reg.b)
+									if err != nil && err != io.EOF {
+										t.Fatalf("want.ReadAt (offset=%d,size=%d): %v", reg.b, reg.e-reg.b+1, err)
+									}
+									digest := sha256.Sum256(tmpData[:tmpn])
+									id := genID(f.id, reg.b, reg.e-reg.b+1, fmt.Sprintf("%x", digest))
 									w, err := f.gr.cache.Add(id)
 									if err != nil {
 										w.Close()
@@ -154,7 +162,6 @@ func testFileReadAt(t *testing.T, factory metadata.Store) {
 									return
 								}
 								respData = respData[:n]
-
 								if !bytes.Equal(wantData, respData) {
 									t.Errorf("off=%d, filesize=%d; read data{size=%d,data=%q}; want (size=%d,data=%q)",
 										offset, filesize, len(respData), string(respData), wantN, string(wantData))
@@ -165,12 +172,12 @@ func testFileReadAt(t *testing.T, factory metadata.Store) {
 								cn := 0
 								nr := 0
 								for int64(nr) < wantN {
-									chunkOffset, chunkSize, _, ok := f.fr.ChunkEntryForOffset(offset + int64(nr))
+									chunkOffset, chunkSize, chunkDigestStr, _, ok := f.fr.ChunkEntryForOffset(offset + int64(nr))
 									if !ok {
 										break
 									}
 									data := make([]byte, chunkSize)
-									id := genID(f.id, chunkOffset, chunkSize)
+									id := genID(f.id, chunkOffset, chunkSize, chunkDigestStr)
 									r, err := f.gr.cache.Get(id)
 									if err != nil {
 										t.Errorf("missed cache of offset=%d, size=%d: %v(got size=%d)", chunkOffset, chunkSize, err, n)
@@ -215,7 +222,7 @@ func (er *exceptFile) ReadAt(p []byte, offset int64) (int, error) {
 	return er.fr.ReadAt(p, offset)
 }
 
-func (er *exceptFile) ChunkEntryForOffset(offset int64) (off int64, size int64, dgst string, ok bool) {
+func (er *exceptFile) ChunkEntryForOffset(offset int64) (off int64, size int64, dgst string, fDgst string, ok bool) {
 	return er.fr.ChunkEntryForOffset(offset)
 }
 
@@ -613,18 +620,17 @@ func testPreReader(t *testing.T, factory metadata.Store) {
 			// NOTE: we assume that the compressed "data64KB" is still larger than 8KB
 			// landmark+dir+foo1, foo2+foo22+dir+bar.txt+foo3, TOC, footer
 			want: []check{
+				hasFileContentsOffset("foo/foo1", 3, data64KB[3:], false),
 				hasFileContentsWithPreCached("foo22", 0, "ccc", chunkInfo{"foo2", "bb", 0, 2}, chunkInfo{"bar/bar.txt", "aaa", 0, 3}, chunkInfo{"foo3", data64KB, 0, 64000}),
 				hasFileContentsOffset("foo2", 0, "bb", true),
 				hasFileContentsOffset("bar/bar.txt", 0, "aaa", true),
 				hasFileContentsOffset("bar/bar.txt", 1, "aa", true),
 				hasFileContentsOffset("bar/bar.txt", 2, "a", true),
-				hasFileContentsOffset("foo3", 0, data64KB, true),
 				hasFileContentsOffset("foo22", 0, "ccc", true),
-				hasFileContentsOffset("foo/foo1", 0, data64KB, false),
 				hasFileContentsOffset("foo/foo1", 0, data64KB, true),
+				hasFileContentsOffset("foo3", 0, data64KB, true),
 				hasFileContentsOffset("foo/foo1", 1, data64KB[1:], true),
 				hasFileContentsOffset("foo/foo1", 2, data64KB[2:], true),
-				hasFileContentsOffset("foo/foo1", 3, data64KB[3:], true),
 			},
 		},
 		{
@@ -649,7 +655,7 @@ func testPreReader(t *testing.T, factory metadata.Store) {
 				hasFileContentsOffset("foo3", 2, data64KB[2:len(data64KB)/2], true),
 				hasFileContentsOffset("foo3", int64(len(data64KB)/2), data64KB[len(data64KB)/2:], false),
 				hasFileContentsOffset("foo3", int64(len(data64KB)-1), data64KB[len(data64KB)-1:], true),
-				hasFileContentsOffset("foo/foo1", 0, data64KB, false),
+				hasFileContentsOffset("foo/foo1", 0, data64KB, true),
 				hasFileContentsOffset("foo/foo1", 1, data64KB[1:], true),
 				hasFileContentsOffset("foo/foo1", 2, data64KB[2:], true),
 				hasFileContentsOffset("foo/foo1", int64(len(data64KB)/2), data64KB[len(data64KB)/2:], true),
@@ -668,7 +674,6 @@ func testPreReader(t *testing.T, factory metadata.Store) {
 					opts = append(opts, tutil.WithEStargzOptions(estargz.WithChunkSize(tt.chunkSize)))
 				}
 				if tt.minChunkSize > 0 {
-					t.Logf("minChunkSize = %d", tt.minChunkSize)
 					opts = append(opts, tutil.WithEStargzOptions(estargz.WithMinChunkSize(tt.minChunkSize)))
 				}
 				esgz, tocDgst, err := tutil.BuildEStargz(tt.in, opts...)
@@ -730,7 +735,6 @@ func hasFileContentsOffset(name string, off int64, contents string, fromCache bo
 		if string(buf) != contents {
 			t.Fatalf("unexpected content of %q: %q want %q", name, longBytesView(buf), longBytesView([]byte(contents)))
 		}
-		t.Logf("reader calls for %q: offsets: %+v", name, cr.called)
 		if fromCache {
 			if len(cr.called) != 0 {
 				t.Fatalf("unexpected read on %q: offsets: %v", name, cr.called)
@@ -769,18 +773,26 @@ func hasFileContentsWithPreCached(name string, off int64, contents string, extra
 			if err != nil {
 				t.Fatalf("failed to lookup %q", e.name)
 			}
-			cacheID := genID(eid, e.chunkOffset, e.chunkSize)
-			er, err := r.cache.Get(cacheID)
+			// Get chunk digest for this chunk
+			fr, err := r.r.OpenFile(eid)
 			if err != nil {
-				t.Fatalf("failed to get cache %q: %+v", cacheID, e)
+				t.Fatalf("failed to open file %q: %v", e.name, err)
+			}
+			chunkOffset, chunkSize, chunkDigestStr, _, ok := fr.ChunkEntryForOffset(e.chunkOffset)
+			if !ok {
+				t.Fatalf("failed to get chunk info for %q at offset %d", e.name, e.chunkOffset)
+			}
+			er, err := r.cache.Get(genID(r.r.RootID(), chunkOffset, chunkSize, chunkDigestStr))
+			if err != nil {
+				t.Fatalf("failed to get cache %q: %+v", chunkDigestStr, e)
 			}
 			data, err := io.ReadAll(io.NewSectionReader(er, 0, e.chunkSize))
 			er.Close()
 			if err != nil {
-				t.Fatalf("failed to read cache %q: %+v", cacheID, e)
+				t.Fatalf("failed to read cache %q: %+v", chunkDigestStr, e)
 			}
 			if string(data) != e.data {
-				t.Fatalf("unexpected contents of cache %q (%+v): %q; wanted %q", cacheID, e, longBytesView(data), longBytesView([]byte(e.data)))
+				t.Fatalf("unexpected contents of cache %q (%+v): %q; wanted %q", chunkDigestStr, e, longBytesView(data), longBytesView([]byte(e.data)))
 			}
 		}
 	}

--- a/metadata/memory/reader.go
+++ b/metadata/memory/reader.go
@@ -245,10 +245,10 @@ type file struct {
 	sr *io.SectionReader
 }
 
-func (r *file) ChunkEntryForOffset(offset int64) (off int64, size int64, dgst string, ok bool) {
+func (r *file) ChunkEntryForOffset(offset int64) (off int64, size int64, dgst, fileDigest string, ok bool) {
 	e, ok := r.r.r.ChunkEntryForOffset(r.e.Name, offset)
 	if !ok {
-		return 0, 0, "", false
+		return 0, 0, "", "", false
 	}
 	dgst = e.Digest
 	if e.ChunkDigest != "" {
@@ -256,7 +256,7 @@ func (r *file) ChunkEntryForOffset(offset int64) (off int64, size int64, dgst st
 		// chunked file)
 		dgst = e.ChunkDigest
 	}
-	return e.ChunkOffset, e.ChunkSize, dgst, true
+	return e.ChunkOffset, e.ChunkSize, dgst, e.Digest, true
 }
 
 func (r *file) ReadAt(p []byte, off int64) (n int, err error) {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -78,7 +78,7 @@ type Reader interface {
 }
 
 type File interface {
-	ChunkEntryForOffset(offset int64) (off int64, size int64, dgst string, ok bool)
+	ChunkEntryForOffset(offset int64) (off int64, size int64, dgst, fileDigest string, ok bool)
 	ReadAt(p []byte, off int64) (n int, err error)
 }
 


### PR DESCRIPTION
Replace the genID-based cache key with the chunk's digest directly. This simplifies the caching mechanism by using the chunk's natural identifier (its digest) rather than generating a synthetic one. Since chunk digests are cryptographic hashes, they are already guaranteed to be unique identifiers for chunk contents, and it will be good for the chunk deduplication.