### PR TITLE
CI: use k3s v1.33

### DIFF
--- a/script/k3s-argo-workflow/run.sh
+++ b/script/k3s-argo-workflow/run.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 CONTEXT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/"
 REPO="${CONTEXT}../../"
 
-K3S_VERSION=master
+K3S_VERSION=release-1.33
 K3S_REPO=https://github.com/k3s-io/k3s
 K3S_CONTAINERD_REPO=https://github.com/k3s-io/containerd
 ARGO_VERSION=v3.6.4

--- a/script/k3s/run-k3s.sh
+++ b/script/k3s/run-k3s.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-K3S_VERSION=master
+K3S_VERSION=release-1.33
 K3S_REPO=https://github.com/k3s-io/k3s
 K3S_CONTAINERD_REPO=https://github.com/k3s-io/containerd
 


### PR DESCRIPTION
Support for Kubernetes v1.34 is worked in #2122. Until that PR is completed, use k3s v1.33 for now to avoid blocking other PRs because of CI failures. 