### PR TITLE
snapshot: preserve normal snapshots during cleanup

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -455,10 +455,32 @@ func (o *snapshotter) getCleanupDirectories(ctx context.Context, t storage.Trans
 		return nil, err
 	}
 
+	remoteSnapshotNames := make(map[string]struct{})
+	{
+		keyToID := make(map[string]string, len(ids))
+		for id, key := range ids {
+			keyToID[key] = id
+		}
+		if err := storage.WalkInfo(ctx, func(ctx context.Context, info snapshots.Info) error {
+			if _, ok := info.Labels[remoteLabel]; ok {
+				if id, exists := keyToID[info.Name]; exists {
+					remoteSnapshotNames[id] = struct{}{}
+				}
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+
 	cleanup := []string{}
 	for _, d := range dirs {
 		if !cleanupCommitted {
 			if _, ok := ids[d]; ok {
+				continue
+			}
+		} else {
+			if _, ok := remoteSnapshotNames[d]; !ok {
 				continue
 			}
 		}


### PR DESCRIPTION
This commit modifies getCleanupDirectories() to:
- Only clean up remote snapshots (those with remoteLabel) during Close()
- Preserve normal snapshot directories and their content
- Ensure normal snapshots remain functional after restart

Fixes: #2126