### PR TITLE
estargz: parallelize MinChunkSize builds

### DIFF
--- a/cmd/ctr-remote/commands/convert.go
+++ b/cmd/ctr-remote/commands/convert.go
@@ -82,7 +82,7 @@ When '--all-platforms' is given all images in a manifest list must be available.
 		},
 		&cli.IntFlag{
 			Name:  "estargz-parallelism",
-			Usage: "Number of workers used to build the layer. Pinning it makes builds reproducible across machines regardless of CPU count. 0 (default) uses GOMAXPROCS; 1 forces a sequential build. Has no effect with --estargz-min-chunk-size.",
+			Usage: "Number of workers used to build the layer. Pinning it makes builds reproducible across machines regardless of CPU count. 0 (default) uses GOMAXPROCS; 1 forces a sequential build.",
 			Value: 0,
 		},
 		&cli.BoolFlag{

--- a/cmd/ctr-remote/commands/optimize.go
+++ b/cmd/ctr-remote/commands/optimize.go
@@ -115,7 +115,7 @@ var OptimizeCommand = &cli.Command{
 		},
 		&cli.IntFlag{
 			Name:  "estargz-parallelism",
-			Usage: "Number of workers used to build the layer. Pinning it makes builds reproducible across machines regardless of CPU count. 0 (default) uses GOMAXPROCS; 1 forces a sequential build. Has no effect with --estargz-min-chunk-size (not applied to zstd:chunked)",
+			Usage: "Number of workers used to build the layer. Pinning it makes builds reproducible across machines regardless of CPU count. 0 (default) uses GOMAXPROCS; 1 forces a sequential build (not applied to zstd:chunked)",
 			Value: 0,
 		},
 		&cli.StringFlag{

--- a/docs/smaller-estargz.md
+++ b/docs/smaller-estargz.md
@@ -4,9 +4,9 @@ The following flags of `ctr-remote i convert` and `ctr-remote i optimize` allow 
 
 - `--estargz-external-toc`: Separate TOC JSON into another image (called "TOC image"). The result eStargz doesn't contain TOC so we can expect a smaller size than normal eStargz.
 
-- `--estargz-min-chunk-size`: The minimal number of bytes of data must be written in one gzip stream. If it's > 0, multiple files and chunks can be written into one gzip stream. Smaller number of gzip header and smaller size of the result blob can be expected. `--estargz-min-chunk-size=0` produces normal eStargz.
+- `--estargz-min-chunk-size`: The minimal number of bytes of data must be written in one gzip stream. If it's > 0, multiple files and chunks can be written into one gzip stream. Smaller number of gzip header and smaller size of the result blob can be expected. `--estargz-min-chunk-size=0` produces normal eStargz. A trailing gzip stream that cannot reach the minimum is folded into the preceding stream instead, so a stream falls below `--estargz-min-chunk-size` only when the layer itself is smaller.
 
-- `--estargz-parallelism`: The number of workers used to build each layer. The tar is split into this many slices that are compressed in parallel, so the value also fixes the chunk boundaries: pinning it makes builds reproducible across machines regardless of their CPU count. `0` (the default) uses `GOMAXPROCS`; `1` forces a fully sequential build. This has no effect with `--estargz-min-chunk-size`, which is built with a single worker.
+- `--estargz-parallelism`: The number of workers used to build each layer. The tar is split into this many slices that are compressed in parallel, so the value also fixes the chunk boundaries: pinning it makes builds reproducible across machines regardless of their CPU count. `0` (the default) uses `GOMAXPROCS`; `1` forces a fully sequential build. With `--estargz-min-chunk-size`, fewer workers may be used when the layer is too small to give each one at least one full gzip stream.
 
 ## `--estargz-external-toc` usage
 

--- a/estargz/build.go
+++ b/estargz/build.go
@@ -123,6 +123,10 @@ func WithContext(ctx context.Context) Option {
 // By increasing this number, one gzip stream can contain multiple files
 // and it hopefully leads to smaller result blob.
 // NOTE: This adds a TOC property that old reader doesn't understand.
+// Builds run in parallel across the configured workers (see WithParallelism);
+// a trailing stream that cannot reach minChunkSize is folded into its
+// predecessor, so a stream falls below minChunkSize only when the input itself
+// is smaller.
 func WithMinChunkSize(minChunkSize int) Option {
 	return func(o *options) error {
 		o.minChunkSize = minChunkSize
@@ -135,8 +139,8 @@ func WithMinChunkSize(minChunkSize int) Option {
 // concurrently, so the value also fixes the resulting chunk boundaries: pinning
 // it makes builds reproducible across machines regardless of their CPU count.
 // Zero (the default) selects runtime.GOMAXPROCS(0); a value of 1 forces a fully
-// sequential build. This has no effect together with WithMinChunkSize, which is
-// always built with a single worker.
+// sequential build. With WithMinChunkSize, fewer workers may be used when the
+// layer is too small to give each one at least one full gzip stream.
 func WithParallelism(workers int) Option {
 	return func(o *options) error {
 		o.parallelism = workers
@@ -246,11 +250,16 @@ func Build(tarBlob *io.SectionReader, opt ...Option) (_ *Blob, rErr error) {
 		workers = runtime.GOMAXPROCS(0)
 	}
 	var tarParts [][]*entry
-	if opts.minChunkSize > 0 {
-		// Each entry needs to know the size of the current gzip stream so they
-		// cannot be processed in parallel.
+	switch {
+	case workers <= 1:
 		tarParts = [][]*entry{entries}
-	} else {
+	case opts.minChunkSize > 0:
+		// Give each worker enough data to fill at least one full stream even at
+		// gzip's maximum compression ratio, so that folding a short trailing
+		// stream (see cutGz) never crosses worker boundaries. This coarsens
+		// parallelism, but layers small enough to stay sequential compress fast.
+		tarParts = divideEntriesByMinSize(entries, workers, int64(opts.minChunkSize)*maxGzipCompressionRatio)
+	default:
 		tarParts = divideEntries(entries, workers)
 	}
 	writers := make([]*Writer, len(tarParts))
@@ -391,6 +400,50 @@ func tocAndFooter(compressor Compressor, toc *JTOC, offset int64) (io.Reader, di
 		return nil, "", err
 	}
 	return buf, tocDigest, nil
+}
+
+// maxGzipCompressionRatio is the largest ratio DEFLATE can achieve: a 258-byte
+// match coded as a roughly two-bit symbol pair, i.e. 258*8/2 = 1032. A slice
+// of MinChunkSize*1032 bytes thus compresses to at least MinChunkSize.
+const maxGzipCompressionRatio = 1032
+
+// divideEntriesByMinSize packs entries into at most maxParts consecutive
+// groups of at least minPartSize uncompressed bytes each (total/maxParts when
+// that is larger). A trailing remainder below minPartSize is folded into the
+// last group; data that cannot fill even one group is returned as one.
+func divideEntriesByMinSize(entries []*entry, maxParts int, minPartSize int64) (set [][]*entry) {
+	var total int64
+	for _, e := range entries {
+		total += e.header.Size
+	}
+	target := total / int64(maxParts)
+	if target < minPartSize {
+		target = minPartSize
+	}
+	var (
+		cur     []*entry
+		curSize int64
+	)
+	for _, e := range entries {
+		cur = append(cur, e)
+		curSize += e.header.Size
+		// the last group takes the remainder, so the count never exceeds maxParts
+		if curSize >= target && len(set) < maxParts-1 {
+			set = append(set, cur)
+			cur, curSize = nil, 0
+		}
+	}
+	switch {
+	case len(cur) == 0:
+	case len(set) > 0 && curSize < minPartSize:
+		set[len(set)-1] = append(set[len(set)-1], cur...)
+	default:
+		set = append(set, cur)
+	}
+	if len(set) == 0 {
+		set = [][]*entry{entries}
+	}
+	return
 }
 
 // divideEntries divides passed entries to the parts at least the number specified by the

--- a/estargz/build_test.go
+++ b/estargz/build_test.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"reflect"
 	"runtime"
+	"sort"
 	"testing"
 )
 
@@ -674,24 +675,6 @@ func TestCountReader(t *testing.T) {
 
 }
 
-func sampleTar(t *testing.T, n, size int) (tarBytes []byte, want map[string]string) {
-	t.Helper()
-	want = make(map[string]string, n)
-	var ents []tarEntry
-	for i := 0; i < n; i++ {
-		name := fmt.Sprintf("file%04d", i)
-		content := randomContents(size)
-		want[name] = content
-		ents = append(ents, file(name, content))
-	}
-	sr := buildTar(t, ents, "")
-	tarBytes = make([]byte, sr.Size())
-	if _, err := sr.ReadAt(tarBytes, 0); err != nil && err != io.EOF {
-		t.Fatalf("read tar: %v", err)
-	}
-	return tarBytes, want
-}
-
 func buildBlobBytes(t *testing.T, tarBytes []byte, opts ...Option) []byte {
 	t.Helper()
 	blob, err := Build(io.NewSectionReader(bytes.NewReader(tarBytes), 0, int64(len(tarBytes))), opts...)
@@ -708,6 +691,29 @@ func buildBlobBytes(t *testing.T, tarBytes []byte, opts ...Option) []byte {
 	return data
 }
 
+// sortedStreamOffsets returns the distinct gzip-stream start offsets in
+// ascending order, so consecutive differences give each interior stream's size.
+func sortedStreamOffsets(t *testing.T, blob []byte) []int64 {
+	t.Helper()
+	r, err := Open(io.NewSectionReader(bytes.NewReader(blob), 0, int64(len(blob))))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	set := make(map[int64]struct{})
+	for _, e := range r.toc.Entries {
+		if e.Type == "chunk" || (e.Type == "reg" && e.Size > 0) {
+			set[e.Offset] = struct{}{}
+		}
+	}
+	out := make([]int64, 0, len(set))
+	for o := range set {
+		out = append(out, o)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// assertRoundTrip verifies that every file in want is recoverable from blob.
 func assertRoundTrip(t *testing.T, blob []byte, want map[string]string) {
 	t.Helper()
 	r, err := Open(io.NewSectionReader(bytes.NewReader(blob), 0, int64(len(blob))))
@@ -737,7 +743,7 @@ func assertRoundTrip(t *testing.T, blob []byte, want map[string]string) {
 // same blob regardless of GOMAXPROCS, which is what makes parallel builds
 // reproducible across machines with different core counts.
 func TestBuildParallelismReproducible(t *testing.T) {
-	tarBytes, want := sampleTar(t, 128, 1500)
+	tarBytes, want := sampleTar(t, 128, 1500, randomContents)
 
 	prev := runtime.GOMAXPROCS(2)
 	defer runtime.GOMAXPROCS(prev)
@@ -751,4 +757,270 @@ func TestBuildParallelismReproducible(t *testing.T) {
 		t.Fatalf("blob differs with GOMAXPROCS: parallelism must be honored verbatim")
 	}
 	assertRoundTrip(t, withTwoCores, want)
+}
+
+// compressibleContent returns n bytes from a short repeating pattern so a
+// worker's slice compresses well, keeping parallel MinChunkSize test blobs small.
+// It is the compressible counterpart to randomContents from testutil.go.
+func compressibleContent(n int) string {
+	const pat = "estargz/parallel-min-chunk-size/0123456789abcdef "
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = pat[i%len(pat)]
+	}
+	return string(b)
+}
+
+func sampleTar(t *testing.T, n, size int, gen func(n int) string) (tarBytes []byte, want map[string]string) {
+	t.Helper()
+	want = make(map[string]string, n)
+	var ents []tarEntry
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("file%04d", i)
+		content := gen(size)
+		want[name] = content
+		ents = append(ents, file(name, content))
+	}
+	sr := buildTar(t, ents, "")
+	tarBytes = make([]byte, sr.Size())
+	if _, err := sr.ReadAt(tarBytes, 0); err != nil && err != io.EOF {
+		t.Fatalf("read tar: %v", err)
+	}
+	return tarBytes, want
+}
+
+func entriesOfSizes(sizes ...int64) []*entry {
+	es := make([]*entry, len(sizes))
+	for i, s := range sizes {
+		es[i] = &entry{header: &tar.Header{Size: s}}
+	}
+	return es
+}
+
+// TestDivideEntriesByMinSize verifies that every group but the last carries at
+// least the per-worker target and the group count never exceeds the worker cap.
+func TestDivideEntriesByMinSize(t *testing.T) {
+	tests := []struct {
+		name        string
+		sizes       []int64
+		maxParts    int
+		minPartSize int64
+		wantParts   int
+	}{
+		{"fills exactly maxParts", []int64{100, 100, 100, 100, 100, 100, 100, 100}, 4, 100, 4},
+		{"floor raises target", []int64{100, 100, 100, 100, 100, 100, 100, 100}, 100, 250, 2},
+		{"cap raises target", []int64{100, 100, 100, 100, 100, 100, 100, 100}, 2, 100, 2},
+		{"single huge entry", []int64{1000}, 4, 100, 1},
+		{"skewed entries", []int64{100, 1000, 100, 100}, 4, 150, 2},
+		{"oversized maxParts", []int64{100, 100, 100, 100, 100, 100, 100, 100}, 1_000_000, 250, 2},
+		{"trailing runt folds into last group", []int64{100, 100, 100, 100, 100}, 4, 150, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries := entriesOfSizes(tt.sizes...)
+			var total int64
+			for _, s := range tt.sizes {
+				total += s
+			}
+			target := total / int64(tt.maxParts)
+			if target < tt.minPartSize {
+				target = tt.minPartSize
+			}
+
+			set := divideEntriesByMinSize(entries, tt.maxParts, tt.minPartSize)
+
+			if len(set) > tt.maxParts {
+				t.Fatalf("group count %d exceeds maxParts %d", len(set), tt.maxParts)
+			}
+			if tt.wantParts != 0 && len(set) != tt.wantParts {
+				t.Fatalf("group count = %d, want %d", len(set), tt.wantParts)
+			}
+			// Every group but the last must reach the target.
+			for i := 0; i+1 < len(set); i++ {
+				var sum int64
+				for _, e := range set[i] {
+					sum += e.header.Size
+				}
+				if sum < target {
+					t.Fatalf("group %d carries %d < target %d", i, sum, target)
+				}
+			}
+			// The last group must also reach minPartSize when there are multiple groups.
+			if len(set) > 1 {
+				var sum int64
+				for _, e := range set[len(set)-1] {
+					sum += e.header.Size
+				}
+				if sum < tt.minPartSize {
+					t.Fatalf("last group carries %d < minPartSize %d", sum, tt.minPartSize)
+				}
+			}
+			// The partition must preserve every entry in order.
+			var flat []*entry
+			for _, g := range set {
+				flat = append(flat, g...)
+			}
+			if !reflect.DeepEqual(flat, entries) {
+				t.Fatalf("partition did not preserve entries in order")
+			}
+		})
+	}
+}
+
+// buildAtGOMAXPROCS builds tarBytes at the given GOMAXPROCS, then restores it.
+func buildAtGOMAXPROCS(t *testing.T, procs int, tarBytes []byte, opts ...Option) []byte {
+	t.Helper()
+	prev := runtime.GOMAXPROCS(procs)
+	defer runtime.GOMAXPROCS(prev)
+	return buildBlobBytes(t, tarBytes, opts...)
+}
+
+// TestBuildMinChunkSizeMergesStreams exercises the per-worker merge end to end:
+// every stream (including the final one) must reach MinChunkSize.
+func TestBuildMinChunkSizeMergesStreams(t *testing.T) {
+	const (
+		minChunk = 128
+		workers  = 2
+	)
+	// Each worker must hold minChunk*maxGzipCompressionRatio incompressible bytes;
+	// size the layer to fill both workers.
+	perWorker := minChunk * maxGzipCompressionRatio
+	tarBytes, want := sampleTar(t, workers*5, perWorker/4, randomContents)
+
+	blob := buildAtGOMAXPROCS(t, workers, tarBytes, WithChunkSize(512), WithMinChunkSize(minChunk))
+	assertRoundTrip(t, blob, want)
+
+	offsets := sortedStreamOffsets(t, blob)
+	if len(offsets) <= workers {
+		t.Fatalf("expected several streams per worker, got %d streams for %d workers", len(offsets), workers)
+	}
+	// Interior streams.
+	for i := 0; i+1 < len(offsets); i++ {
+		if size := offsets[i+1] - offsets[i]; size < minChunk {
+			t.Fatalf("interior stream at offset %d is under-packed: %d < %d", offsets[i], size, minChunk)
+		}
+	}
+	// Final stream: from last offset to the start of the TOC.
+	tocOff, _, err := OpenFooter(io.NewSectionReader(bytes.NewReader(blob), 0, int64(len(blob))))
+	if err != nil {
+		t.Fatalf("OpenFooter: %v", err)
+	}
+	if size := tocOff - offsets[len(offsets)-1]; size < minChunk {
+		t.Fatalf("final stream at offset %d is under-packed: %d < %d", offsets[len(offsets)-1], size, minChunk)
+	}
+}
+
+// TestBuildMinChunkSizeParallelizes checks that a large layer splits across
+// workers while a small layer stays byte-identical to the single-core build,
+// with its short trailing stream folded into the predecessor.
+func TestBuildMinChunkSizeParallelizes(t *testing.T) {
+	const minChunk = 512
+	perWorker := minChunk * maxGzipCompressionRatio
+
+	t.Run("large layer splits", func(t *testing.T) {
+		tarBytes, want := sampleTar(t, 64, perWorker/8, compressibleContent) // several workers' worth
+		parallel := buildAtGOMAXPROCS(t, 4, tarBytes, WithMinChunkSize(minChunk))
+		sequential := buildAtGOMAXPROCS(t, 1, tarBytes, WithMinChunkSize(minChunk))
+
+		assertRoundTrip(t, parallel, want)
+		if bytes.Equal(parallel, sequential) {
+			t.Fatalf("a large layer should be split across workers")
+		}
+	})
+
+	t.Run("small layer stays sequential", func(t *testing.T) {
+		// Far below one worker's floor: the build is single-part at any GOMAXPROCS,
+		// so parallel and sequential must be byte-identical.
+		var ents []tarEntry
+		want := map[string]string{}
+		for i := 0; i < 4; i++ {
+			name := fmt.Sprintf("full%02d", i)
+			c := randomContents(4 * minChunk) // one full stream each
+			ents = append(ents, file(name, c))
+			want[name] = c
+		}
+		tail := randomContents(32) // short trailing stream
+		ents = append(ents, file("tail", tail))
+		want["tail"] = tail
+
+		sr := buildTar(t, ents, "")
+		tarBytes := make([]byte, sr.Size())
+		if _, err := sr.ReadAt(tarBytes, 0); err != nil && err != io.EOF {
+			t.Fatalf("read tar: %v", err)
+		}
+
+		parallel := buildAtGOMAXPROCS(t, 4, tarBytes, WithMinChunkSize(minChunk))
+		sequential := buildAtGOMAXPROCS(t, 1, tarBytes, WithMinChunkSize(minChunk))
+
+		assertRoundTrip(t, parallel, want)
+		if !bytes.Equal(parallel, sequential) {
+			t.Fatalf("a single-part build must be GOMAXPROCS-independent; parallel != sequential")
+		}
+
+		// The short trailing stream must be folded into its predecessor: no
+		// stream, including the final one, may end below MinChunkSize.
+		offsets := sortedStreamOffsets(t, parallel)
+		if len(offsets) < 2 {
+			t.Fatalf("expected multiple streams, got %d", len(offsets))
+		}
+		tocOff, _, err := OpenFooter(io.NewSectionReader(bytes.NewReader(parallel), 0, int64(len(parallel))))
+		if err != nil {
+			t.Fatalf("OpenFooter: %v", err)
+		}
+		ends := append(offsets[1:], tocOff)
+		for i, off := range offsets {
+			if size := ends[i] - off; size < minChunk {
+				t.Fatalf("stream at offset %d is under-packed: %d < %d", off, size, minChunk)
+			}
+		}
+	})
+}
+
+// TestBuildMinChunkSizeKeepsLandmarkStream ensures the prefetch landmark keeps
+// its own stream even when that stream ends below MinChunkSize: its offset
+// marks the end of the prefetch range, so folding it backward would shrink the
+// range to the preceding stream's start.
+func TestBuildMinChunkSizeKeepsLandmarkStream(t *testing.T) {
+	const minChunk = 4096
+	var ents []tarEntry
+	var prioritized []string
+	want := map[string]string{}
+	for i := 0; i < 4; i++ {
+		name := fmt.Sprintf("full%02d", i)
+		c := randomContents(4 * minChunk)
+		ents = append(ents, file(name, c))
+		want[name] = c
+		prioritized = append(prioritized, name)
+	}
+
+	sr := buildTar(t, ents, "")
+	tarBytes := make([]byte, sr.Size())
+	if _, err := sr.ReadAt(tarBytes, 0); err != nil && err != io.EOF {
+		t.Fatalf("read tar: %v", err)
+	}
+
+	// All files prioritized: the landmark is the last entry, ending the blob as
+	// a short stream that must not be folded.
+	blob := buildAtGOMAXPROCS(t, 1, tarBytes,
+		WithMinChunkSize(minChunk), WithPrioritizedFiles(prioritized))
+	assertRoundTrip(t, blob, want)
+
+	r, err := Open(io.NewSectionReader(bytes.NewReader(blob), 0, int64(len(blob))))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	landmark, ok := r.Lookup(PrefetchLandmark)
+	if !ok {
+		t.Fatalf("missing prefetch landmark")
+	}
+	if landmark.InnerOffset != 0 {
+		t.Fatalf("landmark was folded into the preceding stream (InnerOffset = %d)", landmark.InnerOffset)
+	}
+	last, ok := r.Lookup(fmt.Sprintf("full%02d", 3))
+	if !ok {
+		t.Fatalf("missing last file")
+	}
+	if landmark.Offset <= last.Offset {
+		t.Fatalf("landmark offset %d does not end the prefetch range (last file at %d)", landmark.Offset, last.Offset)
+	}
 }

--- a/estargz/estargz.go
+++ b/estargz/estargz.go
@@ -672,6 +672,11 @@ type Writer struct {
 
 	uncompressedCounter *countWriteFlusher
 
+	// cur is the stream being written; pending is the preceding stream, kept
+	// unterminated so cur can fold into it if it ends below MinChunkSize.
+	cur     *gzStream
+	pending *gzStream
+
 	// ChunkSize optionally controls the maximum number of bytes
 	// of data of a regular file that can be written in one gzip
 	// stream before a new gzip stream is started.
@@ -699,6 +704,9 @@ func (ccw currentCompressionWriter) Write(p []byte) (int, error) {
 		if err := ccw.w.condOpenGz(); err != nil {
 			return 0, err
 		}
+	}
+	if r := ccw.w.cur.raw; r != nil {
+		r.Write(p)
 	}
 	return ccw.w.gz.Write(p)
 }
@@ -788,17 +796,103 @@ func (w *Writer) Close() (digest.Digest, error) {
 	return tocDigest, nil
 }
 
+// closeGz ends the in-progress stream and terminates the pending one, folding
+// the former into the latter when it ends below MinChunkSize. No stream is
+// left open after it returns.
 func (w *Writer) closeGz() error {
 	if w.closed {
 		return errors.New("write on closed Writer")
 	}
-	if w.gz != nil {
-		if err := w.gz.Close(); err != nil {
+	if err := w.cutGz(); err != nil {
+		return err
+	}
+	return w.closePendingGz()
+}
+
+// cutGz cuts the blob at the end of the in-progress stream, so that the next
+// write starts a new one. A stream that reached MinChunkSize is kept open as
+// pending, so that an under-filled trailing stream can still fold into it; an
+// under-filled stream folds into pending right away, or is terminated in
+// place when there is none.
+func (w *Writer) cutGz() error {
+	m := w.cur
+	if m == nil {
+		return nil
+	}
+	full := w.MinChunkSize > 0 && m.sink.n >= int64(w.MinChunkSize)
+	if !full {
+		if err := w.gz.Close(); err != nil { // the exact compressed size is now known
 			return err
 		}
 		w.gz = nil
+		if w.pending != nil && m.sink.n < int64(w.MinChunkSize) && !m.pinned {
+			// Fold the stream into pending by replaying its raw bytes. They were
+			// hashed and counted when first written, so they bypass the
+			// registered counting writer.
+			if _, err := w.pending.gz.Write(m.raw.Bytes()); err != nil {
+				return err
+			}
+			for _, e := range m.entries {
+				e.Offset = w.pending.offset
+				e.InnerOffset += m.rawStart - w.pending.rawStart
+			}
+			w.cur = nil
+			return w.closePendingGz()
+		}
+	}
+	// Terminate pending, then fix the stream's position in the blob, writing
+	// its buffered bytes through and resolving its entries' offsets.
+	if err := w.closePendingGz(); err != nil {
+		return err
+	}
+	if m.offset < 0 {
+		m.offset = w.cw.n
+		if _, err := w.cw.Write(m.buf.Bytes()); err != nil {
+			return err
+		}
+		m.sink.w = w.cw
+		m.buf = nil
+	}
+	for _, e := range m.entries {
+		e.Offset = m.offset
+	}
+	m.entries = nil
+	w.cur = nil
+	if full {
+		// Keep the full stream open as the new pending; its raw bytes are no
+		// longer needed since it can no longer fold.
+		m.raw = nil
+		w.pending, w.gz = m, nil
 	}
 	return nil
+}
+
+// closePendingGz writes the pending stream's terminator.
+func (w *Writer) closePendingGz() error {
+	if w.pending == nil {
+		return nil
+	}
+	err := w.pending.gz.Close()
+	w.pending = nil
+	return err
+}
+
+// gzStream is a single compression stream (e.g. a gzip member) of the blob.
+//
+// With MinChunkSize > 0 a stream is not terminated as soon as it is full:
+// cutGz keeps it waiting as w.pending so that, should the next stream end
+// below MinChunkSize, the short tail can be folded into it. closePendingGz
+// writes the withheld terminator once the stream's successor is known to
+// stand on its own, or the blob ends.
+type gzStream struct {
+	gz       io.WriteCloser // compressor for this stream
+	sink     *countWriter   // compressed bytes of this stream, into buf or the blob
+	buf      *bytes.Buffer  // buffers the stream until placed in the blob; nil once placed
+	raw      *bytes.Buffer  // uncompressed bytes of the stream, kept while it may still fold
+	offset   int64          // position of the stream in the blob; -1 until placed
+	rawStart int64          // Writer.uncompressedCounter.n at the stream's start
+	entries  []*TOCEntry    // data entries in this stream; Offsets resolve when placed
+	pinned   bool           // the stream's offset is meaningful (e.g. prefetch landmark); never fold it
 }
 
 func (w *Writer) flushGz() error {
@@ -831,14 +925,27 @@ func (w *Writer) nameIfChanged(mp *map[int]string, id int, name string) string {
 	return name
 }
 
-func (w *Writer) condOpenGz() (err error) {
-	if w.gz == nil {
-		w.gz, err = w.compressor.Writer(w.cw)
-		if w.gz != nil {
-			w.gz = w.uncompressedCounter.register(w.gz)
-		}
+func (w *Writer) condOpenGz() error {
+	if w.cur != nil {
+		return nil
 	}
-	return
+	sink := &countWriter{w: w.cw}
+	var buf, raw *bytes.Buffer
+	offset := w.cw.n
+	if w.pending != nil {
+		// Buffer the stream until pending's terminator is written and its blob
+		// position is known; keep raw bytes so it can fold into pending if short.
+		buf, raw = new(bytes.Buffer), new(bytes.Buffer)
+		sink.w = buf
+		offset = -1
+	}
+	gz, err := w.compressor.Writer(sink)
+	if err != nil {
+		return err
+	}
+	w.cur = &gzStream{gz: gz, sink: sink, buf: buf, raw: raw, offset: offset, rawStart: w.uncompressedCounter.n}
+	w.gz = w.uncompressedCounter.register(gz)
+	return nil
 }
 
 // AppendTar reads the tar or tar.gz file from r and appends
@@ -885,8 +992,6 @@ func (w *Writer) appendTar(r io.Reader, lossless bool) error {
 	if lossless {
 		tr.RawAccounting = true
 	}
-	prevOffset := w.cw.n
-	var prevOffsetUncompressed int64
 	for {
 		h, err := tr.Next()
 		if err == io.EOF {
@@ -994,20 +1099,18 @@ func (w *Writer) appendTar(r io.Reader, lossless bool) error {
 					ent.ChunkSize = chunkSize
 				}
 
-				// We flush the underlying compression writer here to correctly calculate "w.cw.n".
+				// We flush the underlying compression writer here to correctly measure
+				// the stream's compressed size.
 				if err := w.flushGz(); err != nil {
 					return err
 				}
-				if w.needsOpenGz(ent) || w.cw.n-prevOffset >= int64(w.MinChunkSize) {
-					if err := w.closeGz(); err != nil {
+				forced := w.needsOpenGz(ent)
+				if forced || w.cur == nil || w.cur.sink.n >= int64(w.MinChunkSize) {
+					if err := w.cutGz(); err != nil {
 						return err
 					}
-					ent.Offset = w.cw.n
-					prevOffset = ent.Offset
-					prevOffsetUncompressed = w.uncompressedCounter.n
 				} else {
-					ent.Offset = prevOffset
-					ent.InnerOffset = w.uncompressedCounter.n - prevOffsetUncompressed
+					ent.InnerOffset = w.uncompressedCounter.n - w.cur.rawStart
 				}
 
 				ent.ChunkOffset = written
@@ -1016,6 +1119,13 @@ func (w *Writer) appendTar(r io.Reader, lossless bool) error {
 				if err := w.condOpenGz(); err != nil {
 					return err
 				}
+				if forced {
+					// The entry's offset is meaningful on its own (the prefetch
+					// landmark's marks the end of the prefetch range), so this stream
+					// must keep its position even if it ends below MinChunkSize.
+					w.cur.pinned = true
+				}
+				w.cur.entries = append(w.cur.entries, ent)
 
 				teeChunk := io.TeeReader(tee, chunkDigest.Hash())
 				var out io.Writer


### PR DESCRIPTION
Builds with `MinChunkSize > 0` run on a single core, no matter how large the layer is.

They are serial because the writer maintains one invariant -- every gzip stream except the last holds at least `MinChunkSize` compressed bytes -- and does so by placing each stream boundary based on the compressed size of everything written before it.

The build can be parallelized while preserving the invariant as long as:

- each worker's slice of the tar holds at least `MinChunkSize * 1032` uncompressed bytes (`1032` is DEFLATE's maximum compression ratio), so every slice fills at least one full stream;

- the trailing stream of a slice, which usually ends below the minimum, is folded into the stream before it. The writer now withholds a full stream's terminator until the next stream also reaches the minimum, and folds the tail back by replaying its buffered raw bytes. Only the short tail is ever recompressed.

After this change the invariant also comes out stronger: the trailing stream of the whole blob, previously allowed to end short, is folded as well. A stream now ends below `MinChunkSize` if and only if the data itself is smaller (or a prefetch landmark forces a boundary).

Note that with this change `MinChunkSize` layer digests differ from previous releases: large layers build in parallel (the layout depends on GOMAXPROCS, like every other eStargz build) and trailing short streams are folded away. eStargz makes no cross-version byte stability promise.