### PR TITLE
Using decompression commands to improve the layer decompression speed of gzip-formatted images

### DIFF
--- a/docs/ctr-remote.md
+++ b/docs/ctr-remote.md
@@ -58,6 +58,14 @@ ctr-remote image push --plain-http registry2:5000/golang:1.15.3-esgz
 When you run `ctr-remote image optimize`, this runs the source image (`ghcr.io/stargz-containers/golang:1.15.3-buster-org`) as a container and profiles all file accesses during the execution.
 Then these accessed files are marked as "prioritized" files and will be prefetched on runtime.
 
+You can specify the `--estargz-gzip-helper` flag to specify a command-line helper tool for gzip decompression during optimization. Using command-line tools can speed up the decompression of the original image, thereby accelerating the overall optimization process. Even using the gzip command corresponding to the Go gzip library can achieve approximately 32% speed improvement. For more details, see: [Using decompression commands to improve the layer decompression speed of gzip-formatted images](https://github.com/containerd/stargz-snapshotter/pull/2117). Currently, `--estargz-gzip-helper` only supports `pigz`, `igzip`, and `gzip`.
+
+The following example uses the `pigz` command to accelerate the optimization process:
+
+```console
+# ctr-remote image optimize --oci --estargz-gzip-helper pigz ghcr.io/stargz-containers/golang:1.15.3-buster-org registry2:5000/golang:1.15.3-esgz
+```
+
 You can specify the GZIP compression level the converter should use using the `--estargz-compression-level` flag. The values range from 1-9. If the flag isn't provided, the compression level will default to 9.
 
 A value of 9 indicates the archive will be gzipped with max compression. This will reduce the bytes transferred over the network but increase the CPU cycles required to decompress the payload. Whereas gzip compression value 1 indicates archive will be gzipped with least compression. This will increase the bytes transferred over the network but decreases the CPU cycles required to decompress the payload. This value should be chosen based on the workload and host characteristics.

--- a/estargz/build.go
+++ b/estargz/build.go
@@ -42,6 +42,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+type GzipHelperFunc func(io.Reader) (io.ReadCloser, error)
+
 type options struct {
 	chunkSize              int
 	compressionLevel       int
@@ -50,6 +52,7 @@ type options struct {
 	compression            Compression
 	ctx                    context.Context
 	minChunkSize           int
+	gzipHelperFunc         GzipHelperFunc
 }
 
 type Option func(o *options) error
@@ -127,6 +130,18 @@ func WithMinChunkSize(minChunkSize int) Option {
 	}
 }
 
+// WithGzipHelperFunc option specifies a custom function to decompress gzip-compressed layers.
+// When a gzip-compressed layer is detected, this function will be used instead of the
+// Go standard library gzip decompression for better performance.
+// The function should take an io.Reader as input and return an io.ReadCloser.
+// If nil, the Go standard library gzip.NewReader will be used.
+func WithGzipHelperFunc(gzipHelperFunc GzipHelperFunc) Option {
+	return func(o *options) error {
+		o.gzipHelperFunc = gzipHelperFunc
+		return nil
+	}
+}
+
 // Blob is an eStargz blob.
 type Blob struct {
 	io.ReadCloser
@@ -186,7 +201,7 @@ func Build(tarBlob *io.SectionReader, opt ...Option) (_ *Blob, rErr error) {
 			rErr = fmt.Errorf("error from context %q: %w", cErr, rErr)
 		}
 	}()
-	tarBlob, err := decompressBlob(tarBlob, layerFiles)
+	tarBlob, err := decompressBlob(tarBlob, layerFiles, opts.gzipHelperFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -649,7 +664,7 @@ func (cr *countReadSeeker) currentPos() int64 {
 	return *cr.cPos
 }
 
-func decompressBlob(org *io.SectionReader, tmp *tempFiles) (*io.SectionReader, error) {
+func decompressBlob(org *io.SectionReader, tmp *tempFiles, gzipHelperFunc GzipHelperFunc) (*io.SectionReader, error) {
 	if org.Size() < 4 {
 		return org, nil
 	}
@@ -660,7 +675,13 @@ func decompressBlob(org *io.SectionReader, tmp *tempFiles) (*io.SectionReader, e
 	var dR io.Reader
 	if bytes.Equal([]byte{0x1F, 0x8B, 0x08}, src[:3]) {
 		// gzip
-		dgR, err := gzip.NewReader(io.NewSectionReader(org, 0, org.Size()))
+		var dgR io.ReadCloser
+		var err error
+		if gzipHelperFunc != nil {
+			dgR, err = gzipHelperFunc(io.NewSectionReader(org, 0, org.Size()))
+		} else {
+			dgR, err = gzip.NewReader(io.NewSectionReader(org, 0, org.Size()))
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/script/util/make.sh
+++ b/script/util/make.sh
@@ -34,7 +34,7 @@ trap 'cleanup "$?"' EXIT SIGHUP SIGINT SIGQUIT SIGTERM
 
 cat <<EOF > "${TMP_CONTEXT}/Dockerfile"
 FROM golang:${GOBASE_VERSION}
-RUN apt-get update -y && apt-get --no-install-recommends install -y fuse3
+RUN apt-get update -y && apt-get --no-install-recommends install -y fuse3 gzip pigz
 EOF
 MAKECMD="make ${@} PREFIX=/tmp/out/"
 docker build -t "${IMAGE_NAME}" ${DOCKER_BUILD_ARGS:-} "${TMP_CONTEXT}"

--- a/util/decompressutil/gzip.go
+++ b/util/decompressutil/gzip.go
@@ -1,0 +1,112 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package decompressutil
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+
+	"github.com/containerd/stargz-snapshotter/estargz"
+)
+
+var (
+	findCmdOnce sync.Once
+	gzipPath    string
+	pigzPath    string
+	igzipPath   string
+)
+
+func refreshCmdPath() {
+	findCmdOnce.Do(func() {
+		gzipPath = findCmdPath("gzip")
+		pigzPath = findCmdPath("pigz")
+		igzipPath = findCmdPath("igzip")
+	})
+}
+
+func getCmdGzipHelperFunc(cmdPath string) estargz.GzipHelperFunc {
+	return func(in io.Reader) (io.ReadCloser, error) {
+		cmd := exec.Command(cmdPath, "-d", "-c")
+
+		readCloser, writer := io.Pipe()
+		cmd.Stdin = in
+		cmd.Stdout = writer
+
+		var errBuf bytes.Buffer
+		cmd.Stderr = &errBuf
+
+		if err := cmd.Start(); err != nil {
+			writer.Close()
+			return nil, err
+		}
+
+		go func() {
+			if err := cmd.Wait(); err != nil {
+				writer.CloseWithError(fmt.Errorf("gzip helper failed, %s: %s", err, errBuf.String()))
+			}
+			writer.Close()
+		}()
+
+		return readCloser, nil
+	}
+}
+
+func getGoGzipHelperFunc() estargz.GzipHelperFunc {
+	return func(in io.Reader) (io.ReadCloser, error) {
+		readCloser, err := gzip.NewReader(in)
+		if err != nil {
+			return nil, err
+		}
+		return readCloser, nil
+	}
+}
+
+func GetGzipHelperFunc(gzipHelper string) (estargz.GzipHelperFunc, error) {
+	// refresh the path of available decompression commands
+	refreshCmdPath()
+
+	var cmdPath string
+	switch gzipHelper {
+	case "pigz":
+		cmdPath = pigzPath
+	case "igzip":
+		cmdPath = igzipPath
+	case "gzip":
+		cmdPath = gzipPath
+	default:
+		return nil, fmt.Errorf("invalid gzip helper: %s", gzipHelper)
+	}
+
+	if cmdPath == "" {
+		fmt.Printf("Warning: Gzip helper '%s' not found "+
+			"Falling back to Go standard library implementation.\n", gzipHelper)
+		return getGoGzipHelperFunc(), nil
+	}
+	return getCmdGzipHelperFunc(cmdPath), nil
+}
+
+func findCmdPath(cmd string) string {
+	path, err := exec.LookPath(cmd)
+	if err != nil {
+		return ""
+	}
+	return path
+}

--- a/util/decompressutil/gzip_test.go
+++ b/util/decompressutil/gzip_test.go
@@ -1,0 +1,154 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package decompressutil
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestGetGzipHelperFunc(t *testing.T) {
+	refreshCmdPath()
+
+	// Detect commands
+	allCmds := []string{"gzip", "pigz", "igzip"}
+	availableCmds := make(map[string]string)
+	unavailableCmds := []string{}
+
+	for _, cmd := range allCmds {
+		var path string
+		switch cmd {
+		case "gzip":
+			path = gzipPath
+		case "pigz":
+			path = pigzPath
+		case "igzip":
+			path = igzipPath
+		}
+		if path != "" {
+			availableCmds[cmd] = path
+		} else {
+			unavailableCmds = append(unavailableCmds, cmd)
+		}
+	}
+
+	if len(availableCmds) == 0 {
+		t.Skip("Skipping test: gzip, pigz or igzip commands are not available in environment")
+	}
+
+	defer func() {
+		// Reset sync.Once to initial state
+		findCmdOnce = sync.Once{}
+	}()
+
+	testData := []byte("This is test data for verifying GetGzipHelperFunc functionality")
+
+	type testCase struct {
+		name         string
+		gzipHelper   string
+		errorMsg     string
+		goGzipReader bool
+	}
+
+	tests := []testCase{
+		{
+			name:         "invalid gzip helper",
+			gzipHelper:   "nonexistentcmd",
+			errorMsg:     "invalid gzip helper: nonexistentcmd",
+			goGzipReader: false,
+		},
+	}
+
+	// Add test cases according to detected commands
+	for cmd := range availableCmds {
+		tests = append(tests, testCase{
+			name:         fmt.Sprintf("%s gzipHelper", cmd),
+			gzipHelper:   cmd,
+			errorMsg:     "",
+			goGzipReader: false,
+		})
+	}
+	for _, cmd := range unavailableCmds {
+		tests = append(tests, testCase{
+			name:         fmt.Sprintf("%s gzipHelper but not available", cmd),
+			gzipHelper:   cmd,
+			errorMsg:     "",
+			goGzipReader: true,
+		})
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var compressedBuf bytes.Buffer
+			gzipWriter := gzip.NewWriter(&compressedBuf)
+			_, err := gzipWriter.Write(testData)
+			if err != nil {
+				t.Fatalf("Failed to compress data: %v", err)
+			}
+			if err := gzipWriter.Close(); err != nil {
+				t.Fatalf("Failed to close gzip writer: %v", err)
+			}
+
+			tmpfile, err := os.CreateTemp("", "test-decompress-*")
+			if err != nil {
+				t.Fatalf("Failed to create temporary file: %v", err)
+			}
+			defer os.Remove(tmpfile.Name())
+
+			gzipHelperFunc, err := GetGzipHelperFunc(test.gzipHelper)
+			if err == nil {
+				if test.errorMsg != "" {
+					t.Fatalf("Expected error: %v", test.errorMsg)
+				}
+			} else {
+				if test.errorMsg != err.Error() {
+					t.Fatalf("Error message does not match, expected: %v, actual: %v", test.errorMsg, err.Error())
+				} else {
+					return
+				}
+			}
+
+			readCloser, err := gzipHelperFunc(bytes.NewReader(compressedBuf.Bytes()))
+			if err != nil {
+				t.Fatalf("Failed to run gzip helper function: %v", err)
+			}
+
+			if test.goGzipReader {
+				if _, ok := readCloser.(*gzip.Reader); !ok {
+					t.Errorf("Expected gzipHelperFunc return a *gzip.Reader but got %T", readCloser)
+				}
+			}
+			decompressedData, err := io.ReadAll(readCloser)
+			if err != nil {
+				t.Fatalf("Failed to read decompressed data: %v", err)
+			}
+
+			if !bytes.Equal(decompressedData, testData) {
+				t.Errorf("Decompressed data does not match original data")
+			}
+			err = readCloser.Close()
+			if err != nil {
+				t.Fatalf("Failed to close gzip read closer: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The current code uses Go’s built-in gzip library to decompress gzip-formatted images. However, it was found that decompression using Go’s gzip library is slow (especially for large images), while using command-line decompression tools can improve the decompression speed. In the below 10 examples, using decompression commands achieved at least 32% speedup. 
<img width="2172" height="691" alt="image" src="https://github.com/user-attachments/assets/390d1480-dc4a-4305-9f28-34fb0cc50d11" />
The containerd community has also discussed and implemented related optimizations, see: https://github.com/containerd/containerd/pull/2640.

Although containerd uses the igzip command for decompression by default (see: https://github.com/containerd/containerd/blob/02eb68472ea11518c419d8866a3a309826bbb3ab/pkg/archive/compression/compression.go#L270 ), above results show that pigz delivers the best performance across most test cases. Therefore, the current priority for invoking decompression commands is pigz > igzip > gzip.
