### PR TITLE
k3s: fix CI failure by freeing up more disk space

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,6 +251,11 @@ jobs:
       run: |
         sudo wget -O /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.9.3/yq_linux_amd64
         sudo chmod +x /usr/local/bin/yq
+    - name: Workaround for freeing up more disk space
+      # https://github.com/actions/runner-images/issues/2606
+      run: |
+        sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+        sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
     - uses: actions/checkout@v6
     - name: Run test with k3s
       run: make test-k3s


### PR DESCRIPTION
The test for the k3s main is broken in recent days. Fix it by locking the version to the stable one : https://github.com/containerd/stargz-snapshotter/actions/runs/19996164485/job/57343963732#step:7:5003