### PR TITLE
add prefetch metrics

### DIFF
--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -71,6 +71,11 @@ const (
 	BackgroundFetchDownload   = "background_fetch_download"
 	BackgroundFetchDecompress = "background_fetch_decompress"
 	PrefetchSize              = "prefetch_size"
+
+	// prefetch metrics (bytes)
+	PrefetchDecompressedBytes      = "prefetch_decompressed_bytes"
+	ReadBytesServedFromPrefetch    = "read_bytes_served_from_prefetch"
+	ReadBytesServedNotFromPrefetch = "read_bytes_served_not_from_prefetch"
 )
 
 var (


### PR DESCRIPTION
Add prefetch metrics to evaluate prefetch accuracy. Usage as follows:

**View read bytes served from prefetch**
```promql
stargz_fs_bytes_served{operation_type="read_bytes_served_from_prefetch"}
```

**View read bytes served not from prefetch**
```promql
stargz_fs_bytes_served{operation_type="read_bytes_served_not_from_prefetch"}
```

**Calculate overall prefetch hit rate**
```promql
sum(increase(stargz_fs_bytes_served{operation_type="read_bytes_served_from_prefetch"}[5m]))
/
sum(increase(stargz_fs_bytes_served{operation_type=~"read_bytes_served_from_prefetch|read_bytes_served_not_from_prefetch"}[5m]))
```

**View prefetch miss rate**
```promql
sum by (layer) (
  increase(stargz_fs_bytes_served{operation_type="read_bytes_served_not_from_prefetch"}[5m])
)
/
sum by (layer) (
  increase(stargz_fs_bytes_served{operation_type=~"read_bytes_served_from_prefetch|read_bytes_served_not_from_prefetch"}[5m])
)
```

**Calculate prefetch effectiveness**
```promql
sum(increase(stargz_fs_bytes_served{operation_type="read_bytes_served_from_prefetch"}[5m]))
/
sum(increase(stargz_fs_bytes_served{operation_type="prefetch_decompressed_bytes"}[5m]))
```