### PR TITLE
fix no such file error for zero size file in passthrough mode

### DIFF
--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -506,7 +506,7 @@ type chunkData struct {
 func (sf *file) GetPassthroughFd(mergeBufferSize int64, mergeWorkerCount int) (uintptr, error) {
 	var (
 		offset           int64
-		firstChunkOffset int64 = -1
+		firstChunkOffset int64
 		totalSize        int64
 	)
 
@@ -515,9 +515,6 @@ func (sf *file) GetPassthroughFd(mergeBufferSize int64, mergeWorkerCount int) (u
 		chunkOffset, chunkSize, digestStr, ok := sf.fr.ChunkEntryForOffset(offset)
 		if !ok {
 			break
-		}
-		if firstChunkOffset == -1 {
-			firstChunkOffset = chunkOffset
 		}
 		chunks = append(chunks, chunkData{
 			offset:    chunkOffset,
@@ -571,10 +568,6 @@ func (sf *file) prefetchEntireFile(entireCacheID string, chunks []chunkData, tot
 		return fmt.Errorf("failed to create cache writer: %w", err)
 	}
 	defer w.Close()
-
-	if len(chunks) == 0 {
-		return nil
-	}
 
 	batchCount := (totalSize + bufferSize - 1) / bufferSize
 


### PR DESCRIPTION
When a file in the image has a size of 0, attempting to access this file results in the following error, causing a fallback to non-passthrough mode:
```
{"digest":"sha256:20e7644054a8071795c5a1da600e48b6670cc5ce1fe12c6df6b9801efc4cb1cc","error":"passThrough model failed due to node.Open: failed to open blob file for \"f70c2f92426071d3402beccba891fc5047352defec8082a8538d354f45820358\": open /var/lib/containerd-stargz-grpc/stargz/fscache/1605520682/f7/f70c2f92426071d3402beccba891fc5047352defec8082a8538d354f45820358: no such file or directory","fetchedPercent":0,"fetchedSize":0,"level":"error","msg":"statFile error","size":724,"time":"2025-05-08T17:40:41.891697643+08:00"}
```

This issue can be reproduced as follows:
```
touch zero_files

cat Dockerfile
FROM busybox

WORKDIR /data

COPY zero_files .

CMD ["sha256sum", "zero_files"]
```

This PR fixes the issue by removing the check for `len(chunks) == 0`, ensuring that even empty files can properly execute the `w.Commit()` operation.

Additionally, the initial value of `firstChunkOffset` is adjusted. Since the first chunk offset must always be 0, the previous logic could result in `firstChunkOffset` being -1 if the `if !ok { break }` branch was taken.


