### PR TITLE
Preapre for v0.18.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/containerd/stargz-snapshotter v0.15.2-0.20240622031358-6405f362966d
-	github.com/containerd/stargz-snapshotter/estargz v0.17.0
+	github.com/containerd/stargz-snapshotter/estargz v0.18.0
 	github.com/containerd/stargz-snapshotter/ipfs v0.15.2-0.20240622031358-6405f362966d
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/docker/go-metrics v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/containerd/plugin v1.0.0
-	github.com/containerd/stargz-snapshotter/estargz v0.17.0
+	github.com/containerd/stargz-snapshotter/estargz v0.18.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v28.5.1+incompatible
 	github.com/docker/go-metrics v0.0.1


### PR DESCRIPTION
```
# Notable Changes

- Fixed restoring error of snapshots on unexpected restart of stargz snapshotter (#2091, #2092), thanks to @wswsmao
- Added FadvDontNeed option to reduce pagecache consumption in stargz snapshotter (#2095), thanks to @wswsmao
- Removed `testing` dependency from code outside tests (#2098), thanks to @rosstimothy
- Added `all` option for the ctr-remote's `--gpus` flag (#2102, #2118), thanks to @wswsmao
- Added `--prefetch-list` flag to ctr-remote (#2113, #2148), thanks to @wswsmao
- Enabled deduplication in ImageRecorder.Record (#2116), thanks to @wswsmao
- Fixed potential data race in nativeconverter/estargz (#2133), thanks to @escapefreeg
- Added support of decompression helpers in ctr-remote for better conversion speed (#2117), thanks to @escapefreeg
- Improved logging behaviour in fusemanager (#2135), thanks to @mmonaco
- Fixed to preserve normal snapshots during cleanup in stargz snapshotter (#2127), thanks to @ChengyuZhu6
- Fixed lazy pulling failure on images with empty layers (#2137)
- Fixed stargz snapshotter to run without depending on fusermount by default (#2146)
- Enabled ctr-remote to capture early file access (#2129), thanks to @wswsmao
- Refactors and document fixes (#2112, #2150), thanks to @wswsmao

```