### PR TITLE
Remove `testing` dependency from code outside tests

### DIFF
--- a/cmd/containerd-stargz-grpc/db/reader_test.go
+++ b/cmd/containerd-stargz-grpc/db/reader_test.go
@@ -29,15 +29,60 @@ import (
 )
 
 func TestReader(t *testing.T) {
-	testutil.TestReader(t, newTestableReader)
+	testRunner := &testutil.TestRunner{
+		TestingT: t,
+		Runner: func(testingT testutil.TestingT, name string, run func(t testutil.TestingT)) {
+			tt, ok := testingT.(*testing.T)
+			if !ok {
+				testingT.Fatal("TestingT is not a *testing.T")
+				return
+			}
+
+			tt.Run(name, func(t *testing.T) {
+				run(t)
+			})
+		},
+	}
+
+	testutil.TestReader(testRunner, newTestableReader)
 }
 
 func TestFSReader(t *testing.T) {
-	fsreader.TestSuiteReader(t, newStore)
+	testRunner := &fsreader.TestRunner{
+		TestingT: t,
+		Runner: func(testingT fsreader.TestingT, name string, run func(t fsreader.TestingT)) {
+			tt, ok := testingT.(*testing.T)
+			if !ok {
+				testingT.Fatal("TestingT is not a *testing.T")
+				return
+			}
+
+			tt.Run(name, func(t *testing.T) {
+				run(t)
+			})
+		},
+	}
+
+	fsreader.TestSuiteReader(testRunner, newStore)
 }
 
 func TestFSLayer(t *testing.T) {
-	layer.TestSuiteLayer(t, newStore)
+	testRunner := &layer.TestRunner{
+		TestingT: t,
+		Runner: func(testingT layer.TestingT, name string, run func(t layer.TestingT)) {
+			tt, ok := testingT.(*testing.T)
+			if !ok {
+				testingT.Fatal("TestingT is not a *testing.T")
+				return
+			}
+
+			tt.Run(name, func(t *testing.T) {
+				run(t)
+			})
+		},
+	}
+
+	layer.TestSuiteLayer(testRunner, newStore)
 }
 
 func newTestableReader(sr *io.SectionReader, opts ...metadata.Option) (testutil.TestableReader, error) {

--- a/estargz/externaltoc/externaltoc_test.go
+++ b/estargz/externaltoc/externaltoc_test.go
@@ -27,7 +27,22 @@ import (
 
 // TestGzipEStargz tests gzip-based external TOC eStargz
 func TestGzipEStargz(t *testing.T) {
-	estargz.CompressionTestSuite(t,
+	testRunner := &estargz.TestRunner{
+		TestingT: t,
+		Runner: func(testingT estargz.TestingT, name string, run func(t estargz.TestingT)) {
+			tt, ok := testingT.(*testing.T)
+			if !ok {
+				testingT.Fatal("TestingT is not a *testing.T")
+				return
+			}
+
+			tt.Run(name, func(t *testing.T) {
+				run(t)
+			})
+		},
+	}
+
+	estargz.CompressionTestSuite(testRunner,
 		gzipControllerWithLevel(gzip.NoCompression),
 		gzipControllerWithLevel(gzip.BestSpeed),
 		gzipControllerWithLevel(gzip.BestCompression),
@@ -60,11 +75,11 @@ func (gc *gzipController) String() string {
 }
 
 // TestStream tests the passed estargz blob contains the specified list of streams.
-func (gc *gzipController) TestStreams(t *testing.T, b []byte, streams []int64) {
+func (gc *gzipController) TestStreams(t estargz.TestingT, b []byte, streams []int64) {
 	estargz.CheckGzipHasStreams(t, b, streams)
 }
 
-func (gc *gzipController) DiffIDOf(t *testing.T, b []byte) string {
+func (gc *gzipController) DiffIDOf(t estargz.TestingT, b []byte) string {
 	return estargz.GzipDiffIDOf(t, b)
 }
 

--- a/estargz/gzip_test.go
+++ b/estargz/gzip_test.go
@@ -31,7 +31,22 @@ import (
 
 // TestGzipEStargz tests gzip-based eStargz
 func TestGzipEStargz(t *testing.T) {
-	CompressionTestSuite(t,
+	testRunner := &TestRunner{
+		TestingT: t,
+		Runner: func(testingT TestingT, name string, run func(t TestingT)) {
+			tt, ok := testingT.(*testing.T)
+			if !ok {
+				testingT.Fatal("TestingT is not a *testing.T")
+				return
+			}
+
+			tt.Run(name, func(t *testing.T) {
+				run(t)
+			})
+		},
+	}
+
+	CompressionTestSuite(testRunner,
 		gzipControllerWithLevel(gzip.NoCompression),
 		gzipControllerWithLevel(gzip.BestSpeed),
 		gzipControllerWithLevel(gzip.BestCompression),
@@ -56,11 +71,11 @@ func (gc *gzipController) String() string {
 }
 
 // TestStream tests the passed estargz blob contains the specified list of streams.
-func (gc *gzipController) TestStreams(t *testing.T, b []byte, streams []int64) {
+func (gc *gzipController) TestStreams(t TestingT, b []byte, streams []int64) {
 	CheckGzipHasStreams(t, b, streams)
 }
 
-func (gc *gzipController) DiffIDOf(t *testing.T, b []byte) string {
+func (gc *gzipController) DiffIDOf(t TestingT, b []byte) string {
 	return GzipDiffIDOf(t, b)
 }
 

--- a/estargz/testutil.go
+++ b/estargz/testutil.go
@@ -38,7 +38,6 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/containerd/stargz-snapshotter/estargz/errorutil"
@@ -49,16 +48,48 @@ import (
 // TestingController is Compression with some helper methods necessary for testing.
 type TestingController interface {
 	Compression
-	TestStreams(t *testing.T, b []byte, streams []int64)
-	DiffIDOf(*testing.T, []byte) string
+	TestStreams(t TestingT, b []byte, streams []int64)
+	DiffIDOf(TestingT, []byte) string
 	String() string
 }
 
+// TestingT is the minimal set of testing.T required to run the
+// tests defined in CompressionTestSuite. This interface exists to prevent
+// leaking the testing package from being exposed outside tests.
+type TestingT interface {
+	Errorf(format string, args ...any)
+	FailNow()
+	Failed() bool
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Logf(format string, args ...any)
+	Parallel()
+}
+
+// Runner allows running subtests of TestingT. This exists instead of adding
+// a Run method to TestingT interface because the Run implementation of
+// testing.T would not satisfy the interface.
+type Runner func(t TestingT, name string, fn func(t TestingT))
+
+type TestRunner struct {
+	TestingT
+	Runner Runner
+}
+
+func (r *TestRunner) Run(name string, run func(*TestRunner)) {
+	r.Runner(r.TestingT, name, func(t TestingT) {
+		run(&TestRunner{TestingT: t, Runner: r.Runner})
+	})
+}
+
 // CompressionTestSuite tests this pkg with controllers can build valid eStargz blobs and parse them.
-func CompressionTestSuite(t *testing.T, controllers ...TestingControllerFactory) {
-	t.Run("testBuild", func(t *testing.T) { t.Parallel(); testBuild(t, controllers...) })
-	t.Run("testDigestAndVerify", func(t *testing.T) { t.Parallel(); testDigestAndVerify(t, controllers...) })
-	t.Run("testWriteAndOpen", func(t *testing.T) { t.Parallel(); testWriteAndOpen(t, controllers...) })
+func CompressionTestSuite(t *TestRunner, controllers ...TestingControllerFactory) {
+	t.Run("testBuild", func(t *TestRunner) { t.Parallel(); testBuild(t, controllers...) })
+	t.Run("testDigestAndVerify", func(t *TestRunner) {
+		t.Parallel()
+		testDigestAndVerify(t, controllers...)
+	})
+	t.Run("testWriteAndOpen", func(t *TestRunner) { t.Parallel(); testWriteAndOpen(t, controllers...) })
 }
 
 type TestingControllerFactory func() TestingController
@@ -79,7 +110,7 @@ var allowedPrefix = [4]string{"", "./", "/", "../"}
 
 // testBuild tests the resulting stargz blob built by this pkg has the same
 // contents as the normal stargz blob.
-func testBuild(t *testing.T, controllers ...TestingControllerFactory) {
+func testBuild(t *TestRunner, controllers ...TestingControllerFactory) {
 	tests := []struct {
 		name         string
 		chunkSize    int
@@ -165,7 +196,7 @@ func testBuild(t *testing.T, controllers ...TestingControllerFactory) {
 						prefix := prefix
 						for _, minChunkSize := range tt.minChunkSize {
 							minChunkSize := minChunkSize
-							t.Run(tt.name+"-"+fmt.Sprintf("compression=%v,prefix=%q,src=%d,format=%s,minChunkSize=%d", newCL(), prefix, srcCompression, srcTarFormat, minChunkSize), func(t *testing.T) {
+							t.Run(tt.name+"-"+fmt.Sprintf("compression=%v,prefix=%q,src=%d,format=%s,minChunkSize=%d", newCL(), prefix, srcCompression, srcTarFormat, minChunkSize), func(t *TestRunner) {
 								tarBlob := buildTar(t, tt.in, prefix, srcTarFormat)
 								// Test divideEntries()
 								entries, err := sortEntries(tarBlob, nil, nil) // identical order
@@ -265,7 +296,7 @@ func testBuild(t *testing.T, controllers ...TestingControllerFactory) {
 	}
 }
 
-func isSameTarGz(t *testing.T, cla TestingController, a []byte, clb TestingController, b []byte) bool {
+func isSameTarGz(t TestingT, cla TestingController, a []byte, clb TestingController, b []byte) bool {
 	aGz, err := cla.Reader(bytes.NewReader(a))
 	if err != nil {
 		t.Fatalf("failed to read A")
@@ -325,7 +356,7 @@ func isSameTarGz(t *testing.T, cla TestingController, a []byte, clb TestingContr
 	return true
 }
 
-func isSameVersion(t *testing.T, cla TestingController, a []byte, clb TestingController, b []byte) bool {
+func isSameVersion(t TestingT, cla TestingController, a []byte, clb TestingController, b []byte) bool {
 	aJTOC, _, err := parseStargz(io.NewSectionReader(bytes.NewReader(a), 0, int64(len(a))), cla)
 	if err != nil {
 		t.Fatalf("failed to parse A: %v", err)
@@ -339,7 +370,7 @@ func isSameVersion(t *testing.T, cla TestingController, a []byte, clb TestingCon
 	return aJTOC.Version == bJTOC.Version
 }
 
-func isSameEntries(t *testing.T, a, b *Reader) bool {
+func isSameEntries(t TestingT, a, b *Reader) bool {
 	aroot, ok := a.Lookup("")
 	if !ok {
 		t.Fatalf("failed to get root of A")
@@ -353,7 +384,7 @@ func isSameEntries(t *testing.T, a, b *Reader) bool {
 	return contains(t, aEntry, bEntry) && contains(t, bEntry, aEntry)
 }
 
-func compressBlob(t *testing.T, src *io.SectionReader, srcCompression int) *io.SectionReader {
+func compressBlob(t TestingT, src *io.SectionReader, srcCompression int) *io.SectionReader {
 	buf := new(bytes.Buffer)
 	var w io.WriteCloser
 	var err error
@@ -387,7 +418,7 @@ type stargzEntry struct {
 
 // contains checks if all child entries in "b" are also contained in "a".
 // This function also checks if the files/chunks contain the same contents among "a" and "b".
-func contains(t *testing.T, a, b stargzEntry) bool {
+func contains(t TestingT, a, b stargzEntry) bool {
 	ae, ar := a.e, a.r
 	be, br := b.e, b.r
 	t.Logf("Comparing: %q vs %q", ae.Name, be.Name)
@@ -498,7 +529,7 @@ func equalEntry(a, b *TOCEntry) bool {
 		a.Digest == b.Digest
 }
 
-func readOffset(t *testing.T, r *io.SectionReader, offset int64, e stargzEntry) ([]byte, int64, bool) {
+func readOffset(t TestingT, r *io.SectionReader, offset int64, e stargzEntry) ([]byte, int64, bool) {
 	ce, ok := e.r.ChunkEntryForOffset(e.e.Name, offset)
 	if !ok {
 		return nil, 0, false
@@ -517,7 +548,7 @@ func readOffset(t *testing.T, r *io.SectionReader, offset int64, e stargzEntry) 
 	return data[:n], offset + ce.ChunkSize, true
 }
 
-func dumpTOCJSON(t *testing.T, tocJSON *JTOC) string {
+func dumpTOCJSON(t TestingT, tocJSON *JTOC) string {
 	jtocData, err := json.Marshal(*tocJSON)
 	if err != nil {
 		t.Fatalf("failed to marshal TOC JSON: %v", err)
@@ -531,20 +562,19 @@ func dumpTOCJSON(t *testing.T, tocJSON *JTOC) string {
 
 const chunkSize = 3
 
-// type check func(t *testing.T, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, compressionLevel int)
-type check func(t *testing.T, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory)
+type check func(t *TestRunner, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory)
 
 // testDigestAndVerify runs specified checks against sample stargz blobs.
-func testDigestAndVerify(t *testing.T, controllers ...TestingControllerFactory) {
+func testDigestAndVerify(t *TestRunner, controllers ...TestingControllerFactory) {
 	tests := []struct {
 		name         string
-		tarInit      func(t *testing.T, dgstMap map[string]digest.Digest) (blob []tarEntry)
+		tarInit      func(t TestingT, dgstMap map[string]digest.Digest) (blob []tarEntry)
 		checks       []check
 		minChunkSize []int
 	}{
 		{
 			name: "no-regfile",
-			tarInit: func(t *testing.T, dgstMap map[string]digest.Digest) (blob []tarEntry) {
+			tarInit: func(t TestingT, dgstMap map[string]digest.Digest) (blob []tarEntry) {
 				return tarOf(
 					dir("test/"),
 				)
@@ -559,7 +589,7 @@ func testDigestAndVerify(t *testing.T, controllers ...TestingControllerFactory) 
 		},
 		{
 			name: "small-files",
-			tarInit: func(t *testing.T, dgstMap map[string]digest.Digest) (blob []tarEntry) {
+			tarInit: func(t TestingT, dgstMap map[string]digest.Digest) (blob []tarEntry) {
 				return tarOf(
 					regDigest(t, "baz.txt", "", dgstMap),
 					regDigest(t, "foo.txt", "a", dgstMap),
@@ -583,7 +613,7 @@ func testDigestAndVerify(t *testing.T, controllers ...TestingControllerFactory) 
 		},
 		{
 			name: "big-files",
-			tarInit: func(t *testing.T, dgstMap map[string]digest.Digest) (blob []tarEntry) {
+			tarInit: func(t TestingT, dgstMap map[string]digest.Digest) (blob []tarEntry) {
 				return tarOf(
 					regDigest(t, "baz.txt", "bazbazbazbazbazbazbaz", dgstMap),
 					regDigest(t, "foo.txt", "a", dgstMap),
@@ -607,7 +637,7 @@ func testDigestAndVerify(t *testing.T, controllers ...TestingControllerFactory) 
 		{
 			name:         "with-non-regfiles",
 			minChunkSize: []int{0, 64000},
-			tarInit: func(t *testing.T, dgstMap map[string]digest.Digest) (blob []tarEntry) {
+			tarInit: func(t TestingT, dgstMap map[string]digest.Digest) (blob []tarEntry) {
 				return tarOf(
 					regDigest(t, "baz.txt", "bazbazbazbazbazbazbaz", dgstMap),
 					regDigest(t, "foo.txt", "a", dgstMap),
@@ -654,7 +684,7 @@ func testDigestAndVerify(t *testing.T, controllers ...TestingControllerFactory) 
 						srcTarFormat := srcTarFormat
 						for _, minChunkSize := range tt.minChunkSize {
 							minChunkSize := minChunkSize
-							t.Run(tt.name+"-"+fmt.Sprintf("compression=%v,prefix=%q,format=%s,minChunkSize=%d", newCL(), prefix, srcTarFormat, minChunkSize), func(t *testing.T) {
+							t.Run(tt.name+"-"+fmt.Sprintf("compression=%v,prefix=%q,format=%s,minChunkSize=%d", newCL(), prefix, srcTarFormat, minChunkSize), func(t *TestRunner) {
 								// Get original tar file and chunk digests
 								dgstMap := make(map[string]digest.Digest)
 								tarBlob := buildTar(t, tt.tarInit(t, dgstMap), prefix, srcTarFormat)
@@ -690,7 +720,7 @@ func testDigestAndVerify(t *testing.T, controllers ...TestingControllerFactory) 
 // checkStargzTOC checks the TOC JSON of the passed stargz has the expected
 // digest and contains valid chunks. It walks all entries in the stargz and
 // checks all chunk digests stored to the TOC JSON match the actual contents.
-func checkStargzTOC(t *testing.T, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory) {
+func checkStargzTOC(t *TestRunner, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory) {
 	sgz, err := Open(
 		io.NewSectionReader(bytes.NewReader(sgzData), 0, int64(len(sgzData))),
 		WithDecompressors(controller),
@@ -801,7 +831,7 @@ func checkStargzTOC(t *testing.T, sgzData []byte, tocDigest digest.Digest, dgstM
 // checkVerifyTOC checks the verification works for the TOC JSON of the passed
 // stargz. It walks all entries in the stargz and checks the verifications for
 // all chunks work.
-func checkVerifyTOC(t *testing.T, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory) {
+func checkVerifyTOC(t *TestRunner, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory) {
 	sgz, err := Open(
 		io.NewSectionReader(bytes.NewReader(sgzData), 0, int64(len(sgzData))),
 		WithDecompressors(controller),
@@ -882,9 +912,9 @@ func checkVerifyTOC(t *testing.T, sgzData []byte, tocDigest digest.Digest, dgstM
 // checkVerifyInvalidTOCEntryFail checks if misconfigured TOC JSON can be
 // detected during the verification and the verification returns an error.
 func checkVerifyInvalidTOCEntryFail(filename string) check {
-	return func(t *testing.T, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory) {
+	return func(t *TestRunner, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory) {
 		funcs := map[string]rewriteFunc{
-			"lost digest in a entry": func(t *testing.T, toc *JTOC, sgz *io.SectionReader) {
+			"lost digest in a entry": func(t TestingT, toc *JTOC, sgz *io.SectionReader) {
 				var found bool
 				for _, e := range toc.Entries {
 					if cleanEntryName(e.Name) == filename {
@@ -902,7 +932,7 @@ func checkVerifyInvalidTOCEntryFail(filename string) check {
 					t.Fatalf("rewrite target not found")
 				}
 			},
-			"duplicated entry offset": func(t *testing.T, toc *JTOC, sgz *io.SectionReader) {
+			"duplicated entry offset": func(t TestingT, toc *JTOC, sgz *io.SectionReader) {
 				var (
 					sampleEntry *TOCEntry
 					targetEntry *TOCEntry
@@ -929,7 +959,7 @@ func checkVerifyInvalidTOCEntryFail(filename string) check {
 		}
 
 		for name, rFunc := range funcs {
-			t.Run(name, func(t *testing.T) {
+			t.Run(name, func(t *TestRunner) {
 				newSgz, newTocDigest := rewriteTOCJSON(t, io.NewSectionReader(bytes.NewReader(sgzData), 0, int64(len(sgzData))), rFunc, controller)
 				buf := new(bytes.Buffer)
 				if _, err := io.Copy(buf, newSgz); err != nil {
@@ -958,7 +988,7 @@ func checkVerifyInvalidTOCEntryFail(filename string) check {
 // checkVerifyInvalidStargzFail checks if the verification detects that the
 // given stargz file doesn't match to the expected digest and returns error.
 func checkVerifyInvalidStargzFail(invalid *io.SectionReader) check {
-	return func(t *testing.T, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory) {
+	return func(t *TestRunner, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory) {
 		cl := newController()
 		rc, err := Build(invalid, WithChunkSize(chunkSize), WithCompression(cl))
 		if err != nil {
@@ -990,7 +1020,7 @@ func checkVerifyInvalidStargzFail(invalid *io.SectionReader) check {
 // checkVerifyBrokenContentFail checks if the verifier detects broken contents
 // that doesn't match to the expected digest and returns error.
 func checkVerifyBrokenContentFail(filename string) check {
-	return func(t *testing.T, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory) {
+	return func(t *TestRunner, sgzData []byte, tocDigest digest.Digest, dgstMap map[string]digest.Digest, controller TestingController, newController TestingControllerFactory) {
 		// Parse stargz file
 		sgz, err := Open(
 			io.NewSectionReader(bytes.NewReader(sgzData), 0, int64(len(sgzData))),
@@ -1047,9 +1077,9 @@ func chunkID(name string, offset, size int64) string {
 	return fmt.Sprintf("%s-%d-%d", cleanEntryName(name), offset, size)
 }
 
-type rewriteFunc func(t *testing.T, toc *JTOC, sgz *io.SectionReader)
+type rewriteFunc func(t TestingT, toc *JTOC, sgz *io.SectionReader)
 
-func rewriteTOCJSON(t *testing.T, sgz *io.SectionReader, rewrite rewriteFunc, controller TestingController) (newSgz io.Reader, tocDigest digest.Digest) {
+func rewriteTOCJSON(t TestingT, sgz *io.SectionReader, rewrite rewriteFunc, controller TestingController) (newSgz io.Reader, tocDigest digest.Digest) {
 	decodedJTOC, jtocOffset, err := parseStargz(sgz, controller)
 	if err != nil {
 		t.Fatalf("failed to extract TOC JSON: %v", err)
@@ -1120,7 +1150,7 @@ func parseStargz(sgz *io.SectionReader, controller TestingController) (decodedJT
 	return decodedJTOC, tocOffset, nil
 }
 
-func testWriteAndOpen(t *testing.T, controllers ...TestingControllerFactory) {
+func testWriteAndOpen(t *TestRunner, controllers ...TestingControllerFactory) {
 	const content = "Some contents"
 	invalidUtf8 := "\xff\xfe\xfd"
 
@@ -1464,7 +1494,7 @@ func testWriteAndOpen(t *testing.T, controllers ...TestingControllerFactory) {
 				for _, srcTarFormat := range []tar.Format{tar.FormatUSTAR, tar.FormatPAX, tar.FormatGNU} {
 					srcTarFormat := srcTarFormat
 					for _, lossless := range []bool{true, false} {
-						t.Run(tt.name+"-"+fmt.Sprintf("compression=%v,prefix=%q,lossless=%v,format=%s", newCL(), prefix, lossless, srcTarFormat), func(t *testing.T) {
+						t.Run(tt.name+"-"+fmt.Sprintf("compression=%v,prefix=%q,lossless=%v,format=%s", newCL(), prefix, lossless, srcTarFormat), func(t *TestRunner) {
 							var tr io.Reader = buildTar(t, tt.in, prefix, srcTarFormat)
 							origTarDgstr := digest.Canonical.Digester()
 							tr = io.TeeReader(tr, origTarDgstr.Hash())
@@ -1628,7 +1658,7 @@ func digestFor(content string) string {
 
 type numTOCEntries int
 
-func (n numTOCEntries) check(t *testing.T, r *Reader) {
+func (n numTOCEntries) check(t TestingT, r *Reader) {
 	if r.toc == nil {
 		t.Fatal("nil TOC")
 	}
@@ -1648,15 +1678,15 @@ func (n numTOCEntries) check(t *testing.T, r *Reader) {
 func checks(s ...stargzCheck) []stargzCheck { return s }
 
 type stargzCheck interface {
-	check(t *testing.T, r *Reader)
+	check(t TestingT, r *Reader)
 }
 
-type stargzCheckFn func(*testing.T, *Reader)
+type stargzCheckFn func(TestingT, *Reader)
 
-func (f stargzCheckFn) check(t *testing.T, r *Reader) { f(t, r) }
+func (f stargzCheckFn) check(t TestingT, r *Reader) { f(t, r) }
 
 func maxDepth(max int) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		e, ok := r.Lookup("")
 		if !ok {
 			t.Fatal("root directory not found")
@@ -1673,7 +1703,7 @@ func maxDepth(max int) stargzCheck {
 	})
 }
 
-func getMaxDepth(t *testing.T, e *TOCEntry, current, limit int) (max int, rErr error) {
+func getMaxDepth(t TestingT, e *TOCEntry, current, limit int) (max int, rErr error) {
 	if current > limit {
 		return -1, fmt.Errorf("walkMaxDepth: exceeds limit: current:%d > limit:%d",
 			current, limit)
@@ -1695,7 +1725,7 @@ func getMaxDepth(t *testing.T, e *TOCEntry, current, limit int) (max int, rErr e
 }
 
 func hasFileLen(file string, wantLen int) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		for _, ent := range r.toc.Entries {
 			if ent.Name == file {
 				if ent.Type != "reg" {
@@ -1711,7 +1741,7 @@ func hasFileLen(file string, wantLen int) stargzCheck {
 }
 
 func hasFileXattrs(file, name, value string) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		for _, ent := range r.toc.Entries {
 			if ent.Name == file {
 				if ent.Type != "reg" {
@@ -1738,7 +1768,7 @@ func hasFileXattrs(file, name, value string) stargzCheck {
 }
 
 func hasFileDigest(file string, digest string) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		ent, ok := r.Lookup(file)
 		if !ok {
 			t.Fatalf("didn't find TOCEntry for file %q", file)
@@ -1750,7 +1780,7 @@ func hasFileDigest(file string, digest string) stargzCheck {
 }
 
 func hasFileContentsWithPreRead(file string, offset int, want string, extra ...chunkInfo) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		extraMap := make(map[string]chunkInfo)
 		for _, e := range extra {
 			extraMap[e.name] = e
@@ -1797,7 +1827,7 @@ func hasFileContentsWithPreRead(file string, offset int, want string, extra ...c
 }
 
 func hasFileContentsRange(file string, offset int, want string) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		f, err := r.OpenFile(file)
 		if err != nil {
 			t.Fatal(err)
@@ -1814,7 +1844,7 @@ func hasFileContentsRange(file string, offset int, want string) stargzCheck {
 }
 
 func hasChunkEntries(file string, wantChunks int) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		ent, ok := r.Lookup(file)
 		if !ok {
 			t.Fatalf("no file for %q", file)
@@ -1858,7 +1888,7 @@ func hasChunkEntries(file string, wantChunks int) stargzCheck {
 }
 
 func entryHasChildren(dir string, want ...string) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		want := append([]string(nil), want...)
 		var got []string
 		ent, ok := r.Lookup(dir)
@@ -1877,7 +1907,7 @@ func entryHasChildren(dir string, want ...string) stargzCheck {
 }
 
 func hasDir(file string) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		for _, ent := range r.toc.Entries {
 			if ent.Name == cleanEntryName(file) {
 				if ent.Type != "dir" {
@@ -1891,7 +1921,7 @@ func hasDir(file string) stargzCheck {
 }
 
 func hasDirLinkCount(file string, count int) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		for _, ent := range r.toc.Entries {
 			if ent.Name == cleanEntryName(file) {
 				if ent.Type != "dir" {
@@ -1909,7 +1939,7 @@ func hasDirLinkCount(file string, count int) stargzCheck {
 }
 
 func hasMode(file string, mode os.FileMode) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		for _, ent := range r.toc.Entries {
 			if ent.Name == cleanEntryName(file) {
 				if ent.Stat().Mode() != mode {
@@ -1924,7 +1954,7 @@ func hasMode(file string, mode os.FileMode) stargzCheck {
 }
 
 func hasSymlink(file, target string) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		for _, ent := range r.toc.Entries {
 			if ent.Name == file {
 				if ent.Type != "symlink" {
@@ -1940,7 +1970,7 @@ func hasSymlink(file, target string) stargzCheck {
 }
 
 func lookupMatch(name string, want *TOCEntry) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		e, ok := r.Lookup(name)
 		if !ok {
 			t.Fatalf("failed to Lookup entry %q", name)
@@ -1953,7 +1983,7 @@ func lookupMatch(name string, want *TOCEntry) stargzCheck {
 }
 
 func hasEntryOwner(entry string, owner owner) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		ent, ok := r.Lookup(strings.TrimSuffix(entry, "/"))
 		if !ok {
 			t.Errorf("entry %q not found", entry)
@@ -1967,7 +1997,7 @@ func hasEntryOwner(entry string, owner owner) stargzCheck {
 }
 
 func mustSameEntry(files ...string) stargzCheck {
-	return stargzCheckFn(func(t *testing.T, r *Reader) {
+	return stargzCheckFn(func(t TestingT, r *Reader) {
 		var first *TOCEntry
 		for _, f := range files {
 			if first == nil {
@@ -2039,7 +2069,7 @@ func (f tarEntryFunc) appendTar(tw *tar.Writer, prefix string, format tar.Format
 	return f(tw, prefix, format)
 }
 
-func buildTar(t *testing.T, ents []tarEntry, prefix string, opts ...interface{}) *io.SectionReader {
+func buildTar(t TestingT, ents []tarEntry, prefix string, opts ...interface{}) *io.SectionReader {
 	format := tar.FormatUnknown
 	for _, opt := range opts {
 		switch v := opt.(type) {
@@ -2248,7 +2278,7 @@ func noPrefetchLandmark() tarEntry {
 	})
 }
 
-func regDigest(t *testing.T, name string, contentStr string, digestMap map[string]digest.Digest) tarEntry {
+func regDigest(t TestingT, name string, contentStr string, digestMap map[string]digest.Digest) tarEntry {
 	if digestMap == nil {
 		t.Fatalf("digest map mustn't be nil")
 	}
@@ -2318,7 +2348,7 @@ func (f fileInfoOnlyMode) ModTime() time.Time { return time.Now() }
 func (f fileInfoOnlyMode) IsDir() bool        { return os.FileMode(f).IsDir() }
 func (f fileInfoOnlyMode) Sys() interface{}   { return nil }
 
-func CheckGzipHasStreams(t *testing.T, b []byte, streams []int64) {
+func CheckGzipHasStreams(t TestingT, b []byte, streams []int64) {
 	if len(streams) == 0 {
 		return // nop
 	}
@@ -2356,7 +2386,7 @@ func CheckGzipHasStreams(t *testing.T, b []byte, streams []int64) {
 	}
 }
 
-func GzipDiffIDOf(t *testing.T, b []byte) string {
+func GzipDiffIDOf(t TestingT, b []byte) string {
 	h := sha256.New()
 	zr, err := gzip.NewReader(bytes.NewReader(b))
 	if err != nil {

--- a/fs/layer/layer_test.go
+++ b/fs/layer/layer_test.go
@@ -30,7 +30,22 @@ import (
 )
 
 func TestLayer(t *testing.T) {
-	TestSuiteLayer(t, memorymetadata.NewReader)
+	testRunner := &TestRunner{
+		TestingT: t,
+		Runner: func(testingT TestingT, name string, run func(t TestingT)) {
+			tt, ok := testingT.(*testing.T)
+			if !ok {
+				testingT.Fatal("TestingT is not a *testing.T")
+				return
+			}
+
+			tt.Run(name, func(t *testing.T) {
+				run(t)
+			})
+		},
+	}
+
+	TestSuiteLayer(testRunner, memorymetadata.NewReader)
 }
 
 func TestWaiter(t *testing.T) {

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -39,7 +39,6 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"testing"
 	"time"
 
 	"github.com/containerd/containerd/v2/pkg/reference"
@@ -76,7 +75,33 @@ type layerConfig struct {
 	passThroughConfig passThroughConfig
 }
 
-func TestSuiteLayer(t *testing.T, store metadata.Store) {
+// TestingT is the minimal set of testing.T required to run the
+// tests defined in TestSuiteLayer. This interface exists to prevent
+// leaking the testing package from being exposed outside tests.
+type TestingT interface {
+	Errorf(format string, args ...any)
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Logf(format string, args ...any)
+}
+
+// Runner allows running subtests of TestingT. This exists instead of adding
+// a Run method to TestingT interface because the Run implementation of
+// testing.T would not satisfy the interface.
+type Runner func(t TestingT, name string, fn func(t TestingT))
+
+type TestRunner struct {
+	TestingT
+	Runner Runner
+}
+
+func (r *TestRunner) Run(name string, run func(*TestRunner)) {
+	r.Runner(r.TestingT, name, func(t TestingT) {
+		run(&TestRunner{TestingT: t, Runner: r.Runner})
+	})
+}
+
+func TestSuiteLayer(t *TestRunner, store metadata.Store) {
 	for _, lc := range []layerConfig{
 		{
 			name: "default",
@@ -117,14 +142,14 @@ func TestSuiteLayer(t *testing.T, store metadata.Store) {
 
 var testStateLayerDigest = digest.FromString("dummy")
 
-func testPrefetch(t *testing.T, factory metadata.Store, lc layerConfig) {
+func testPrefetch(t *TestRunner, factory metadata.Store, lc layerConfig) {
 	randomData, err := tutil.RandomBytes(64000)
 	if err != nil {
 		t.Fatalf("failed rand.Read: %v", err)
 	}
 	data64KB := string(randomData)
 	defaultPrefetchSize := int64(10000)
-	landmarkPosition := func(t *testing.T, l *layer) int64 {
+	landmarkPosition := func(t TestingT, l *layer) int64 {
 		if l.r == nil {
 			t.Fatalf("layer hasn't been verified yet")
 		}
@@ -144,7 +169,7 @@ func testPrefetch(t *testing.T, factory metadata.Store, lc layerConfig) {
 		in               []tutil.TarEntry
 		wantNum          int      // number of chunks wanted in the cache
 		wants            []string // filenames to compare
-		prefetchSize     func(*testing.T, *layer) int64
+		prefetchSize     func(TestingT, *layer) int64
 		prioritizedFiles []string
 	}{
 		{
@@ -222,7 +247,7 @@ func testPrefetch(t *testing.T, factory metadata.Store, lc layerConfig) {
 	for _, tt := range tests {
 		for srcCompressionName, srcCompression := range srcCompressions {
 			cl := srcCompression()
-			t.Run("testPrefetch-"+tt.name+"-"+srcCompressionName+"-"+lc.name, func(t *testing.T) {
+			t.Run("testPrefetch-"+tt.name+"-"+srcCompressionName+"-"+lc.name, func(t *TestRunner) {
 				chunkSize := sampleChunkSize
 				if tt.chunkSize > 0 {
 					chunkSize = tt.chunkSize
@@ -349,7 +374,7 @@ func isDup(a, b region) bool {
 	return b.end >= a.begin
 }
 
-func newBlob(t *testing.T, sr *io.SectionReader) *sampleBlob {
+func newBlob(t TestingT, sr *io.SectionReader) *sampleBlob {
 	return &sampleBlob{
 		t: t,
 		r: sr,
@@ -357,7 +382,7 @@ func newBlob(t *testing.T, sr *io.SectionReader) *sampleBlob {
 }
 
 type sampleBlob struct {
-	t *testing.T
+	t TestingT
 
 	r                    *io.SectionReader
 	readCalled           bool
@@ -422,7 +447,7 @@ const (
 	lastChunkOffset1   = sampleChunkSize * (int64(len(sampleData1)) / sampleChunkSize)
 )
 
-func testNodeRead(t *testing.T, factory metadata.Store, lc layerConfig) {
+func testNodeRead(t *TestRunner, factory metadata.Store, lc layerConfig) {
 	sizeCond := map[string]int64{
 		"single_chunk": sampleChunkSize - sampleMiddleOffset,
 		"multi_chunks": sampleChunkSize + sampleMiddleOffset,
@@ -447,7 +472,7 @@ func testNodeRead(t *testing.T, factory metadata.Store, lc layerConfig) {
 				for fn, filesize := range fileSizeCond {
 					for _, srcCompression := range srcCompressions {
 						cl := srcCompression()
-						t.Run(fmt.Sprintf("reading_%s_%s_%s_%s_%s", sn, in, bo, fn, lc.name), func(t *testing.T) {
+						t.Run(fmt.Sprintf("reading_%s_%s_%s_%s_%s", sn, in, bo, fn, lc.name), func(t *TestRunner) {
 							if filesize > int64(len(sampleData1)) {
 								t.Fatal("sample file size is larger than sample data")
 							}
@@ -502,7 +527,7 @@ func testNodeRead(t *testing.T, factory metadata.Store, lc layerConfig) {
 	}
 }
 
-func makeNodeReader(t *testing.T, contents []byte, chunkSize int, factory metadata.Store, cl tutil.Compression, lc layerConfig) (_ *file, closeFn func() error) {
+func makeNodeReader(t TestingT, contents []byte, chunkSize int, factory metadata.Store, cl tutil.Compression, lc layerConfig) (_ *file, closeFn func() error) {
 	testName := "test"
 	sr, tocDgst, err := tutil.BuildEStargz(
 		[]tutil.TarEntry{tutil.File(testName, string(contents))},
@@ -530,20 +555,20 @@ func makeNodeReader(t *testing.T, contents []byte, chunkSize int, factory metada
 	return f.(*file), r.Close
 }
 
-func testNodes(t *testing.T, factory metadata.Store, lc layerConfig) {
+func testNodes(t *TestRunner, factory metadata.Store, lc layerConfig) {
 	for _, o := range []OverlayOpaqueType{OverlayOpaqueAll, OverlayOpaqueTrusted, OverlayOpaqueUser} {
 		testNodesWithOpaque(t, factory, o, lc)
 	}
 }
 
-func testNodesWithOpaque(t *testing.T, factory metadata.Store, opaque OverlayOpaqueType, lc layerConfig) {
+func testNodesWithOpaque(t *TestRunner, factory metadata.Store, opaque OverlayOpaqueType, lc layerConfig) {
 	randomData, err := tutil.RandomBytes(64000)
 	if err != nil {
 		t.Fatalf("failed rand.Read: %v", err)
 	}
 	data64KB := string(randomData)
 	hasOpaque := func(entry string) check {
-		return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
+		return func(t TestingT, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 			for _, k := range opaqueXattrs[opaque] {
 				hasNodeXattrs(entry, k, opaqueXattrValue)(t, root, cc, cr)
 			}
@@ -749,7 +774,7 @@ func testNodesWithOpaque(t *testing.T, factory metadata.Store, opaque OverlayOpa
 	for _, tt := range tests {
 		for _, srcCompression := range srcCompressions {
 			cl := srcCompression()
-			t.Run(tt.name+"-"+lc.name, func(t *testing.T) {
+			t.Run(tt.name+"-"+lc.name, func(t *TestRunner) {
 				opts := []tutil.BuildEStargzOption{
 					tutil.WithEStargzOptions(estargz.WithCompression(cl)),
 				}
@@ -780,7 +805,7 @@ func testNodesWithOpaque(t *testing.T, factory metadata.Store, opaque OverlayOpa
 	}
 }
 
-func getRootNode(t *testing.T, r metadata.Reader, opaque OverlayOpaqueType, tocDgst digest.Digest, cc cache.BlobCache, lc layerConfig) *node {
+func getRootNode(t TestingT, r metadata.Reader, opaque OverlayOpaqueType, tocDgst digest.Digest, cc cache.BlobCache, lc layerConfig) *node {
 	vr, err := reader.NewReader(r, cc, digest.FromString(""))
 	if err != nil {
 		t.Fatalf("failed to create reader: %v", err)
@@ -814,10 +839,10 @@ func (tb *testBlobState) Refresh(ctx context.Context, host source.RegistryHosts,
 }
 func (tb *testBlobState) Close() error { return nil }
 
-type check func(*testing.T, *node, cache.BlobCache, *calledReaderAt)
+type check func(TestingT, *node, cache.BlobCache, *calledReaderAt)
 
 func fileNotExist(file string) check {
-	return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
+	return func(t TestingT, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 		if _, _, err := getDirentAndNode(t, root, file); err == nil {
 			t.Errorf("Node %q exists", file)
 		}
@@ -825,7 +850,7 @@ func fileNotExist(file string) check {
 }
 
 func hasFileDigest(filename string, digest string) check {
-	return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
+	return func(t TestingT, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 		_, n, err := getDirentAndNode(t, root, filename)
 		if err != nil {
 			t.Fatalf("failed to get node %q: %v", filename, err)
@@ -854,7 +879,7 @@ func hasFileDigest(filename string, digest string) check {
 }
 
 func hasSize(name string, size int) check {
-	return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
+	return func(t TestingT, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 		_, n, err := getDirentAndNode(t, root, name)
 		if err != nil {
 			t.Fatalf("failed to get node %q: %v", name, err)
@@ -870,7 +895,7 @@ func hasSize(name string, size int) check {
 }
 
 func hasExtraMode(name string, mode os.FileMode) check {
-	return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
+	return func(t TestingT, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 		_, n, err := getDirentAndNode(t, root, name)
 		if err != nil {
 			t.Fatalf("failed to get node %q: %v", name, err)
@@ -889,7 +914,7 @@ func hasExtraMode(name string, mode os.FileMode) check {
 }
 
 func hasValidWhiteout(name string) check {
-	return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
+	return func(t TestingT, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 		ent, n, err := getDirentAndNode(t, root, name)
 		if err != nil {
 			t.Fatalf("failed to get node %q: %v", name, err)
@@ -925,7 +950,7 @@ func hasValidWhiteout(name string) check {
 }
 
 func hasNodeXattrs(entry, name, value string) check {
-	return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
+	return func(t TestingT, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 		_, n, err := getDirentAndNode(t, root, entry)
 		if err != nil {
 			t.Fatalf("failed to get node %q: %v", entry, err)
@@ -966,7 +991,7 @@ func hasNodeXattrs(entry, name, value string) check {
 	}
 }
 
-func hasEntry(t *testing.T, name string, ents fusefs.DirStream) (fuse.DirEntry, bool) {
+func hasEntry(t TestingT, name string, ents fusefs.DirStream) (fuse.DirEntry, bool) {
 	for ents.HasNext() {
 		de, errno := ents.Next()
 		if errno != 0 {
@@ -979,8 +1004,8 @@ func hasEntry(t *testing.T, name string, ents fusefs.DirStream) (fuse.DirEntry, 
 	return fuse.DirEntry{}, false
 }
 
-func hasStateFile(t *testing.T, id string) check {
-	return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
+func hasStateFile(t TestingT, id string) check {
+	return func(t TestingT, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 
 		// Check the state dir is hidden on OpenDir for "/"
 		ents, errno := root.Readdir(context.Background())
@@ -1077,7 +1102,7 @@ func hasStateFile(t *testing.T, id string) check {
 
 // getDirentAndNode gets dirent and node at the specified path at once and makes
 // sure that the both of them exist.
-func getDirentAndNode(t *testing.T, root *node, path string) (ent fuse.DirEntry, n *fusefs.Inode, err error) {
+func getDirentAndNode(t TestingT, root *node, path string) (ent fuse.DirEntry, n *fusefs.Inode, err error) {
 	dir, base := filepath.Split(filepath.Clean(path))
 
 	// get the target's parent directory.
@@ -1153,7 +1178,7 @@ type chunkInfo struct {
 }
 
 func hasFileContentsWithPreCached(name string, off int64, contents string, extra ...chunkInfo) check {
-	return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
+	return func(t TestingT, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 		buf := readFile(t, root, name, int64(len(contents)), off)
 		if len(buf) != len(contents) {
 			t.Fatalf("failed to read contents %q (off:%d, want:%q) got %q", name, off, longBytesView([]byte(contents)), longBytesView(buf))
@@ -1175,7 +1200,7 @@ func hasFileContentsWithPreCached(name string, off int64, contents string, extra
 }
 
 func hasFileContentsOffset(name string, off int64, contents string, fromCache bool) check {
-	return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
+	return func(t TestingT, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 		cr.called = nil // reset test
 		buf := readFile(t, root, name, int64(len(contents)), off)
 		if len(buf) != len(contents) {
@@ -1197,7 +1222,7 @@ func hasFileContentsOffset(name string, off int64, contents string, fromCache bo
 	}
 }
 
-func readFile(t *testing.T, root *node, filename string, size, off int64) []byte {
+func readFile(t TestingT, root *node, filename string, size, off int64) []byte {
 	_, n, err := getDirentAndNode(t, root, filename)
 	if err != nil {
 		t.Fatalf("failed to get node %q: %v", filename, err)

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -118,7 +118,11 @@ func TestSuiteLayer(t *testing.T, store metadata.Store) {
 var testStateLayerDigest = digest.FromString("dummy")
 
 func testPrefetch(t *testing.T, factory metadata.Store, lc layerConfig) {
-	data64KB := string(tutil.RandomBytes(t, 64000))
+	randomData, err := tutil.RandomBytes(64000)
+	if err != nil {
+		t.Fatalf("failed rand.Read: %v", err)
+	}
+	data64KB := string(randomData)
 	defaultPrefetchSize := int64(10000)
 	landmarkPosition := func(t *testing.T, l *layer) int64 {
 		if l.r == nil {
@@ -533,7 +537,11 @@ func testNodes(t *testing.T, factory metadata.Store, lc layerConfig) {
 }
 
 func testNodesWithOpaque(t *testing.T, factory metadata.Store, opaque OverlayOpaqueType, lc layerConfig) {
-	data64KB := string(tutil.RandomBytes(t, 64000))
+	randomData, err := tutil.RandomBytes(64000)
+	if err != nil {
+		t.Fatalf("failed rand.Read: %v", err)
+	}
+	data64KB := string(randomData)
 	hasOpaque := func(entry string) check {
 		return func(t *testing.T, root *node, cc cache.BlobCache, cr *calledReaderAt) {
 			for _, k := range opaqueXattrs[opaque] {

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -29,5 +29,20 @@ import (
 )
 
 func TestReader(t *testing.T) {
-	TestSuiteReader(t, memorymetadata.NewReader)
+	testRunner := &TestRunner{
+		TestingT: t,
+		Runner: func(testingT TestingT, name string, run func(t TestingT)) {
+			tt, ok := testingT.(*testing.T)
+			if !ok {
+				testingT.Fatal("TestingT is not a *testing.T")
+				return
+			}
+
+			tt.Run(name, func(t *testing.T) {
+				run(t)
+			})
+		},
+	}
+
+	TestSuiteReader(testRunner, memorymetadata.NewReader)
 }

--- a/fs/reader/testutil.go
+++ b/fs/reader/testutil.go
@@ -32,7 +32,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/containerd/stargz-snapshotter/cache"
@@ -64,7 +63,34 @@ var (
 	MockReadAtOutput = 4194304
 )
 
-func TestSuiteReader(t *testing.T, store metadata.Store) {
+// TestingT is the minimal set of testing.T required to run the
+// tests defined in TestSuiteReader. This interface exists to prevent
+// leaking the testing package from being exposed outside tests.
+type TestingT interface {
+	Cleanup(func())
+	Errorf(format string, args ...any)
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Logf(format string, args ...any)
+}
+
+// Runner allows running subtests of TestingT. This exists instead of adding
+// a Run method to TestingT interface because the Run implementation of
+// testing.T would not satisfy the interface.
+type Runner func(t TestingT, name string, fn func(t TestingT))
+
+type TestRunner struct {
+	TestingT
+	Runner Runner
+}
+
+func (r *TestRunner) Run(name string, run func(*TestRunner)) {
+	r.Runner(r.TestingT, name, func(t TestingT) {
+		run(&TestRunner{TestingT: t, Runner: r.Runner})
+	})
+}
+
+func TestSuiteReader(t *TestRunner, store metadata.Store) {
 	testFileReadAt(t, store)
 	testCacheVerify(t, store)
 	testFailReader(t, store)
@@ -72,7 +98,7 @@ func TestSuiteReader(t *testing.T, store metadata.Store) {
 	testProcessBatchChunks(t)
 }
 
-func testFileReadAt(t *testing.T, factory metadata.Store) {
+func testFileReadAt(t *TestRunner, factory metadata.Store) {
 	sizeCond := map[string]int64{
 		"single_chunk": sampleChunkSize - sampleMiddleOffset,
 		"multi_chunks": sampleChunkSize + sampleMiddleOffset,
@@ -109,7 +135,7 @@ func testFileReadAt(t *testing.T, factory metadata.Store) {
 					for cc, cacheExcept := range cacheCond {
 						for srcCompressionName, srcCompression := range srcCompressions {
 							srcCompression := srcCompression()
-							t.Run(fmt.Sprintf("reading_%s_%s_%s_%s_%s_%s", sn, in, bo, fn, cc, srcCompressionName), func(t *testing.T) {
+							t.Run(fmt.Sprintf("reading_%s_%s_%s_%s_%s_%s", sn, in, bo, fn, cc, srcCompressionName), func(t *TestRunner) {
 								if filesize > int64(len(sampleData1)) {
 									t.Fatal("sample file size is larger than sample data")
 								}
@@ -199,7 +225,7 @@ func testFileReadAt(t *testing.T, factory metadata.Store) {
 	}
 }
 
-func newExceptFile(t *testing.T, fr metadata.File, except ...region) metadata.File {
+func newExceptFile(t TestingT, fr metadata.File, except ...region) metadata.File {
 	er := exceptFile{fr: fr, t: t}
 	er.except = map[region]bool{}
 	for _, reg := range except {
@@ -211,7 +237,7 @@ func newExceptFile(t *testing.T, fr metadata.File, except ...region) metadata.Fi
 type exceptFile struct {
 	fr     metadata.File
 	except map[region]bool
-	t      *testing.T
+	t      TestingT
 }
 
 func (er *exceptFile) ReadAt(p []byte, offset int64) (int, error) {
@@ -225,7 +251,7 @@ func (er *exceptFile) ChunkEntryForOffset(offset int64) (off int64, size int64, 
 	return er.fr.ChunkEntryForOffset(offset)
 }
 
-func makeFile(t *testing.T, contents []byte, chunkSize int, factory metadata.Store, comp tutil.Compression) (*file, func() error) {
+func makeFile(t TestingT, contents []byte, chunkSize int, factory metadata.Store, comp tutil.Compression) (*file, func() error) {
 	testName := "test"
 	sr, dgst, err := tutil.BuildEStargz([]tutil.TarEntry{
 		tutil.File(testName, string(contents)),
@@ -265,7 +291,7 @@ func makeFile(t *testing.T, contents []byte, chunkSize int, factory metadata.Sto
 	return f, vr.Close
 }
 
-func testCacheVerify(t *testing.T, factory metadata.Store) {
+func testCacheVerify(t *TestRunner, factory metadata.Store) {
 	for _, skipVerify := range [2]bool{true, false} {
 		for _, invalidChunkBeforeVerify := range [2]bool{true, false} {
 			for _, invalidChunkAfterVerify := range [2]bool{true, false} {
@@ -273,7 +299,7 @@ func testCacheVerify(t *testing.T, factory metadata.Store) {
 					srcCompression := srcCompression()
 					name := fmt.Sprintf("test_cache_verify_%v_%v_%v_%v",
 						skipVerify, invalidChunkBeforeVerify, invalidChunkAfterVerify, srcCompressionName)
-					t.Run(name, func(t *testing.T) {
+					t.Run(name, func(t *TestRunner) {
 						sr, tocDgst, err := tutil.BuildEStargz([]tutil.TarEntry{
 							tutil.File("a", sampleData1+"a"),
 							tutil.File("b", sampleData1+"b"),
@@ -483,11 +509,11 @@ func prepareMap(mr metadata.Reader, id uint32, p string) (off2id map[int64]uint3
 	return off2id, id2path, nil
 }
 
-func testFailReader(t *testing.T, factory metadata.Store) {
+func testFailReader(t *TestRunner, factory metadata.Store) {
 	testFileName := "test"
 	for srcCompressionName, srcCompression := range srcCompressions {
 		srcCompression := srcCompression()
-		t.Run(fmt.Sprintf("%v", srcCompressionName), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%v", srcCompressionName), func(t *TestRunner) {
 			for _, rs := range []bool{true, false} {
 				for _, vs := range []bool{true, false} {
 					stargzFile, tocDigest, err := tutil.BuildEStargz([]tutil.TarEntry{
@@ -595,7 +621,7 @@ func (bev *testChunkVerifier) verifier(id uint32, chunkDigest string) (digest.Ve
 	return &testVerifier{bev.success}, nil
 }
 
-func testPreReader(t *testing.T, factory metadata.Store) {
+func testPreReader(t *TestRunner, factory metadata.Store) {
 	randomData, err := tutil.RandomBytes(64000)
 	if err != nil {
 		t.Fatalf("failed rand.Read: %v", err)
@@ -670,7 +696,7 @@ func testPreReader(t *testing.T, factory metadata.Store) {
 	for _, tt := range tests {
 		for srcCompresionName, srcCompression := range srcCompressions {
 			srcCompression := srcCompression()
-			t.Run(tt.name+"-"+srcCompresionName, func(t *testing.T) {
+			t.Run(tt.name+"-"+srcCompresionName, func(t *TestRunner) {
 				opts := []tutil.BuildEStargzOption{
 					tutil.WithEStargzOptions(estargz.WithCompression(srcCompression)),
 				}
@@ -709,7 +735,7 @@ func testPreReader(t *testing.T, factory metadata.Store) {
 	}
 }
 
-type check func(*testing.T, *reader, *calledReaderAt)
+type check func(TestingT, *reader, *calledReaderAt)
 
 type chunkInfo struct {
 	name        string
@@ -719,7 +745,7 @@ type chunkInfo struct {
 }
 
 func hasFileContentsOffset(name string, off int64, contents string, fromCache bool) check {
-	return func(t *testing.T, r *reader, cr *calledReaderAt) {
+	return func(t TestingT, r *reader, cr *calledReaderAt) {
 		tid, err := lookup(r, name)
 		if err != nil {
 			t.Fatalf("failed to lookup %q", name)
@@ -754,7 +780,7 @@ func hasFileContentsOffset(name string, off int64, contents string, fromCache bo
 }
 
 func hasFileContentsWithPreCached(name string, off int64, contents string, extra ...chunkInfo) check {
-	return func(t *testing.T, r *reader, cr *calledReaderAt) {
+	return func(t TestingT, r *reader, cr *calledReaderAt) {
 		tid, err := lookup(r, name)
 		if err != nil {
 			t.Fatalf("failed to lookup %q", name)
@@ -874,7 +900,7 @@ func (f *mockFile) ReadAt(p []byte, offset int64) (int, error) {
 	return MockReadAtOutput, nil
 }
 
-func testProcessBatchChunks(t *testing.T) {
+func testProcessBatchChunks(t *TestRunner) {
 	type testCase struct {
 		name               string
 		setupMock          func()
@@ -882,7 +908,7 @@ func testProcessBatchChunks(t *testing.T) {
 		expectErrorInHoles bool
 	}
 
-	runTest := func(t *testing.T, tc testCase) {
+	runTest := func(t TestingT, tc testCase) {
 		if tc.setupMock != nil {
 			tc.setupMock()
 		}
@@ -1004,7 +1030,7 @@ func testProcessBatchChunks(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(t *TestRunner) {
 			runTest(t, tc)
 		})
 	}

--- a/fs/reader/testutil.go
+++ b/fs/reader/testutil.go
@@ -596,7 +596,11 @@ func (bev *testChunkVerifier) verifier(id uint32, chunkDigest string) (digest.Ve
 }
 
 func testPreReader(t *testing.T, factory metadata.Store) {
-	data64KB := string(tutil.RandomBytes(t, 64000))
+	randomData, err := tutil.RandomBytes(64000)
+	if err != nil {
+		t.Fatalf("failed rand.Read: %v", err)
+	}
+	data64KB := string(randomData)
 	tests := []struct {
 		name         string
 		chunkSize    int

--- a/metadata/memory/reader_test.go
+++ b/metadata/memory/reader_test.go
@@ -25,7 +25,21 @@ import (
 )
 
 func TestReader(t *testing.T) {
-	testutil.TestReader(t, readerFactory)
+	testRunner := &testutil.TestRunner{
+		TestingT: t,
+		Runner: func(testingT testutil.TestingT, name string, run func(t testutil.TestingT)) {
+			tt, ok := testingT.(*testing.T)
+			if !ok {
+				testingT.Fatal("TestingT is not a *testing.T")
+				return
+			}
+
+			tt.Run(name, func(t *testing.T) {
+				run(t)
+			})
+		},
+	}
+	testutil.TestReader(testRunner, readerFactory)
 }
 
 func readerFactory(sr *io.SectionReader, opts ...metadata.Option) (testutil.TestableReader, error) {

--- a/metadata/testutil/testutil.go
+++ b/metadata/testutil/testutil.go
@@ -64,7 +64,11 @@ type TestableReader interface {
 func TestReader(t *testing.T, factory ReaderFactory) {
 	sampleTime := time.Now().Truncate(time.Second)
 	sampleText := "qwer" + "tyui" + "opas" + "dfgh" + "jk"
-	data64KB := string(tutil.RandomBytes(t, 64000))
+	randomData, err := tutil.RandomBytes(64000)
+	if err != nil {
+		t.Fatalf("failed rand.Read: %v", err)
+	}
+	data64KB := string(randomData)
 	tests := []struct {
 		name         string
 		chunkSize    int

--- a/metadata/testutil/testutil.go
+++ b/metadata/testutil/testutil.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/containerd/stargz-snapshotter/estargz"
@@ -60,8 +59,34 @@ type TestableReader interface {
 	NumOfNodes() (i int, _ error)
 }
 
+// TestingT is the minimal set of testing.T required to run the
+// tests defined in TestReader. This interface exists to prevent
+// leaking the testing package from being exposed outside tests.
+type TestingT interface {
+	Errorf(format string, args ...any)
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Logf(format string, args ...any)
+}
+
+// Runner allows running subtests of TestingT. This exists instead of adding
+// a Run method to TestingT interface because the Run implementation of
+// testing.T would not satisfy the interface.
+type Runner func(t TestingT, name string, fn func(t TestingT))
+
+type TestRunner struct {
+	TestingT
+	Runner Runner
+}
+
+func (r *TestRunner) Run(name string, run func(*TestRunner)) {
+	r.Runner(r.TestingT, name, func(t TestingT) {
+		run(&TestRunner{TestingT: t, Runner: r.Runner})
+	})
+}
+
 // TestReader tests Reader returns correct file metadata.
-func TestReader(t *testing.T, factory ReaderFactory) {
+func TestReader(t *TestRunner, factory ReaderFactory) {
 	sampleTime := time.Now().Truncate(time.Second)
 	sampleText := "qwer" + "tyui" + "opas" + "dfgh" + "jk"
 	randomData, err := tutil.RandomBytes(64000)
@@ -290,7 +315,8 @@ func TestReader(t *testing.T, factory ReaderFactory) {
 			prefix := prefix
 			for srcCompresionName, srcCompression := range srcCompressions {
 				srcCompression := srcCompression()
-				t.Run(tt.name+"-"+srcCompresionName, func(t *testing.T) {
+
+				t.Run(tt.name+"-"+srcCompresionName, func(t *TestRunner) {
 					opts := []tutil.BuildEStargzOption{
 						tutil.WithBuildTarOptions(tutil.WithPrefix(prefix)),
 						tutil.WithEStargzOptions(estargz.WithCompression(srcCompression)),
@@ -347,7 +373,7 @@ func TestReader(t *testing.T, factory ReaderFactory) {
 		}
 	}
 
-	t.Run("clone-id-stability", func(t *testing.T) {
+	t.Run("clone-id-stability", func(t *TestRunner) {
 		var mapEntries func(r TestableReader, id uint32, m map[string]uint32) (map[string]uint32, error)
 		mapEntries = func(r TestableReader, id uint32, m map[string]uint32) (map[string]uint32, error) {
 			if m == nil {
@@ -430,7 +456,7 @@ func newCalledTelemetry() (telemetry *metadata.Telemetry, check func() error) {
 		}
 }
 
-func dumpNodes(t *testing.T, r TestableReader, id uint32, level int) {
+func dumpNodes(t TestingT, r TestableReader, id uint32, level int) {
 	if err := r.ForeachChild(id, func(name string, id uint32, mode os.FileMode) bool {
 		ind := ""
 		for i := 0; i < level; i++ {
@@ -444,10 +470,10 @@ func dumpNodes(t *testing.T, r TestableReader, id uint32, level int) {
 	}
 }
 
-type check func(*testing.T, TestableReader)
+type check func(TestingT, TestableReader)
 
 func numOfNodes(want int) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		i, err := r.NumOfNodes()
 		if err != nil {
 			t.Errorf("num of nodes: %v", err)
@@ -459,7 +485,7 @@ func numOfNodes(want int) check {
 }
 
 func numOfChunks(name string, num int) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		nr, ok := r.(interface {
 			NumOfChunks(id uint32) (i int, _ error)
 		})
@@ -483,7 +509,7 @@ func numOfChunks(name string, num int) check {
 }
 
 func sameNodes(n string, nodes ...string) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, n)
 		if err != nil {
 			t.Errorf("failed to lookup %q: %v", n, err)
@@ -503,7 +529,7 @@ func sameNodes(n string, nodes ...string) check {
 }
 
 func linkName(name string, linkName string) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("failed to lookup %q: %v", name, err)
@@ -526,7 +552,7 @@ func linkName(name string, linkName string) check {
 }
 
 func hasNumLink(name string, numLink int) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("failed to lookup %q: %v", name, err)
@@ -545,7 +571,7 @@ func hasNumLink(name string, numLink int) check {
 }
 
 func hasDirChildren(name string, children ...string) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("failed to lookup %q: %v", name, err)
@@ -580,7 +606,7 @@ func hasDirChildren(name string, children ...string) check {
 }
 
 func hasChardev(name string, maj, min int) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("cannot find chardev %q: %v", name, err)
@@ -603,7 +629,7 @@ func hasChardev(name string, maj, min int) check {
 }
 
 func hasBlockdev(name string, maj, min int) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("cannot find blockdev %q: %v", name, err)
@@ -626,7 +652,7 @@ func hasBlockdev(name string, maj, min int) check {
 }
 
 func hasFifo(name string) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("cannot find blockdev %q: %v", name, err)
@@ -645,7 +671,7 @@ func hasFifo(name string) check {
 }
 
 func hasFile(name, content string, size int64) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("cannot find file %q: %v", name, err)
@@ -690,7 +716,7 @@ type chunkInfo struct {
 }
 
 func hasFileContentsWithPreRead(name string, off int64, contents string, extra ...chunkInfo) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		extraMap := make(map[uint32]chunkInfo)
 		for _, e := range extra {
 			id, err := lookup(r, e.name)
@@ -757,7 +783,7 @@ func hasFileContentsWithPreRead(name string, off int64, contents string, extra .
 }
 
 func hasFileContentsOffset(name string, off int64, contents string) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("failed to lookup %q: %v", name, err)
@@ -786,7 +812,7 @@ func hasFileContentsOffset(name string, off int64, contents string) check {
 }
 
 func hasMode(name string, mode os.FileMode) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("cannot find file %q: %v", name, err)
@@ -805,7 +831,7 @@ func hasMode(name string, mode os.FileMode) check {
 }
 
 func hasOwner(name string, uid, gid int) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("cannot find file %q: %v", name, err)
@@ -824,7 +850,7 @@ func hasOwner(name string, uid, gid int) check {
 }
 
 func hasModTime(name string, modTime time.Time) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("cannot find file %q: %v", name, err)
@@ -844,7 +870,7 @@ func hasModTime(name string, modTime time.Time) check {
 }
 
 func hasXattrs(name string, xattrs map[string]string) check {
-	return func(t *testing.T, r TestableReader) {
+	return func(t TestingT, r TestableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
 			t.Errorf("cannot find file %q: %v", name, err)

--- a/util/testutil/util.go
+++ b/util/testutil/util.go
@@ -18,14 +18,13 @@ package testutil
 
 import (
 	"crypto/rand"
-	"testing"
 )
 
 // RandomBytes returns the specified number of random bytes
-func RandomBytes(t *testing.T, n int) []byte {
+func RandomBytes(n int) ([]byte, error) {
 	b := make([]byte, n)
 	if _, err := rand.Read(b); err != nil {
-		t.Fatalf("failed rand.Read: %v", err)
+		return nil, err
 	}
-	return b
+	return b, nil
 }


### PR DESCRIPTION
The various `testutil` packages reduce duplication, but exist outside of a `_test.go` package and they, along with all of their dependencies are not pruned via dead code elimination which causes #1760. To cut the dependency without refactoring the tests, this creates a local interface which covers the subset of the `testing.T` methods used by the test helpers. 


Closes https://github.com/containerd/stargz-snapshotter/issues/1760.