### PR TITLE
Prepare for v0.18.1

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/containerd/go-cni v1.1.13
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.1
-	github.com/containerd/stargz-snapshotter v0.15.2-0.20240622031358-6405f362966d
-	github.com/containerd/stargz-snapshotter/estargz v0.18.0
-	github.com/containerd/stargz-snapshotter/ipfs v0.15.2-0.20240622031358-6405f362966d
+	github.com/containerd/stargz-snapshotter v0.18.1
+	github.com/containerd/stargz-snapshotter/estargz v0.18.1
+	github.com/containerd/stargz-snapshotter/ipfs v0.18.1
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/docker/go-metrics v0.0.1
 	github.com/goccy/go-json v0.10.5

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/containerd/plugin v1.0.0
-	github.com/containerd/stargz-snapshotter/estargz v0.18.0
+	github.com/containerd/stargz-snapshotter/estargz v0.18.1
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v28.5.2+incompatible
 	github.com/docker/go-metrics v0.0.1


### PR DESCRIPTION
```
## Notable Changes

- Avoid repeated decompression and further utilize the --GH option to speed up conversion (#2145), thanks to @escapefreeg
- Improved sortEntries performance (#2153), thanks to @wswsmao

```