### PR TITLE
ci: declare workflow-level `contents: read` on benchmark, kind-image, tests

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,9 @@ on:
 env:
   DOCKER_BUILDKIT: 1
 
+permissions:
+  contents: read
+
 jobs:
   hello-bench:
     runs-on: ubuntu-24.04

--- a/.github/workflows/kind-image.yml
+++ b/.github/workflows/kind-image.yml
@@ -9,6 +9,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+
 jobs:
   kind-image:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
 env:
   DOCKER_BUILDKIT: 1
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Three CI workflows just run benchmarks / kind-based image tests. No GitHub API writes from the workflows.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.