### PR TITLE
fusemanager: Log by default

### DIFF
--- a/fusemanager/fusemanager.go
+++ b/fusemanager/fusemanager.go
@@ -117,10 +117,6 @@ func startNew(ctx context.Context, logPath, address, fusestore, logLevel string)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	} else {
-		err := os.Remove(logPath)
-		if err != nil && !os.IsNotExist(err) {
-			return err
-		}
 		file, err := os.Create(logPath)
 		if err != nil {
 			return err


### PR DESCRIPTION
## fusemanager: Drop --debug flag (not used)
There's `--log-level` instead.

## fusemanager: Hookup normal stdout+stderr by default
Dropping logging output by default is surprising. I think switching this as the default is safe to do for existing users.

## fusemanager: Drop manual truncation of logPath
`os.Create()` truncates existing files already, but additionally works
cleanly if the path is a literal `/dev/stdout` or `/dev/stderr` which
would otherwise fail to be removed.