### PR TITLE
cmd/ctr-remote: add --runtime flag to image optimize command

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -160,15 +160,16 @@ func Analyze(ctx context.Context, client *containerd.Client, ref string, opts ..
 	for range 3 {
 		id := xid.New().String()
 		var s runtimespec.Spec
-		container, err = client.NewContainer(ctx, id,
+		cOpts := []containerd.NewContainerOpts{
 			containerd.WithImage(platformImg),
 			containerd.WithSnapshotter(aOpts.snapshotter),
 			containerd.WithImageStopSignal(platformImg, "SIGKILL"),
-
-			// WithImageConfig depends on WithImage and WithSnapshotter for resolving
-			// username (accesses to /etc/{passwd,group} files on the rootfs)
 			containerd.WithSpec(&s, sOpts...),
-		)
+		}
+		if aOpts.runtime != "" {
+			cOpts = append(cOpts, containerd.WithRuntime(aOpts.runtime, nil))
+		}
+		container, err = client.NewContainer(ctx, id, cOpts...)
 		if err != nil {
 			if errdefs.IsAlreadyExists(err) {
 				log.G(ctx).WithError(err).Warnf("failed to create container")

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -164,6 +164,9 @@ func Analyze(ctx context.Context, client *containerd.Client, ref string, opts ..
 			containerd.WithImage(platformImg),
 			containerd.WithSnapshotter(aOpts.snapshotter),
 			containerd.WithImageStopSignal(platformImg, "SIGKILL"),
+
+			// WithImageConfig depends on WithImage and WithSnapshotter for resolving
+			// username (accesses to /etc/{passwd,group} files on the rootfs)
 			containerd.WithSpec(&s, sOpts...),
 		}
 		if aOpts.runtime != "" {

--- a/analyzer/option.go
+++ b/analyzer/option.go
@@ -27,6 +27,7 @@ type analyzerOpts struct {
 	period       time.Duration
 	waitOnSignal bool
 	snapshotter  string
+	runtime      string
 	specOpts     SpecOpts
 	terminal     bool
 	stdin        bool
@@ -79,6 +80,13 @@ func WithWaitOnSignal() Option {
 func WithSnapshotter(snapshotter string) Option {
 	return func(opts *analyzerOpts) {
 		opts.snapshotter = snapshotter
+	}
+}
+
+// WithRuntime is the runtime to use for the analyzer container.
+func WithRuntime(runtime string) Option {
+	return func(opts *analyzerOpts) {
+		opts.runtime = runtime
 	}
 }
 

--- a/cmd/ctr-remote/commands/flags.go
+++ b/cmd/ctr-remote/commands/flags.go
@@ -84,6 +84,10 @@ var samplerFlags = []cli.Flag{
 		Usage: "user/group name to override image's default config(user[:group])",
 	},
 	&cli.StringFlag{
+		Name:  "runtime",
+		Usage: "runtime name to use for the analyzer container (e.g., io.containerd.runc.v2, io.containerd.crun.v1)",
+	},
+	&cli.StringFlag{
 		Name:  "cwd",
 		Usage: "working dir to override image's default config",
 	},

--- a/cmd/ctr-remote/commands/optimize.go
+++ b/cmd/ctr-remote/commands/optimize.go
@@ -459,6 +459,9 @@ func analyze(ctx context.Context, clicontext *cli.Context, client *containerd.Cl
 
 	// Analyze layers and get prioritized files
 	aOpts := []analyzer.Option{analyzer.WithSpecOpts(getSpecOpts(clicontext))}
+	if runtime := clicontext.String("runtime"); runtime != "" {
+		aOpts = append(aOpts, analyzer.WithRuntime(runtime))
+	}
 	if clicontext.IsSet("gpus") {
 		aOpts = append(aOpts, analyzer.WithPreMonitor())
 	}


### PR DESCRIPTION
## Summary

The `ctr-remote image optimize` command creates an analyzer container to
profile workload access patterns. Without the ability to specify a runtime,
it defaults to the containerd-configured runtime (typically runc). In
environments using crun as the OCI runtime, this causes "runc not found"
errors.

Added a `--runtime` flag that allows users to specify the runtime name
(e.g., `io.containerd.crun.v1`) for the analyzer container.

### Changes
- `analyzer/option.go`: added `runtime` field and `WithRuntime()` option
- `analyzer/analyzer.go`: pass `containerd.WithRuntime()` when creating the container
- `cmd/ctr-remote/commands/flags.go`: added `--runtime` flag to sampler flags
- `cmd/ctr-remote/commands/optimize.go`: wire the runtime flag to analyzer options

### Usage
```bash
ctr-remote image optimize --runtime io.containerd.crun.v1 source:tag target:tag
```

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #1918
