### PR TITLE
bump golangci/golangci-lint-action from 6.5.2 to 7.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,9 +40,9 @@ jobs:
       with:
         go-version: '1.24.x'
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6.5.2
+      uses: golangci/golangci-lint-action@v7.0.0
       with:
-        version: v1.64.5
+        version: v2.0
         args: --verbose --timeout=10m
         working-directory: ${{ matrix.targetdir }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,44 +1,54 @@
-# This is applied to `estargz` submodule as well.
-# https://golangci-lint.run/usage/configuration#config-file
-
+version: "2"
 linters:
   enable:
-    - depguard      # Checks for imports that shouldn't be used.
-    - staticcheck
-    - unconvert
-    - gofmt
-    - goimports
-    - revive
-    - ineffassign
-    - govet
-    - unused
+    - depguard
     - misspell
+    - revive
+    - unconvert
   disable:
     - errcheck
-
-linters-settings:
-  depguard:
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: github.com/containerd/containerd/errdefs
+              desc: The containerd errdefs package was migrated to a separate module. Use github.com/containerd/errdefs instead.
+            - pkg: github.com/containerd/containerd/log
+              desc: The containerd log package was migrated to a separate module. Use github.com/containerd/log instead.
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      main:
-        deny:
-          - pkg: "github.com/containerd/containerd/errdefs"
-            desc: The containerd errdefs package was migrated to a separate module. Use github.com/containerd/errdefs instead.
-          - pkg: "github.com/containerd/containerd/log"
-            desc: The containerd log package was migrated to a separate module. Use github.com/containerd/log instead.
-
-run:
-  timeout: 4m
-
-issues:
-  exclude-rules:
-    - linters:
-        - revive
-      text: "unused-parameter"
-    - linters:
-        - revive
-      text: "redefines-builtin-id"
-  exclude-dirs:
-    - docs
-    - images
-    - out
-    - script
+      - linters:
+          - revive
+        text: unused-parameter
+      - linters:
+          - revive
+        text: redefines-builtin-id
+    paths:
+      - docs
+      - images
+      - out
+      - script
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - docs
+      - images
+      - out
+      - script
+      - third_party$
+      - builtin$
+      - examples$

--- a/analyzer/fanotify/service/service.go
+++ b/analyzer/fanotify/service/service.go
@@ -68,7 +68,7 @@ func Serve(target string, r io.Reader, w io.Writer) error {
 			return fmt.Errorf("read fanotify fd: %w", err)
 		}
 		if event.Vers != unix.FANOTIFY_METADATA_VERSION {
-			return fmt.Errorf("Fanotify version mismatch %d(got) != %d(want)",
+			return fmt.Errorf("fanotify version mismatch %d(got) != %d(want)",
 				event.Vers, unix.FANOTIFY_METADATA_VERSION)
 		}
 		if event.Fd < 0 {

--- a/analyzer/recorder/recorder.go
+++ b/analyzer/recorder/recorder.go
@@ -151,7 +151,7 @@ func (r *ImageRecorder) Record(name string) error {
 		}
 		whDir := cleanEntryName(path.Join(path.Dir("/"+name), whiteoutOpaqueDir))
 		if _, ok := r.index[i][whDir]; ok {
-			return fmt.Errorf("Parent dir of %q is a deleted directory", name)
+			return fmt.Errorf("parent dir of %q is a deleted directory", name)
 		}
 	}
 	if index < 0 {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -405,7 +405,7 @@ func (mc *MemoryCache) Get(key string, opts ...Option) (Reader, error) {
 	defer mc.mu.Unlock()
 	b, ok := mc.Membuf[key]
 	if !ok {
-		return nil, fmt.Errorf("Missed cache: %q", key)
+		return nil, fmt.Errorf("missed cache: %q", key)
 	}
 	return &reader{bytes.NewReader(b.Bytes()), func() error { return nil }}, nil
 }

--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -117,7 +117,7 @@ func main() {
 
 	// Get configuration from specified file
 	tree, err := toml.LoadFile(*configPath)
-	if err != nil && !(os.IsNotExist(err) && *configPath == defaultConfigPath) {
+	if err != nil && (!os.IsNotExist(err) || *configPath != defaultConfigPath) {
 		log.G(ctx).WithError(err).Fatalf("failed to load config file %q", *configPath)
 	}
 	if err := tree.Unmarshal(&config); err != nil {
@@ -134,17 +134,17 @@ func main() {
 	// Configure FUSE passthrough
 	// Always set Direct to true to ensure that
 	// *directoryCache.Get always return *os.File instead of buffer
-	if config.Config.Config.FuseConfig.PassThrough {
-		config.Config.Config.DirectoryCacheConfig.Direct = true
+	if config.PassThrough {
+		config.Direct = true
 	}
 
 	// Configure keychain
 	keyChainConfig := keychainconfig.Config{
-		EnableKubeKeychain:         config.Config.KubeconfigKeychainConfig.EnableKeychain,
-		EnableCRIKeychain:          config.Config.CRIKeychainConfig.EnableKeychain,
-		KubeconfigPath:             config.Config.KubeconfigKeychainConfig.KubeconfigPath,
+		EnableKubeKeychain:         config.KubeconfigKeychainConfig.EnableKeychain,
+		EnableCRIKeychain:          config.CRIKeychainConfig.EnableKeychain,
+		KubeconfigPath:             config.KubeconfigPath,
 		DefaultImageServiceAddress: defaultImageServiceAddress,
-		ImageServicePath:           config.CRIKeychainConfig.ImageServicePath,
+		ImageServicePath:           config.ImageServicePath,
 	}
 
 	var rs snapshots.Snapshotter

--- a/cmd/stargz-fuse-manager/main.go
+++ b/cmd/stargz-fuse-manager/main.go
@@ -40,9 +40,9 @@ func init() {
 		keyChainConfig := keychainconfig.Config{
 			EnableKubeKeychain:         cc.Config.Config.KubeconfigKeychainConfig.EnableKeychain,
 			EnableCRIKeychain:          cc.Config.Config.CRIKeychainConfig.EnableKeychain,
-			KubeconfigPath:             cc.Config.Config.KubeconfigKeychainConfig.KubeconfigPath,
+			KubeconfigPath:             cc.Config.Config.KubeconfigPath,
 			DefaultImageServiceAddress: cc.Config.DefaultImageServiceAddress,
-			ImageServicePath:           cc.Config.Config.CRIKeychainConfig.ImageServicePath,
+			ImageServicePath:           cc.Config.Config.ImageServicePath,
 		}
 		credsFuncs, err := keychainconfig.ConfigKeychain(cc.Ctx, cc.Server, &keyChainConfig)
 		if err != nil {

--- a/estargz/build.go
+++ b/estargz/build.go
@@ -408,11 +408,11 @@ func readerFromEntries(entries ...*entry) io.Reader {
 		defer tw.Close()
 		for _, entry := range entries {
 			if err := tw.WriteHeader(entry.header); err != nil {
-				pw.CloseWithError(fmt.Errorf("Failed to write tar header: %v", err))
+				pw.CloseWithError(fmt.Errorf("failed to write tar header: %v", err))
 				return
 			}
 			if _, err := io.Copy(tw, entry.payload); err != nil {
-				pw.CloseWithError(fmt.Errorf("Failed to write tar payload: %v", err))
+				pw.CloseWithError(fmt.Errorf("failed to write tar payload: %v", err))
 				return
 			}
 		}
@@ -627,12 +627,12 @@ func (cr *countReadSeeker) Seek(offset int64, whence int) (int64, error) {
 
 	switch whence {
 	default:
-		return 0, fmt.Errorf("Unknown whence: %v", whence)
+		return 0, fmt.Errorf("unknown whence: %v", whence)
 	case io.SeekStart:
 	case io.SeekCurrent:
 		offset += *cr.cPos
 	case io.SeekEnd:
-		return 0, fmt.Errorf("Unsupported whence: %v", whence)
+		return 0, fmt.Errorf("unsupported whence: %v", whence)
 	}
 
 	if offset < 0 {

--- a/estargz/estargz_test.go
+++ b/estargz/estargz_test.go
@@ -81,7 +81,7 @@ func TestChunkEntryForOffset(t *testing.T) {
 			if ok != te.wantOk {
 				t.Errorf("ok = %v; want (%v)", ok, te.wantOk)
 			} else if ok {
-				if !(ce.ChunkOffset == te.wantChunkOffset && ce.ChunkSize == te.wantChunkSize) {
+				if ce.ChunkOffset != te.wantChunkOffset || ce.ChunkSize != te.wantChunkSize {
 					t.Errorf("chunkOffset = %d, ChunkSize = %d; want (chunkOffset = %d, chunkSize = %d)",
 						ce.ChunkOffset, ce.ChunkSize, te.wantChunkOffset, te.wantChunkSize)
 				}

--- a/estargz/externaltoc/externaltoc.go
+++ b/estargz/externaltoc/externaltoc.go
@@ -135,7 +135,7 @@ func gzipFooterBytes() ([]byte, error) {
 	header[0], header[1] = 'S', 'G'
 	subfield := "STARGZEXTERNALTOC"                                   // len("STARGZEXTERNALTOC") = 17
 	binary.LittleEndian.PutUint16(header[2:4], uint16(len(subfield))) // little-endian per RFC1952
-	gz.Header.Extra = append(header, []byte(subfield)...)
+	gz.Extra = append(header, []byte(subfield)...)
 	if err := gz.Close(); err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (gz *GzipDecompressor) ParseFooter(p []byte) (blobPayloadSize, tocOffset, t
 		return 0, 0, 0, err
 	}
 	defer zr.Close()
-	extra := zr.Header.Extra
+	extra := zr.Extra
 	si1, si2, subfieldlen, subfield := extra[0], extra[1], extra[2:4], extra[4:]
 	if si1 != 'S' || si2 != 'G' {
 		return 0, 0, 0, fmt.Errorf("invalid subfield IDs: %q, %q; want E, S", si1, si2)

--- a/estargz/externaltoc/externaltoc_test.go
+++ b/estargz/externaltoc/externaltoc_test.go
@@ -56,7 +56,7 @@ type gzipController struct {
 }
 
 func (gc *gzipController) String() string {
-	return fmt.Sprintf("externaltoc_gzip_compression_level=%v", gc.GzipCompressor.compressionLevel)
+	return fmt.Sprintf("externaltoc_gzip_compression_level=%v", gc.compressionLevel)
 }
 
 // TestStream tests the passed estargz blob contains the specified list of streams.

--- a/estargz/gzip.go
+++ b/estargz/gzip.go
@@ -109,7 +109,7 @@ func gzipFooterBytes(tocOff int64) []byte {
 	header[0], header[1] = 'S', 'G'
 	subfield := fmt.Sprintf("%016xSTARGZ", tocOff)
 	binary.LittleEndian.PutUint16(header[2:4], uint16(len(subfield))) // little-endian per RFC1952
-	gz.Header.Extra = append(header, []byte(subfield)...)
+	gz.Extra = append(header, []byte(subfield)...)
 	gz.Close()
 	if buf.Len() != FooterSize {
 		panic(fmt.Sprintf("footer buffer = %d, not %d", buf.Len(), FooterSize))
@@ -136,7 +136,7 @@ func (gz *GzipDecompressor) ParseFooter(p []byte) (blobPayloadSize, tocOffset, t
 		return 0, 0, 0, err
 	}
 	defer zr.Close()
-	extra := zr.Header.Extra
+	extra := zr.Extra
 	si1, si2, subfieldlen, subfield := extra[0], extra[1], extra[2:4], extra[4:]
 	if si1 != 'S' || si2 != 'G' {
 		return 0, 0, 0, fmt.Errorf("invalid subfield IDs: %q, %q; want E, S", si1, si2)
@@ -181,7 +181,7 @@ func (gz *LegacyGzipDecompressor) ParseFooter(p []byte) (blobPayloadSize, tocOff
 		return 0, 0, 0, fmt.Errorf("legacy: failed to get footer gzip reader: %w", err)
 	}
 	defer zr.Close()
-	extra := zr.Header.Extra
+	extra := zr.Extra
 	if len(extra) != 16+len("STARGZ") {
 		return 0, 0, 0, fmt.Errorf("legacy: invalid stargz's extra field size")
 	}

--- a/estargz/gzip_test.go
+++ b/estargz/gzip_test.go
@@ -52,7 +52,7 @@ type gzipController struct {
 }
 
 func (gc *gzipController) String() string {
-	return fmt.Sprintf("gzip_compression_level=%v", gc.GzipCompressor.compressionLevel)
+	return fmt.Sprintf("gzip_compression_level=%v", gc.compressionLevel)
 }
 
 // TestStream tests the passed estargz blob contains the specified list of streams.
@@ -106,7 +106,7 @@ func checkLegacyFooter(t *testing.T, off int64) {
 func legacyFooterBytes(tocOff int64) []byte {
 	buf := bytes.NewBuffer(make([]byte, 0, legacyFooterSize))
 	gz, _ := gzip.NewWriterLevel(buf, gzip.NoCompression)
-	gz.Header.Extra = []byte(fmt.Sprintf("%016xSTARGZ", tocOff))
+	gz.Extra = []byte(fmt.Sprintf("%016xSTARGZ", tocOff))
 	gz.Close()
 	if buf.Len() != legacyFooterSize {
 		panic(fmt.Sprintf("footer buffer = %d, not %d", buf.Len(), legacyFooterSize))

--- a/estargz/zstdchunked/zstdchunked_test.go
+++ b/estargz/zstdchunked/zstdchunked_test.go
@@ -50,7 +50,7 @@ type zstdController struct {
 }
 
 func (zc *zstdController) String() string {
-	return fmt.Sprintf("zstd_compression_level=%v", zc.Compressor.CompressionLevel)
+	return fmt.Sprintf("zstd_compression_level=%v", zc.CompressionLevel)
 }
 
 // TestStream tests the passed zstdchunked blob contains the specified list of streams.

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -139,12 +139,12 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snapshot.F
 		maxConcurrency = defaultMaxConcurrency
 	}
 
-	attrTimeout := time.Duration(cfg.FuseConfig.AttrTimeout) * time.Second
+	attrTimeout := time.Duration(cfg.AttrTimeout) * time.Second
 	if attrTimeout == 0 {
 		attrTimeout = defaultFuseTimeout
 	}
 
-	entryTimeout := time.Duration(cfg.FuseConfig.EntryTimeout) * time.Second
+	entryTimeout := time.Duration(cfg.EntryTimeout) * time.Second
 	if entryTimeout == 0 {
 		entryTimeout = defaultFuseTimeout
 	}

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -328,9 +328,9 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 
 	// Combine layer information together and cache it.
 	l := newLayer(r, desc, blobR, vr, passThroughConfig{
-		enable:           r.config.FuseConfig.PassThrough,
-		mergeBufferSize:  r.config.FuseConfig.MergeBufferSize,
-		mergeWorkerCount: r.config.FuseConfig.MergeWorkerCount,
+		enable:           r.config.PassThrough,
+		mergeBufferSize:  r.config.MergeBufferSize,
+		mergeWorkerCount: r.config.MergeWorkerCount,
 	})
 	r.layerCacheMu.Lock()
 	cachedL, done2, added := r.layerCache.Add(name, l)

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -84,7 +84,7 @@ func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseIno
 	}
 	opq, ok := opaqueXattrs[opaque]
 	if !ok {
-		return nil, fmt.Errorf("Unknown overlay opaque type")
+		return nil, fmt.Errorf("unknown overlay opaque type")
 	}
 	ffs := &fs{
 		r:            r,

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -832,8 +832,8 @@ func hasSize(name string, size int) check {
 		if errno := n.Operations().(fusefs.NodeGetattrer).Getattr(context.Background(), nil, &ao); errno != 0 {
 			t.Fatalf("failed to get attributes of node %q: %v", name, errno)
 		}
-		if ao.Attr.Size != uint64(size) {
-			t.Fatalf("got size = %d, want %d", ao.Attr.Size, size)
+		if ao.Size != uint64(size) {
+			t.Fatalf("got size = %d, want %d", ao.Size, size)
 		}
 	}
 }

--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -120,7 +120,7 @@ func (b *blob) Refresh(ctx context.Context, hosts source.RegistryHosts, refspec 
 		return err
 	}
 	if newSize != b.size {
-		return fmt.Errorf("Invalid size of new blob %d; want %d", newSize, b.size)
+		return fmt.Errorf("invalid size of new blob %d; want %d", newSize, b.size)
 	}
 
 	// update the blob's fetcher with new one

--- a/fs/remote/blob_test.go
+++ b/fs/remote/blob_test.go
@@ -609,7 +609,7 @@ func TestCheckInterval(t *testing.T) {
 		if !tr.called {
 			return b.lastCheck, false
 		}
-		if !(b.lastCheck.After(beforeUpdate) && b.lastCheck.Before(afterUpdate)) {
+		if !b.lastCheck.After(beforeUpdate) || !b.lastCheck.Before(afterUpdate) {
 			t.Errorf("%q: updated time must be after %q and before %q but %q", name, beforeUpdate, afterUpdate, b.lastCheck)
 		}
 

--- a/fusemanager/fusemanager_test.go
+++ b/fusemanager/fusemanager_test.go
@@ -135,7 +135,7 @@ func TestFuseManager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create fuse manager: %v", err)
 	}
-	defer fm.Server.Close(context.Background())
+	defer fm.Close(context.Background())
 
 	pb.RegisterStargzFuseManagerServiceServer(grpcServer, fm)
 

--- a/service/keychain/kubeconfig/kubeconfig.go
+++ b/service/keychain/kubeconfig/kubeconfig.go
@@ -146,7 +146,7 @@ func (kc *keychain) credentials(host string, refspec reference.Spec) (string, st
 		if acfg, err := cfg.GetAuthConfig(host); err == nil {
 			if acfg.IdentityToken != "" {
 				return "", acfg.IdentityToken, nil
-			} else if !(acfg.Username == "" && acfg.Password == "") {
+			} else if acfg.Username != "" || acfg.Password != "" {
 				return acfg.Username, acfg.Password, nil
 			}
 		}
@@ -204,7 +204,7 @@ func (kc *keychain) startSyncSecrets(ctx context.Context, client kubernetes.Inte
 	})
 	go informer.Run(ctx.Done())
 	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
-		return fmt.Errorf("Timed out for syncing cache")
+		return fmt.Errorf("timed out for syncing cache")
 	}
 
 	// get informer and queue

--- a/service/plugincore/plugin.go
+++ b/service/plugincore/plugin.go
@@ -78,17 +78,17 @@ func RegisterPlugin() {
 
 			// Configure keychain
 			credsFuncs := []resolver.Credential{dockerconfig.NewDockerconfigKeychain(ctx)}
-			if config.Config.KubeconfigKeychainConfig.EnableKeychain {
+			if config.KubeconfigKeychainConfig.EnableKeychain {
 				var opts []kubeconfig.Option
-				if kcp := config.Config.KubeconfigKeychainConfig.KubeconfigPath; kcp != "" {
+				if kcp := config.KubeconfigPath; kcp != "" {
 					opts = append(opts, kubeconfig.WithKubeconfigPath(kcp))
 				}
 				credsFuncs = append(credsFuncs, kubeconfig.NewKubeconfigKeychain(ctx, opts...))
 			}
-			if addr := config.CRIKeychainImageServicePath; config.Config.CRIKeychainConfig.EnableKeychain && addr != "" {
+			if addr := config.CRIKeychainImageServicePath; config.CRIKeychainConfig.EnableKeychain && addr != "" {
 				// connects to the backend CRI service (defaults to containerd socket)
 				criAddr := ic.Properties[ctdplugins.PropertyGRPCAddress]
-				if cp := config.Config.CRIKeychainConfig.ImageServicePath; cp != "" {
+				if cp := config.ImageServicePath; cp != "" {
 					criAddr = cp
 				}
 				if criAddr == "" {

--- a/service/resolver/registry.go
+++ b/service/resolver/registry.go
@@ -120,7 +120,7 @@ func multiCredsFuncs(ref reference.Spec, credsFuncs ...Credential) func(string) 
 		for _, f := range credsFuncs {
 			if username, secret, err := f(host, ref); err != nil {
 				return "", "", err
-			} else if !(username == "" && secret == "") {
+			} else if username != "" || secret != "" {
 				return username, secret, nil
 			}
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -33,7 +33,6 @@ import (
 	esgzexternaltoc "github.com/containerd/stargz-snapshotter/nativeconverter/estargz/externaltoc"
 	"github.com/containerd/stargz-snapshotter/service/resolver"
 	"github.com/containerd/stargz-snapshotter/snapshot"
-	snbase "github.com/containerd/stargz-snapshotter/snapshot"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -75,12 +74,12 @@ func NewStargzSnapshotterService(ctx context.Context, root string, config *Confi
 
 	var snapshotter snapshots.Snapshotter
 
-	snOpts := []snbase.Opt{snbase.AsynchronousRemove}
-	if config.SnapshotterConfig.AllowInvalidMountsOnRestart {
-		snOpts = append(snOpts, snbase.AllowInvalidMountsOnRestart)
+	snOpts := []snapshot.Opt{snapshot.AsynchronousRemove}
+	if config.AllowInvalidMountsOnRestart {
+		snOpts = append(snOpts, snapshot.AllowInvalidMountsOnRestart)
 	}
 
-	snapshotter, err = snbase.NewSnapshotter(ctx, snapshotterRoot(root), fs, snOpts...)
+	snapshotter, err = snapshot.NewSnapshotter(ctx, snapshotterRoot(root), fs, snOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new snapshotter: %w", err)
 	}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -122,7 +122,7 @@ type snapshotter struct {
 // the root as same as overlayfs snapshotter.
 func NewSnapshotter(ctx context.Context, root string, targetFs FileSystem, opts ...Opt) (snapshots.Snapshotter, error) {
 	if targetFs == nil {
-		return nil, fmt.Errorf("Specify filesystem to use")
+		return nil, fmt.Errorf("specify filesystem to use")
 	}
 
 	var config SnapshotterConfig

--- a/store/fs.go
+++ b/store/fs.go
@@ -56,7 +56,7 @@ const (
 )
 
 func Mount(ctx context.Context, mountpoint string, layerManager *LayerManager, debug bool) error {
-	timeSec := time.Second
+	t := time.Second
 	rawFS := fusefs.NewNodeFS(&rootnode{
 		fs: &fs{
 			layerManager: layerManager,
@@ -64,8 +64,8 @@ func Mount(ctx context.Context, mountpoint string, layerManager *LayerManager, d
 			layerMap:     new(idMap),
 		},
 	}, &fusefs.Options{
-		AttrTimeout:     &timeSec,
-		EntryTimeout:    &timeSec,
+		AttrTimeout:     &t,
+		EntryTimeout:    &t,
 		NullPermissions: true,
 	})
 	mountOpts := &fuse.MountOptions{
@@ -135,7 +135,7 @@ func (n *rootnode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 			log.G(ctx).Warn("rootnode.Lookup: uknown node type detected")
 			return nil, syscall.EIO
 		}
-		out.Attr.Ino = cn.StableAttr().Ino
+		out.Ino = cn.StableAttr().Ino
 		return cn, 0
 	}
 	switch name {
@@ -145,7 +145,7 @@ func (n *rootnode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 		cn := &MemSymlinkOnForget{fusefs.MemSymlink{Data: []byte(n.fs.layerManager.refPool.root())}, n.fs, fattr}
 		copyAttr(cn.attr, &out.Attr)
 		return n.fs.newInodeWithID(ctx, func(ino uint32) fusefs.InodeEmbedder {
-			out.Attr.Ino = uint64(ino)
+			out.Ino = uint64(ino)
 			cn.attr.Ino = uint64(ino)
 			sAttr.Ino = uint64(ino)
 			fattr.Ino = uint64(ino)
@@ -170,7 +170,7 @@ func (n *rootnode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	}
 	copyAttr(&cn.attr, &out.Attr)
 	return n.fs.newInodeWithID(ctx, func(ino uint32) fusefs.InodeEmbedder {
-		out.Attr.Ino = uint64(ino)
+		out.Ino = uint64(ino)
 		cn.attr.Ino = uint64(ino)
 		sAttr.Ino = uint64(ino)
 		return n.NewPersistentInode(ctx, cn, sAttr)
@@ -207,7 +207,7 @@ func (n *refnode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (
 			log.G(ctx).Warn("refnode.Lookup: uknown node type detected")
 			return nil, syscall.EIO
 		}
-		out.Attr.Ino = cn.StableAttr().Ino
+		out.Ino = cn.StableAttr().Ino
 		return cn, 0
 	}
 	targetDigest, err := digest.Parse(name)
@@ -223,7 +223,7 @@ func (n *refnode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (
 	}
 	copyAttr(&cn.attr, &out.Attr)
 	return n.fs.newInodeWithID(ctx, func(ino uint32) fusefs.InodeEmbedder {
-		out.Attr.Ino = uint64(ino)
+		out.Ino = uint64(ino)
 		cn.attr.Ino = uint64(ino)
 		sAttr.Ino = uint64(ino)
 		return n.NewPersistentInode(ctx, cn, sAttr)
@@ -321,7 +321,7 @@ func (n *layernode) Lookup(ctx context.Context, name string, out *fuse.EntryOut)
 			log.G(ctx).Warn("layernode.Lookup: uknown node type detected")
 			return nil, syscall.EIO
 		}
-		out.Attr.Ino = cn.StableAttr().Ino
+		out.Ino = cn.StableAttr().Ino
 		return cn, 0
 	}
 	switch name {
@@ -342,7 +342,7 @@ func (n *layernode) Lookup(ctx context.Context, name string, out *fuse.EntryOut)
 		cn := &MemRegularFileOnForget{fusefs.MemRegularFile{Data: infoData}, n.fs, &fattr}
 		copyAttr(cn.attr, &out.Attr)
 		return n.fs.newInodeWithID(ctx, func(ino uint32) fusefs.InodeEmbedder {
-			out.Attr.Ino = uint64(ino)
+			out.Ino = uint64(ino)
 			cn.attr.Ino = uint64(ino)
 			sAttr.Ino = uint64(ino)
 			fattr.Ino = uint64(ino)
@@ -381,7 +381,7 @@ func (n *layernode) Lookup(ctx context.Context, name string, out *fuse.EntryOut)
 			cn := &blobnode{l: l, fs: n.fs}
 			copyAttr(&cn.attr, &out.Attr)
 			return n.fs.newInodeWithID(ctx, func(ino uint32) fusefs.InodeEmbedder {
-				out.Attr.Ino = uint64(ino)
+				out.Ino = uint64(ino)
 				cn.attr.Ino = uint64(ino)
 				sAttr.Ino = uint64(ino)
 				return n.NewPersistentInode(ctx, cn, sAttr)
@@ -408,8 +408,8 @@ func (n *layernode) Lookup(ctx context.Context, name string, out *fuse.EntryOut)
 
 			copyAttr(&out.Attr, &ao.Attr)
 			cn = n.NewPersistentInode(ctx, root, fusefs.StableAttr{
-				Mode: out.Attr.Mode,
-				Ino:  out.Attr.Ino,
+				Mode: out.Mode,
+				Ino:  out.Ino,
 			})
 			return nil
 		}()

--- a/task/task.go
+++ b/task/task.go
@@ -100,10 +100,7 @@ func (ts *BackgroundTaskManager) DonePrioritizedTask() {
 func (ts *BackgroundTaskManager) InvokeBackgroundTask(do func(context.Context), timeout time.Duration) {
 	for {
 		// Wait until all prioritized tasks are done
-		for {
-			if atomic.LoadInt64(&ts.prioritizedTasks) <= 0 {
-				break
-			}
+		for atomic.LoadInt64(&ts.prioritizedTasks) > 0 {
 
 			// waits until a prioritized task is done
 			ts.prioritizedTaskDoneCond.L.Lock()


### PR DESCRIPTION
- https://github.com/containerd/stargz-snapshotter/pull/2025

config file is migrated by `golangci-lint migrate`.