### PR TITLE
Add log file access information on first access

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -75,6 +75,9 @@ type Config struct {
 	// NoPrometheus disables exposing filesystem-related metrics. Default is false.
 	NoPrometheus bool `toml:"no_prometheus" json:"no_prometheus"`
 
+	// LogFileAccess enables logging information on first access to each file. Default is false.
+	LogFileAccess bool `toml:"log_file_access" json:"log_file_access"`
+
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob" json:"blob"`
 

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -336,7 +336,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 		enable:           r.config.PassThrough,
 		mergeBufferSize:  r.config.MergeBufferSize,
 		mergeWorkerCount: r.config.MergeWorkerCount,
-	})
+	}, r.config.LogFileAccess)
 	r.layerCacheMu.Lock()
 	cachedL, done2, added := r.layerCache.Add(name, l)
 	r.layerCacheMu.Unlock()
@@ -397,6 +397,7 @@ func newLayer(
 	blob *blobRef,
 	vr *reader.VerifiableReader,
 	pth passThroughConfig,
+	logFileAccess bool,
 ) *layer {
 	return &layer{
 		resolver:         resolver,
@@ -405,6 +406,7 @@ func newLayer(
 		verifiableReader: vr,
 		prefetchWaiter:   newWaiter(),
 		passThrough:      pth,
+		logFileAccess:    logFileAccess,
 	}
 }
 
@@ -426,6 +428,7 @@ type layer struct {
 	prefetchOnce        sync.Once
 	backgroundFetchOnce sync.Once
 	passThrough         passThroughConfig
+	logFileAccess       bool
 }
 
 func (l *layer) Info() Info {
@@ -612,7 +615,7 @@ func (l *layer) RootNode(baseInode uint32) (fusefs.InodeEmbedder, error) {
 	if l.r == nil {
 		return nil, fmt.Errorf("layer hasn't been verified yet")
 	}
-	return newNode(l.desc.Digest, l.r, l.blob, baseInode, l.resolver.overlayOpaqueType, l.passThrough)
+	return newNode(l.desc.Digest, l.r, l.blob, baseInode, l.resolver.overlayOpaqueType, l.passThrough, l.logFileAccess)
 }
 
 func (l *layer) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, error) {

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -286,6 +286,7 @@ func testPrefetch(t *TestRunner, factory metadata.Store, lc layerConfig) {
 					&blobRef{blob, func(bool) {}},
 					vr,
 					lc.passThroughConfig,
+					false,
 				)
 				if err := l.Verify(dgst); err != nil {
 					t.Errorf("failed to verify reader: %v", err)
@@ -824,7 +825,7 @@ func getRootNode(t TestingT, r metadata.Reader, opaque OverlayOpaqueType, tocDgs
 	if err != nil {
 		t.Fatalf("failed to verify reader: %v", err)
 	}
-	rootNode, err := newNode(testStateLayerDigest, rr, &testBlobState{10, 5}, 100, opaque, lc.passThroughConfig)
+	rootNode, err := newNode(testStateLayerDigest, rr, &testBlobState{10, 5}, 100, opaque, lc.passThroughConfig, false)
 	if err != nil {
 		t.Fatalf("failed to get root node: %v", err)
 	}


### PR DESCRIPTION
This PR introduces a file access log in debug mode.
By using a sync.Map to track accessed node IDs, it ensures that metadata for each file—including its path, size, mode, and layer digest—is logged only once when it is first opened or its symlink is read. 
This feature is useful for analyzing container image usage patterns and identifying which files are actually being accessed during runtime.