### PR TITLE
ctr-remote: fix "-t" flag is not defined for images optimize

### DIFF
--- a/cmd/ctr-remote/commands/flags.go
+++ b/cmd/ctr-remote/commands/flags.go
@@ -66,8 +66,9 @@ func parseGPUs(gpuStr string) ([]int, bool) {
 
 var samplerFlags = []cli.Flag{
 	&cli.BoolFlag{
-		Name:  "terminal,t",
-		Usage: "enable terminal for sample container. must be specified with i option",
+		Name:    "terminal",
+		Aliases: []string{"t"},
+		Usage:   "enable terminal for sample container. must be specified with i option",
 	},
 	&cli.BoolFlag{
 		Name:  "i",


### PR DESCRIPTION
Problem
When following tutorial in `docs/ctr-remote.md`, I tried command below and got hint: `Incorrect Usage: flag provided but not defined: -t`. And I clone the `main` branch and reporduce the same error. The error seems to be the error usage of `urfave/cli`

```
# ctr-remote i optimize -t -i --oci --entrypoint='[ "/bin/bash", "-c" ]' --net-host --args='[ "ip a && curl example.com" ]' ghcr.io/stargz-containers/centos:8-test registry2:5000/centos:8-test-esgz
```

Solution
The original usage is:

```
Name: "command,subcommand",
```

change it into:

```
Name:    "command",
Aliases: []string{"subcommand"},
```