### PR TITLE
estargz: Fix panic in go 1.27RC by emitting footer manually

### DIFF
--- a/estargz/externaltoc/externaltoc.go
+++ b/estargz/externaltoc/externaltoc.go
@@ -126,23 +126,20 @@ const FooterSize = 46
 
 // gzipFooterBytes returns the 104 bytes footer.
 func gzipFooterBytes() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0, FooterSize))
-	gz, _ := gzip.NewWriterLevel(buf, gzip.NoCompression) // MUST be NoCompression to keep 51 bytes
-
-	// Extra header indicating the offset of TOCJSON
+	// Extra header indicating the external toc
 	// https://tools.ietf.org/html/rfc1952#section-2.3.1.1
 	header := make([]byte, 4)
 	header[0], header[1] = 'S', 'G'
 	subfield := "STARGZEXTERNALTOC"                                   // len("STARGZEXTERNALTOC") = 17
 	binary.LittleEndian.PutUint16(header[2:4], uint16(len(subfield))) // little-endian per RFC1952
-	gz.Extra = append(header, []byte(subfield)...)
-	if err := gz.Close(); err != nil {
-		return nil, err
+	extra := append(header, []byte(subfield)...)
+
+	buf := estargz.CreateGzipFooter(extra)
+
+	if len(buf) != FooterSize {
+		panic(fmt.Sprintf("footer buffer = %d, not %d", len(buf), FooterSize))
 	}
-	if buf.Len() != FooterSize {
-		panic(fmt.Sprintf("footer buffer = %d, not %d", buf.Len(), FooterSize))
-	}
-	return buf.Bytes(), nil
+	return buf, nil
 }
 
 func NewGzipDecompressor(provideTOCFunc func() ([]byte, error)) *GzipDecompressor {

--- a/estargz/gzip.go
+++ b/estargz/gzip.go
@@ -100,21 +100,52 @@ func (gc *GzipCompressor) WriteTOCAndFooter(w io.Writer, off int64, toc *JTOC, d
 
 // gzipFooterBytes returns the 51 bytes footer.
 func gzipFooterBytes(tocOff int64) []byte {
-	buf := bytes.NewBuffer(make([]byte, 0, FooterSize))
-	gz, _ := gzip.NewWriterLevel(buf, gzip.NoCompression) // MUST be NoCompression to keep 51 bytes
-
 	// Extra header indicating the offset of TOCJSON
 	// https://tools.ietf.org/html/rfc1952#section-2.3.1.1
 	header := make([]byte, 4)
 	header[0], header[1] = 'S', 'G'
 	subfield := fmt.Sprintf("%016xSTARGZ", tocOff)
 	binary.LittleEndian.PutUint16(header[2:4], uint16(len(subfield))) // little-endian per RFC1952
-	gz.Extra = append(header, []byte(subfield)...)
-	gz.Close()
-	if buf.Len() != FooterSize {
-		panic(fmt.Sprintf("footer buffer = %d, not %d", buf.Len(), FooterSize))
+	extra := append(header, []byte(subfield)...)
+
+	buf := CreateGzipFooter(extra)
+	if len(buf) != FooterSize {
+		panic(fmt.Sprintf("footer buffer = %d, not %d", len(buf), FooterSize))
 	}
-	return buf.Bytes()
+	return buf
+}
+
+// CreateGzipFooter creates eStargz's footer with the specified extra field.
+func CreateGzipFooter(extra []byte) []byte {
+	// Gzip header (10 bytes)
+	// https://datatracker.ietf.org/doc/html/rfc1952
+	buf := make([]byte, 10)
+	buf[0] = 0x1f // ID1
+	buf[1] = 0x8b // ID2
+	buf[2] = 8    // "deflate"
+	buf[3] = 0x4  // FEXTRA
+	// MTIME = 0
+	// XFL = 0
+	buf[9] = 255 // unknown
+
+	// Extra field
+	xlen := make([]byte, 2)
+	binary.LittleEndian.PutUint16(xlen, uint16(len(extra)))
+	buf = append(buf, append(xlen, extra...)...)
+
+	// Flate header (5 bytes)
+	// https://datatracker.ietf.org/doc/html/rfc1951
+	flateHeader := []byte{
+		1,    // BFINAL = 1 (last block), BFTYPE = 0 (no compression), remaining bits are ignored
+		0, 0, // LEN = 0
+		0xff, 0xff, // NLEN (the one's complement of LEN)
+	}
+	buf = append(buf, flateHeader...)
+
+	// Gzip footer (8 bytes): CRC32 = 0, ISIZE = 0
+	buf = append(buf, make([]byte, 8)...)
+
+	return buf
 }
 
 type GzipDecompressor struct{}

--- a/estargz/gzip_test.go
+++ b/estargz/gzip_test.go
@@ -151,12 +151,9 @@ func TestGzipParseFooterInvalidExtra(t *testing.T) {
 }
 
 func legacyFooterBytes(tocOff int64) []byte {
-	buf := bytes.NewBuffer(make([]byte, 0, legacyFooterSize))
-	gz, _ := gzip.NewWriterLevel(buf, gzip.NoCompression)
-	gz.Extra = fmt.Appendf(nil, "%016xSTARGZ", tocOff)
-	gz.Close()
-	if buf.Len() != legacyFooterSize {
-		panic(fmt.Sprintf("footer buffer = %d, not %d", buf.Len(), legacyFooterSize))
+	buf := CreateGzipFooter(fmt.Appendf(nil, "%016xSTARGZ", tocOff))
+	if len(buf) != legacyFooterSize {
+		panic(fmt.Sprintf("footer buffer = %d, not %d", len(buf), legacyFooterSize))
 	}
-	return buf.Bytes()
+	return buf
 }


### PR DESCRIPTION
Fixes #2330

You can test this with the tip version of the go compiler.

```
docker run --rm -it -v $(pwd):/build/:ro -w /build/estargz/ golang:tip /bin/bash -c "go version ; go test ./..."
```
