### PR TITLE
Prepare for v0.17.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/containerd/stargz-snapshotter v0.15.2-0.20240622031358-6405f362966d
-	github.com/containerd/stargz-snapshotter/estargz v0.16.1
+	github.com/containerd/stargz-snapshotter/estargz v0.17.0
 	github.com/containerd/stargz-snapshotter/ipfs v0.15.2-0.20240622031358-6405f362966d
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/go-metrics v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/containerd/plugin v1.0.0
-	github.com/containerd/stargz-snapshotter/estargz v0.16.1
+	github.com/containerd/stargz-snapshotter/estargz v0.17.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v28.3.2+incompatible
 	github.com/docker/go-metrics v0.0.1


### PR DESCRIPTION
```
# Notable Changes

- New features
  - Added support for FUSE passthourgh (#1868, #1870, #1874, #1876, #1881, #1923, #1987, #2012, #2045, #2068, thanks to @wswsmao)
  - Added support for detaching FUSE server as a separated processs (FUSE manager) (#1892, #1912, #1905, thanks to @wswsmao)
  - Expanded support for graceful restarting of Stargz Snapshotter (#2077)
  - Added arm64 KIND node image (`ghcr.io/containerd/stargz-snapshotter:0.17.0-kind`) (#1983)
- Fixes and changes
  - Set maximum filename length to 255 bytes (#2024, thanks to @wswsmao)
  - Fixed EOPNOTSUPP issue on getdents64 (#2063, thanks to @wswsmao)
  - Fixed TTLCache failed to release resources on exit (#2076)
  - Fixed the configuration and docs to prevent GC failures in CRI plugin (#1893)
  - Refactored blob manipulation logic to make it more modular (#1955, thanks to @ChengyuZhu6)
- Document updates
  - Added docs about how to use Stargz Snapshotter on Lima (#1967)
  - Added docs about how to use Stargz Snapshotter with Transfer Service (#2084)
  - Improved legibility in `docs/overview.md` (#2061, thanks to @soulshake)
- CI updates
  - Added tests for wider configrations (FUSE passthrough and FUSE manager) (#2074, #2083, #1914)
  - Fixed dependabot's configuration to avoid CI failures in gomod PRs (#1920, #1941, thanks to @djdongjin)
  - Bump up `containerd/project-checks` to v1.2.2 (#2004, thanks to @wswsmao)
- Dependencies
  - Replace `harshicorp/multierror` with `errors.Join` (#1921, thanks to @djdongjin)
  - Bump up Kubernetes to v1.33 (#2078)
  - go.mod dependency updates (#1936, #1942, thanks to @thaJeztah)

For other changes, refer to the full diff: https://github.com/containerd/stargz-snapshotter/compare/v0.16.3...v0.17.0
```