### PR TITLE
Make graceful restarting available in wider configurations

### DIFF
--- a/fusemanager/fusemanager.go
+++ b/fusemanager/fusemanager.go
@@ -221,17 +221,16 @@ func runFuseManager(ctx context.Context) error {
 	return nil
 }
 
-func StartFuseManager(ctx context.Context, executable, address, fusestore, logLevel, logPath string) error {
+func StartFuseManager(ctx context.Context, executable, address, fusestore, logLevel, logPath string) (newlyStarted bool, err error) {
 	// if socket exists, do not start it
 	if _, err := os.Stat(address); err == nil {
-		return nil
+		return false, nil
 	} else if !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
 
 	if _, err := os.Stat(executable); err != nil {
-		log.G(ctx).WithError(err).Errorf("failed to stat fusemanager binary: %s", executable)
-		return err
+		return false, fmt.Errorf("failed to stat fusemanager binary: %q", executable)
 	}
 
 	args := []string{
@@ -244,12 +243,12 @@ func StartFuseManager(ctx context.Context, executable, address, fusestore, logLe
 
 	cmd := exec.Command(executable, args...)
 	if err := cmd.Start(); err != nil {
-		return err
+		return false, err
 	}
 
 	if err := cmd.Wait(); err != nil {
-		return err
+		return false, err
 	}
 
-	return nil
+	return true, nil
 }

--- a/script/integration/containerd/entrypoint.sh
+++ b/script/integration/containerd/entrypoint.sh
@@ -492,7 +492,7 @@ if [ "${BUILTIN_SNAPSHOTTER}" != "true" ] ; then
     run_and_check_remote_snapshots ctr-remote images rpull --user "${DUMMYUSER}:${DUMMYPASS}" "${REGISTRY_HOST}/alpine:esgz"
     ctr-remote run --rm --snapshotter=stargz "${REGISTRY_HOST}/alpine:esgz" test echo hi
 
-    TARGET_SIGNALS=(SIGINT)
+    TARGET_SIGNALS=(SIGINT SIGTERM)
     for S in "${TARGET_SIGNALS[@]}" ; do
         # Kill the snapshotter
         kill_all containerd-stargz-grpc "$S"

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -73,7 +73,6 @@ type SnapshotterConfig struct {
 	asyncRemove                 bool
 	noRestore                   bool
 	allowInvalidMountsOnRestart bool
-	detach                      bool
 }
 
 // Opt is an option to configure the remote snapshotter
@@ -98,11 +97,6 @@ func AllowInvalidMountsOnRestart(config *SnapshotterConfig) error {
 	return nil
 }
 
-func SetDetachFlag(config *SnapshotterConfig) error {
-	config.detach = true
-	return nil
-}
-
 type snapshotter struct {
 	root        string
 	ms          *storage.MetaStore
@@ -113,7 +107,6 @@ type snapshotter struct {
 	userxattr                   bool // whether to enable "userxattr" mount option
 	noRestore                   bool
 	allowInvalidMountsOnRestart bool
-	detach                      bool
 }
 
 // NewSnapshotter returns a Snapshotter which can use unpacked remote layers
@@ -164,7 +157,6 @@ func NewSnapshotter(ctx context.Context, root string, targetFs FileSystem, opts 
 		userxattr:                   userxattr,
 		noRestore:                   config.noRestore,
 		allowInvalidMountsOnRestart: config.allowInvalidMountsOnRestart,
-		detach:                      config.detach,
 	}
 
 	if err := o.restoreRemoteSnapshot(ctx); err != nil {
@@ -731,7 +723,7 @@ func (o *snapshotter) checkAvailability(ctx context.Context, key string) bool {
 }
 
 func (o *snapshotter) restoreRemoteSnapshot(ctx context.Context) error {
-	if o.detach {
+	if o.noRestore {
 		return nil
 	}
 
@@ -745,10 +737,6 @@ func (o *snapshotter) restoreRemoteSnapshot(ctx context.Context) error {
 				return fmt.Errorf("failed to unmount %s: %w", m.Mountpoint, err)
 			}
 		}
-	}
-
-	if o.noRestore {
-		return nil
 	}
 
 	var task []snapshots.Info


### PR DESCRIPTION
Depends on  #2076
Following up https://github.com/containerd/stargz-snapshotter/pull/1892

When stargz snapshotter receives SIGINT, it perform the graceful exit with explicitly unmounting the mountpoints and releasing the associated resources.

This PR makes this avilablable also in the following situations

- when FUSE manager is killed by SIGINT. The user can use SIGTERM and SIGINT for different porpose
  - SIGTERM: Usable for restarting only containerd-stargz-grpc (e.g. for reloading configuration). No need to unmount snapshots because they are managed by the FUSE manager.
  - SIGINT: Usable when the user wants to use the graceful exit feature of containerd-stargz-grpc because the user will kill the FUSE manager for node restart, etc.
- when containerd-stargz-grpc is killed by SIGTERM (systemd's default [KillSignal](https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html#KillSignal=))

This PR also adds docs about how to gracefully kill and restart Stargz Snapshotter under different configurations.
