### PR TITLE
CI: k3s: Use v1.35.4 tag

### DIFF
--- a/script/k3s-argo-workflow/run.sh
+++ b/script/k3s-argo-workflow/run.sh
@@ -26,7 +26,7 @@ ARGO_VERSION=v3.6.4
 
 K3S_NODE_REPO=ghcr.io/stargz-containers
 K3S_NODE_IMAGE_NAME=k3s
-K3S_NODE_TAG=v1.35.3-k3s1
+K3S_NODE_TAG=v1.35.4-k3s1
 K3S_NODE_IMAGE="${K3S_NODE_REPO}/${K3S_NODE_IMAGE_NAME}:${K3S_NODE_TAG}"
 K3S_CLUSTER_NAME="k3s-demo-cluster-$(date +%s%N | shasum | base64 | fold -w 10 | head -1)"
 

--- a/script/k3s/run-k3s.sh
+++ b/script/k3s/run-k3s.sh
@@ -23,7 +23,7 @@ K3S_CONTAINERD_REPO=https://github.com/k3s-io/containerd
 REGISTRY_HOST=k3s-private-registry
 K3S_NODE_REPO=ghcr.io/stargz-containers
 K3S_NODE_IMAGE_NAME=k3s
-K3S_NODE_TAG=v1.35.3-k3s1
+K3S_NODE_TAG=v1.35.4-k3s1
 K3S_NODE_IMAGE="${K3S_NODE_REPO}/${K3S_NODE_IMAGE_NAME}:${K3S_NODE_TAG}"
 
 # Arguments


### PR DESCRIPTION
Fix the recent CI failures

https://github.com/containerd/stargz-snapshotter/actions/runs/24693951901/job/72222301115?pr=2296
```
3.020 ++ [[ ! v1.35.3-k3s1 =~ ^v1\.35\.4[+-] ]]
3.020 ++ echo 'Tagged version '\''v1.35.3-k3s1'\'' does not match expected version '\''v1.35.4[+-]*'\'''
3.020 Tagged version 'v1.35.3-k3s1' does not match expected version 'v1.35.4[+-]*'
3.020 ++ exit 1
```