### PR TITLE
Align the Maximum filename length with the running file system

### DIFF
--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -832,7 +832,7 @@ func defaultStatfs(stat *fuse.StatfsOut) {
 	stat.Files = 0 // dummy
 	stat.Ffree = 0
 	stat.Bsize = blockSize
-	stat.NameLen = 1<<32 - 1
+	stat.NameLen = 255 // Standard max filename length for most filesystems (ext4, etc.) for compatibility
 	stat.Frsize = blockSize
 	stat.Padding = 0
 	stat.Spare = [6]uint32{}


### PR DESCRIPTION
During my testing with pjdfstest, I encountered a situation where the cases related to the maximum filename length got stuck.
```
prove -r pjdfstest/tests/chmod/02.t
pjdfstest/tests/chmod/02.t ..
```

Upon analyzing the logs, I discovered the following information:

- Test pass log
```
+++ /pjdfstest/pjdfstest pathconf . _PC_NAME_MAX
++ name_max=255
++ namegen_len 255
++ len=255
++ name=
++ :
+++ dd if=/dev/urandom bs=64 count=1
+++ openssl md5
+++ awk '{print $NF}'
++ namepart=8e41e9afda303d0b8626dc889b958c90
++ name=8e41e9afda303d0b8626dc889b958c90
+++ printf %s 8e41e9afda303d0b8626dc889b958c90
+++ wc -c
++ curlen=32
++ '[' 32 -lt 255 ']'
++ :
...
+++ dd if=/dev/urandom bs=64 count=1
+++ openssl md5
+++ awk '{print $NF}'
++ namepart=ffe35295125856b903d3f213885d8deb
++ name=8e41e9afda303d0b8626dc889b958c90e9d6681a1b59ce554d00b98a945d01e6217f08208c5036d1967f8e6a82487dd6a7b83559baeef4ee5b9ef94e613162aa665da18098dca53edce294d1ee35a8116900f85cb5520f60ec71b6c83e75fa89db099095f5690086df2bda07b6ca3733ffe35295125856b903d3f213885d8deb
+++ printf %s 8e41e9afda303d0b8626dc889b958c90e9d6681a1b59ce554d00b98a945d01e6217f08208c5036d1967f8e6a82487dd6a7b83559baeef4ee5b9ef94e613162aa665da18098dca53edce294d1ee35a8116900f85cb5520f60ec71b6c83e75fa89db099095f5690086df2bda07b6ca3733ffe35295125856b903d3f213885d8deb
+++ wc -c
++ curlen=256
++ '[' 256 -lt 255 ']'
++ break
+++ echo 8e41e9afda303d0b8626dc889b958c90e9d6681a1b59ce554d00b98a945d01e6217f08208c5036d1967f8e6a82487dd6a7b83559baeef4ee5b9ef94e613162aa665da18098dca53edce294d1ee35a8116900f85cb5520f60ec71b6c83e75fa89db099095f5690086df2bda07b6ca3733ffe35295125856b903d3f213885d8deb
+++ cut -b -255
++ name=8e41e9afda303d0b8626dc889b958c90e9d6681a1b59ce554d00b98a945d01e6217f08208c5036d1967f8e6a82487dd6a7b83559baeef4ee5b9ef94e613162aa665da18098dca53edce294d1ee35a8116900f85cb5520f60ec71b6c83e75fa89db099095f5690086df2bda07b6ca3733ffe35295125856b903d3f213885d8de

```

- Abnormal scenario logs
```
+++ /pjdfstest/pjdfstest pathconf . _PC_NAME_MAX
++ name_max=4294967295
++ namegen_len 4294967295
++ len=4294967295
++ name=
++ :
+++ dd if=/dev/urandom bs=64 count=1
+++ openssl md5
+++ awk '{print $NF}'
++ namepart=36e12125e9641a2062445902c67d6025
++ name=36e12125e9641a2062445902c67d6025
+++ printf %s 36e12125e9641a2062445902c67d6025
+++ wc -c
++ curlen=32
++ '[' 32 -lt 4294967295 ']'
++ :

...

+++ printf %s 36e12125e9641a2062445902c67d60256b81744c186a6c832d20fac3ebccd22a795d8b032b8abd2f831fd8760a9e1576947c54b9adbcd7928073770130a6ad81066f18c1ef21c2eed4d4efc57b9f81e938eb16d1e86546730f54d9c74ad5be745763c249ac30e80d6d6e2a885851793b28709571e1081aba333409a7e04a55f333b4b91a83b9904557a9e95cd8ebacae
+++ wc -c
++ curlen=288
++ '[' 288 -lt 4294967295 ']'
++ :
+++ dd if=/dev/urandom bs=64 count=1
+++ openssl md5
+++ awk '{print $NF}'
++ namepart=14a98a3a4e98bbe0b4bdcea36d34929c
++ name=36e12125e9641a2062445902c67d60256b81744c186a6c832d20fac3ebccd22a795d8b032b8abd2f831fd8760a9e1576947c54b9adbcd7928073770130a6ad81066f18c1ef21c2eed4d4efc57b9f81e938eb16d1e86546730f54d9c74ad5be745763c249ac30e80d6d6e2a885851793b28709571e1081aba333409a7e04a55f333b4b91a83b9904557a9e95cd8ebacae14a98a3a4e98bbe0b4bdcea36d34929c
+++ printf %s 36e12125e9641a2062445902c67d60256b81744c186a6c832d20fac3ebccd22a795d8b032b8abd2f831fd8760a9e1576947c54b9adbcd7928073770130a6ad81066f18c1ef21c2eed4d4efc57b9f81e938eb16d1e86546730f54d9c74ad5be745763c249ac30e80d6d6e2a885851793b28709571e1081aba333409a7e04a55f333b4b91a83b9904557a9e95cd8ebacae14a98a3a4e98bbe0b4bdcea36d34929c
+++ wc -c
++ curlen=320
++ '[' 320 -lt 4294967295 ']'
++ :

```


This indicates that in the stuck scenario, when attempting to retrieve the maximum filename length, the value obtained was `4294967295 (1 << 32 - 1)`, which is an extremely large number. Therefore, rather than being stuck, it seems that the process is continuously calculating the longest filename.

This PR aims not only to address the aforementioned issue but also to adjust the logic for obtaining `NameLen` in `defaultStatfs` to ensure it aligns with the currently running file system.