### PR TITLE
CI: Enable actions/attest-build-provenance@v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
         arch: ["amd64", "arm-v7", "arm64", "ppc64le", "s390x"]
     env:
       OUTPUT_DIR: ${{ github.workspace }}/out
+    # The maximum access is "read" for PRs from public forked repos
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      contents: read  # for checkout
+      id-token: write  # for provenances
+      attestations: write  # for provenances
     steps:
     - uses: actions/checkout@v4
     - name: Build Binary
@@ -35,6 +41,9 @@ jobs:
         SHA256SUM_FILE_NAME="${TAR_FILE_NAME}.sha256sum"
         docker build ${BUILD_ARGS} --target release-binaries -o - . | gzip > "${OUTPUT_DIR}/${TAR_FILE_NAME}"
         ( cd ${OUTPUT_DIR}; sha256sum ${TAR_FILE_NAME} ) > "${OUTPUT_DIR}/${SHA256SUM_FILE_NAME}"
+    - uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: '${{ env.OUTPUT_DIR }}/**'
     - name: Save Binary
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
https://github.com/actions/attest-build-provenance

https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/