### PR TITLE
CI: fix k3s test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9.2.0
       with:
-        version: v2.6
+        version: v2.11
         args: --verbose --timeout=10m
         working-directory: ${{ matrix.targetdir }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         fetch-depth: '0'
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25.x'
+        go-version: '1.26.x'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9.2.0
       with:
@@ -241,7 +241,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25.x'
+        go-version: '1.26.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.8.3/install.sh | bash
@@ -271,7 +271,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.25.x'
+        go-version: '1.26.x'
     - name: Install k3d
       run: |
         wget -q -O - https://raw.githubusercontent.com/rancher/k3d/v5.8.3/install.sh | bash
@@ -316,7 +316,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
       - uses: actions/checkout@v6
         with:
           path: src/github.com/containerd/stargz-snapshotter

--- a/script/k3s-argo-workflow/run.sh
+++ b/script/k3s-argo-workflow/run.sh
@@ -26,8 +26,7 @@ ARGO_VERSION=v3.6.4
 
 K3S_NODE_REPO=ghcr.io/stargz-containers
 K3S_NODE_IMAGE_NAME=k3s
-K3S_NODE_TAG=v1.35.4-k3s1
-K3S_NODE_IMAGE="${K3S_NODE_REPO}/${K3S_NODE_IMAGE_NAME}:${K3S_NODE_TAG}"
+K3S_NODE_IMAGE=
 K3S_CLUSTER_NAME="k3s-demo-cluster-$(date +%s%N | shasum | base64 | fold -w 10 | head -1)"
 
 ORG_ARGOYAML=$(mktemp)
@@ -160,6 +159,10 @@ echo "replace github.com/containerd/stargz-snapshotter/estargz => ./scripts/vend
 
 cat "${TMP_K3S_REPO}/go.mod"
 
+# K3s's script to create the image requires specific name for the tag determined by the k8s.io/kubernetes go module's version name (see scripts/version.sh)
+REQUIRED_VERSION_NAME=$(go -C "${TMP_K3S_REPO}" list -mod=readonly -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' k8s.io/kubernetes)
+K3S_NODE_IMAGE="${K3S_NODE_REPO}/${K3S_NODE_IMAGE_NAME}:${REQUIRED_VERSION_NAME}"
+
 (
     cd "${TMP_K3S_REPO}" && \
         export GOTOOLCHAIN=auto && \
@@ -170,7 +173,7 @@ cat "${TMP_K3S_REPO}/go.mod"
         make deps && \
         git add . && \
         git commit -m tmp && \
-        SKIP_AIRGAP=1 REPO="${K3S_NODE_REPO}" IMAGE_NAME="${K3S_NODE_IMAGE_NAME}" TAG="${K3S_NODE_TAG}" SKIP_VALIDATE=1 make local-image
+        SKIP_AIRGAP=1 REPO="${K3S_NODE_REPO}" IMAGE_NAME="${K3S_NODE_IMAGE_NAME}" TAG="${REQUIRED_VERSION_NAME}" SKIP_VALIDATE=1 make local-image
 )
 
 #1

--- a/script/k3s/run-k3s.sh
+++ b/script/k3s/run-k3s.sh
@@ -23,8 +23,6 @@ K3S_CONTAINERD_REPO=https://github.com/k3s-io/containerd
 REGISTRY_HOST=k3s-private-registry
 K3S_NODE_REPO=ghcr.io/stargz-containers
 K3S_NODE_IMAGE_NAME=k3s
-K3S_NODE_TAG=v1.35.4-k3s1
-K3S_NODE_IMAGE="${K3S_NODE_REPO}/${K3S_NODE_IMAGE_NAME}:${K3S_NODE_TAG}"
 
 # Arguments
 K3S_CLUSTER_NAME="${1}"
@@ -61,6 +59,10 @@ echo "replace github.com/containerd/stargz-snapshotter/estargz => ./scripts/vend
 
 cat "${TMP_K3S_REPO}/go.mod"
 
+# K3s's script to create the image requires specific name for the tag determined by the k8s.io/kubernetes go module's version name (see scripts/version.sh)
+REQUIRED_VERSION_NAME=$(go list -C "${TMP_K3S_REPO}" -mod=readonly -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' k8s.io/kubernetes)
+K3S_NODE_IMAGE="${K3S_NODE_REPO}/${K3S_NODE_IMAGE_NAME}:${REQUIRED_VERSION_NAME}"
+
 (
     cd "${TMP_K3S_REPO}" && \
         export GOTOOLCHAIN=auto && \
@@ -71,8 +73,9 @@ cat "${TMP_K3S_REPO}/go.mod"
         make deps && \
         git add . && \
         git commit -m tmp && \
-        SKIP_AIRGAP=1 REPO="${K3S_NODE_REPO}" IMAGE_NAME="${K3S_NODE_IMAGE_NAME}" TAG="${K3S_NODE_TAG}" SKIP_VALIDATE=1 make local-image
+        SKIP_AIRGAP=1 REPO="${K3S_NODE_REPO}" IMAGE_NAME="${K3S_NODE_IMAGE_NAME}" TAG="${REQUIRED_VERSION_NAME}" SKIP_VALIDATE=1 make local-image
 )
+
 cat <<EOF > "${TMP_BUILTIN_CONF}"
 mirrors:
   ${REGISTRY_HOST}:5000:


### PR DESCRIPTION
This commit fixes the recent k3s ci failure by meeting the naming conversion required by k3s's  script.