### PR TITLE
add hot reloading for fs config

### DIFF
--- a/cmd/containerd-stargz-grpc/cfgwatcher.go
+++ b/cmd/containerd-stargz-grpc/cfgwatcher.go
@@ -1,0 +1,152 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/log"
+	fsconfig "github.com/containerd/stargz-snapshotter/fs/config"
+	"github.com/fsnotify/fsnotify"
+	"github.com/pelletier/go-toml"
+)
+
+// WatchConfig monitors the specified configuration file for changes.
+// It triggers the config reload when a change is detected.
+func WatchConfig(
+	ctx context.Context,
+	filePath string,
+	rs snapshots.Snapshotter,
+	initialConfig *fsconfig.Config,
+) error {
+	absFilePath, err := filepath.Abs(filePath)
+	if err != nil {
+		return err
+	}
+
+	watchDir := filepath.Dir(absFilePath)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	if err := watcher.Add(watchDir); err != nil {
+		watcher.Close()
+		return err
+	}
+
+	log.G(ctx).Infof("started monitoring config file: %s", absFilePath)
+
+	cw := &configWatcher{
+		lastConfig: initialConfig,
+	}
+
+	go func() {
+		defer watcher.Close()
+
+		var (
+			debounceTimer *time.Timer
+			mu            sync.Mutex
+		)
+
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+
+				if event.Name == absFilePath {
+					// Trigger on Write, Create, Rename, or Chmod events
+					// such as vim, nano, etc.
+					if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) ||
+						event.Has(fsnotify.Rename) || event.Has(fsnotify.Chmod) {
+
+						mu.Lock()
+						if debounceTimer != nil {
+							debounceTimer.Stop()
+						}
+						// Debounce changes with a 50ms delay
+						debounceTimer = time.AfterFunc(50*time.Millisecond, func() {
+							log.G(ctx).Infof("config file modification detected: %s", absFilePath)
+							cw.reload(ctx, absFilePath, rs)
+						})
+						mu.Unlock()
+					}
+				}
+
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				log.G(ctx).WithError(err).Error("config watcher encountered an error")
+			}
+		}
+	}()
+
+	return nil
+}
+
+type configWatcher struct {
+	lastConfig *fsconfig.Config
+	mu         sync.Mutex
+}
+
+func (w *configWatcher) reload(ctx context.Context, configPath string, rs snapshots.Snapshotter) {
+	log.G(ctx).Infof("Config file %s changed, reloading...", configPath)
+	var newConfig snapshotterConfig
+	tree, err := toml.LoadFile(configPath)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("failed to reload config file")
+		return
+	}
+	if err := tree.Unmarshal(&newConfig); err != nil {
+		log.G(ctx).WithError(err).Error("failed to unmarshal config")
+		return
+	}
+
+	newFsConfig := newConfig.Config.Config
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.lastConfig != nil && reflect.DeepEqual(*w.lastConfig, newFsConfig) {
+		log.G(ctx).Info("Config content unchanged, skipping update")
+		return
+	}
+
+	if updater, ok := rs.(interface {
+		UpdateConfig(context.Context, fsconfig.Config) error
+	}); ok {
+		log.G(ctx).Debugf("applying new config: %+v", newFsConfig)
+		if err := updater.UpdateConfig(ctx, newFsConfig); err != nil {
+			log.G(ctx).WithError(err).Error("failed to update config")
+		} else {
+			log.G(ctx).Info("Config updated successfully")
+			cfgCopy := newFsConfig
+			w.lastConfig = &cfgCopy
+		}
+	} else {
+		log.G(ctx).Warn("snapshotter does not support config update")
+	}
+}

--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -260,6 +260,10 @@ func main() {
 		}
 	}
 
+	if err := WatchConfig(ctx, *configPath, rs, &config.Config.Config); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to start config watcher")
+	}
+
 	cleanup, err := serve(ctx, rpc, *address, rs, config)
 	if err != nil {
 		log.G(ctx).WithError(err).Fatalf("failed to serve snapshotter")

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/containerd/stargz-snapshotter/ipfs v0.18.1
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/docker/go-metrics v0.0.1
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/goccy/go-json v0.10.5
 	github.com/klauspost/compress v1.18.2
 	github.com/opencontainers/go-digest v1.0.0
@@ -56,7 +57,6 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -260,6 +260,14 @@ insecure = true
 
 The config file can be passed to stargz snapshotter using `containerd-stargz-grpc`'s `--config` option.
 
+## Configuration hot reload
+
+[Fs configurations](/fs/config/config.go) supports hot reloading. When the configuration file is modified, the snapshotter detects the change and applies the new configuration without restarting the process.
+This enables instant performance tuning (e.g. concurrency, timeouts) without I/O suspension, and allows updating FUSE parameters that cannot be changed by simply restarting the main process when FUSE manager is enabled.
+
+Note that other configurations (e.g. `proxy_plugins`, `fuse_manager`, `resolver`, `mount_options`) require a restart to take effect.
+Also, some specific fields in `[stargz]` section (e.g. `no_prometheus`) do not support hot reloading and changes to them will be ignored until restart.
+
 ## Make your remote snapshotter
 
 It isn't difficult for you to implement your remote snapshotter using [our general snapshotter package](/snapshot) without considering the protocol between that and containerd.

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/stargz-snapshotter/fs/config"
 	"github.com/moby/sys/mountinfo"
 	"golang.org/x/sync/errgroup"
 )
@@ -164,6 +165,17 @@ func NewSnapshotter(ctx context.Context, root string, targetFs FileSystem, opts 
 	}
 
 	return o, nil
+}
+
+type configUpdater interface {
+	UpdateConfig(ctx context.Context, config config.Config) error
+}
+
+func (o *snapshotter) UpdateConfig(ctx context.Context, config config.Config) error {
+	if updater, ok := o.fs.(configUpdater); ok {
+		return updater.UpdateConfig(ctx, config)
+	}
+	return nil
 }
 
 // Stat returns the info for an active or committed snapshot by name or


### PR DESCRIPTION
Fixes: https://github.com/containerd/stargz-snapshotter/issues/2178

This PR implements hot reloading, but only for fs configurations. My rationale is to reserve this feature for settings that are truly optional improvements.

The fs settings fit this model perfectly: the system is fully functional out-of-the-box, but users can tweak them for better results. Because the "best" value can be subjective or workload-dependent, users may want to adjust them frequently. Hot reloading makes this process of discovery and tuning seamless.

For higher-level settings that control fundamental behavior, hot reloading offers little benefit and introduces potential risk. A restart is the more appropriate mechanism for enabling or altering core features.