### PR TITLE
estargz: Do not fail parsing empty layers

### DIFF
--- a/estargz/estargz.go
+++ b/estargz/estargz.go
@@ -307,6 +307,15 @@ func (r *Reader) initFields() error {
 		}
 	}
 
+	if len(r.m) == 0 {
+		r.m[""] = &TOCEntry{
+			Name:    "",
+			Type:    "dir",
+			Mode:    0755,
+			NumLink: 1,
+		}
+	}
+
 	return nil
 }
 

--- a/estargz/testutil.go
+++ b/estargz/testutil.go
@@ -1560,6 +1560,9 @@ func testWriteAndOpen(t *TestRunner, controllers ...TestingControllerFactory) {
 							if err != nil {
 								t.Fatalf("stargz.Open: %v", err)
 							}
+							if _, ok := r.Lookup(""); !ok {
+								t.Fatalf("failed to lookup rootdir: %v", err)
+							}
 							wantTOCVersion := 1
 							if tt.wantTOCVersion > 0 {
 								wantTOCVersion = tt.wantTOCVersion


### PR DESCRIPTION
Stargz snapshotter can't perform lazy pulling for images that contains empty layers. This PR fixes this issue.



### Test image

```
echo "FROM denoland/deno:alpine-1.43.2@sha256:f51f2853d4235c5f223015fa6f045b1978a98aa883cf15cff405bfb95656f16e" | docker buildx build --builder=container --output type=image,name=ghcr.io/ktock/deno:alpine-1.43.2-esgz-emptylayer,push=true,oci-mediatype=true,compression=estargz,force-compression=true -
```

This contains an empty layer "sha256:6616d0fdd6dd05b2515b5c83800740fd633a514238fe7caa3f7eeda7f89ad988".

### Test command

```
ctr-remote i rpull ghcr.io/ktock/deno:alpine-1.43.2-esgz-emptylayer
```

### Actual behaviour

```
{"error":"failed to resolve layer: failed to resolve layer \"sha256:6616d0fdd6dd05b2515b5c83800740fd633a514238fe7caa3f7eeda7f89ad988\" from \"ghcr.io/ktock/deno:alpine-1.43.2-esgz-emptylayer\": failed to get root node: failed to resolve target","key":"default/3/extract-810753276-MZr_ sha256:0cdf7f72928814ea0968bde6c77c9ab437273b6b6cd8aa0e2deef5eef67fd378","level":"warning","msg":"failed to prepare remote snapshot","parent":"sha256:5d8a07f4b7477daceba36222438bf44d68ab5e44fa143767f64529020b87d181","remote-snapshot-prepared":"false","time":"2025-10-03T14:55:38.075725569Z"}
```

Then it fallbacks to the normal pull.

### Expected behaviour

`ctr-remote i rpull` succeeds with lazy pulling.
