### PR TITLE
Fix file exists error when restoring remote snapshot after unexpected…

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -760,10 +760,13 @@ func (o *snapshotter) restoreRemoteSnapshot(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			if err := os.Mkdir(filepath.Join(o.root, "snapshots", id), 0700); err != nil {
+			if err := os.Mkdir(filepath.Join(o.root, "snapshots", id), 0700); err != nil && !os.IsExist(err) {
 				return err
 			}
-			return os.Mkdir(o.upperPath(id), 0755)
+			if err := os.Mkdir(o.upperPath(id), 0755); err != nil && !os.IsExist(err) {
+				return err
+			}
+			return nil
 		}(); err != nil {
 			return fmt.Errorf("failed to create remote snapshot directory: %s: %w", info.Name, err)
 		}


### PR DESCRIPTION
After [PR #2076](https://github.com/containerd/stargz-snapshotter/pull/2076), in scenarios where the process restarts unexpectedly (such as due to OOM), restoring a remote snapshot may fail if the target directory already exists. For example:


```
{"error":"failed to create new snapshotter: failed to restore remote snapshot: failed to create remote snapshot directory: sha256:52fa3204fe00dd4d492873408e2ef89c13e142748931086998cc2eca69549b48: mkdir /var/lib/containerd-stargz-grpc/snapshotter/snapshots/1: file exists","level":"fatal","msg":"failed to configure snapshotter","time":"2025-07-23T12:48:12.070612675Z"}
```
This PR adjusts the logic in restoreRemoteSnapshot so that if mkdir fails because the directory already exists, it is treated as a result of an ungraceful shutdown and the process continues.
