### PR TITLE
test: k3s: use main branch instead of removed master branch

### DIFF
--- a/script/k3s-argo-workflow/run.sh
+++ b/script/k3s-argo-workflow/run.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 CONTEXT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/"
 REPO="${CONTEXT}../../"
 
-K3S_VERSION=master
+K3S_VERSION=main
 K3S_REPO=https://github.com/k3s-io/k3s
 K3S_CONTAINERD_REPO=https://github.com/k3s-io/containerd
 ARGO_VERSION=v3.6.4

--- a/script/k3s/run-k3s.sh
+++ b/script/k3s/run-k3s.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-K3S_VERSION=master
+K3S_VERSION=main
 K3S_REPO=https://github.com/k3s-io/k3s
 K3S_CONTAINERD_REPO=https://github.com/k3s-io/containerd
 


### PR DESCRIPTION
k3s seems to renamed the default branch in recent days.