### PR TITLE
allow asynchronous prefetch via configurable threshold

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -54,6 +54,11 @@ type Config struct {
 	// PrefetchTimeoutSec is the default timeout (in seconds) when the prefetching takes long. Default is 10s.
 	PrefetchTimeoutSec int64 `toml:"prefetch_timeout_sec" json:"prefetch_timeout_sec"`
 
+	// PrefetchAsyncSize is a threshold (in bytes) to allow running containers without waiting for
+	// prefetch completion. If prefetch size exceeds this threshold, prefetch continues in background.
+	// Default is 0 (disabled).
+	PrefetchAsyncSize int64 `toml:"prefetch_async_size" json:"prefetch_async_size"`
+
 	// NoPrefetch disables prefetching. Default is false.
 	NoPrefetch bool `toml:"noprefetch" json:"noprefetch"`
 

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -524,6 +524,16 @@ func (l *layer) prefetch(ctx context.Context, prefetchSize int64) error {
 		prefetchSize = l.blob.Size()
 	}
 
+	threshold := l.resolver.config.PrefetchAsyncSize
+	if threshold > 0 && prefetchSize > threshold {
+		log.G(ctx).Infof(
+			"prefetch size %d > threshold %d; allow container run while prefetching in background",
+			prefetchSize,
+			threshold,
+		)
+		l.prefetchWaiter.done()
+	}
+
 	// Fetch the target range
 	downloadStart := time.Now()
 	err := l.blob.Cache(0, prefetchSize)


### PR DESCRIPTION
Introduce `PrefetchAsyncSize` to enable non-blocking prefetching when the target size is large.

When the prefetch size of a layer exceeds this threshold, the prefetch waiter is notified immediately. This allows the container to start and initialize without waiting for the entire prefetch process to complete, while the data fetching and decompression continue in the background.

This is particularly beneficial for AI/ML workloads where container images often contain massive model files (e.g., >10GB). By using this feature, the AI framework can start running and loading its environment immediately, while the large model layers are being prefetched in the background, significantly reducing the overall startup latency.