### PR TITLE
estargz: add --estargz-parallelism to control build parallelism

### DIFF
--- a/cmd/ctr-remote/commands/convert.go
+++ b/cmd/ctr-remote/commands/convert.go
@@ -80,6 +80,11 @@ When '--all-platforms' is given all images in a manifest list must be available.
 			Usage: "The minimal number of bytes of data must be written in one gzip stream. Note that this adds a TOC property that old reader doesn't understand.",
 			Value: 0,
 		},
+		&cli.IntFlag{
+			Name:  "estargz-parallelism",
+			Usage: "Number of workers used to build the layer. Pinning it makes builds reproducible across machines regardless of CPU count. 0 (default) uses GOMAXPROCS; 1 forces a sequential build. Has no effect with --estargz-min-chunk-size.",
+			Value: 0,
+		},
 		&cli.BoolFlag{
 			Name:  "estargz-external-toc",
 			Usage: "Separate TOC JSON into another image (called \"TOC image\"). The name of TOC image is the original + \"-esgztoc\" suffix. Both eStargz and the TOC image should be pushed to the same registry. stargz-snapshotter refers to the TOC image when it pulls the result eStargz image.",
@@ -278,6 +283,7 @@ func getESGZConvertOpts(context *cli.Context) ([]estargz.Option, error) {
 		estargz.WithCompressionLevel(context.Int("estargz-compression-level")),
 		estargz.WithChunkSize(context.Int("estargz-chunk-size")),
 		estargz.WithMinChunkSize(context.Int("estargz-min-chunk-size")),
+		estargz.WithParallelism(context.Int("estargz-parallelism")),
 	}
 	if estargzRecordIn := context.String("estargz-record-in"); estargzRecordIn != "" {
 		paths, err := readPathsFromRecordFile(estargzRecordIn)

--- a/cmd/ctr-remote/commands/optimize.go
+++ b/cmd/ctr-remote/commands/optimize.go
@@ -113,6 +113,11 @@ var OptimizeCommand = &cli.Command{
 			Usage: "The minimal number of bytes of data must be written in one gzip stream. Note that this adds a TOC property that old reader doesn't understand (not applied to zstd:chunked)",
 			Value: 0,
 		},
+		&cli.IntFlag{
+			Name:  "estargz-parallelism",
+			Usage: "Number of workers used to build the layer. Pinning it makes builds reproducible across machines regardless of CPU count. 0 (default) uses GOMAXPROCS; 1 forces a sequential build. Has no effect with --estargz-min-chunk-size (not applied to zstd:chunked)",
+			Value: 0,
+		},
 		&cli.StringFlag{
 			Name:    "estargz-gzip-helper",
 			Aliases: []string{"GH"},
@@ -201,6 +206,7 @@ var OptimizeCommand = &cli.Command{
 			esgzOpts := []estargz.Option{
 				estargz.WithChunkSize(clicontext.Int("estargz-chunk-size")),
 				estargz.WithMinChunkSize(clicontext.Int("estargz-min-chunk-size")),
+				estargz.WithParallelism(clicontext.Int("estargz-parallelism")),
 			}
 			if estargzGzipHelper := clicontext.String("estargz-gzip-helper"); estargzGzipHelper != "" {
 				gzipHelperFunc, err := decompressutil.GetGzipHelperFunc(estargzGzipHelper)

--- a/docs/smaller-estargz.md
+++ b/docs/smaller-estargz.md
@@ -6,6 +6,8 @@ The following flags of `ctr-remote i convert` and `ctr-remote i optimize` allow 
 
 - `--estargz-min-chunk-size`: The minimal number of bytes of data must be written in one gzip stream. If it's > 0, multiple files and chunks can be written into one gzip stream. Smaller number of gzip header and smaller size of the result blob can be expected. `--estargz-min-chunk-size=0` produces normal eStargz.
 
+- `--estargz-parallelism`: The number of workers used to build each layer. The tar is split into this many slices that are compressed in parallel, so the value also fixes the chunk boundaries: pinning it makes builds reproducible across machines regardless of their CPU count. `0` (the default) uses `GOMAXPROCS`; `1` forces a fully sequential build. This has no effect with `--estargz-min-chunk-size`, which is built with a single worker.
+
 ## `--estargz-external-toc` usage
 
 convert:

--- a/estargz/build.go
+++ b/estargz/build.go
@@ -51,6 +51,7 @@ type options struct {
 	compression            Compression
 	ctx                    context.Context
 	minChunkSize           int
+	parallelism            int
 	gzipHelperFunc         GzipHelperFunc
 }
 
@@ -125,6 +126,20 @@ func WithContext(ctx context.Context) Option {
 func WithMinChunkSize(minChunkSize int) Option {
 	return func(o *options) error {
 		o.minChunkSize = minChunkSize
+		return nil
+	}
+}
+
+// WithParallelism option specifies the number of workers used to build the
+// layer. The tar is sliced into this many parts that are compressed
+// concurrently, so the value also fixes the resulting chunk boundaries: pinning
+// it makes builds reproducible across machines regardless of their CPU count.
+// Zero (the default) selects runtime.GOMAXPROCS(0); a value of 1 forces a fully
+// sequential build. This has no effect together with WithMinChunkSize, which is
+// always built with a single worker.
+func WithParallelism(workers int) Option {
+	return func(o *options) error {
+		o.parallelism = workers
 		return nil
 	}
 }
@@ -223,13 +238,20 @@ func Build(tarBlob *io.SectionReader, opt ...Option) (_ *Blob, rErr error) {
 	if err != nil {
 		return nil, err
 	}
+	// The worker count slices the tar and so fixes the chunk boundaries; an
+	// explicit value is honored verbatim, which keeps builds reproducible across
+	// machines. Zero falls back to GOMAXPROCS.
+	workers := opts.parallelism
+	if workers <= 0 {
+		workers = runtime.GOMAXPROCS(0)
+	}
 	var tarParts [][]*entry
 	if opts.minChunkSize > 0 {
 		// Each entry needs to know the size of the current gzip stream so they
 		// cannot be processed in parallel.
 		tarParts = [][]*entry{entries}
 	} else {
-		tarParts = divideEntries(entries, runtime.GOMAXPROCS(0))
+		tarParts = divideEntries(entries, workers)
 	}
 	writers := make([]*Writer, len(tarParts))
 	payloads := make([]*os.File, len(tarParts))

--- a/estargz/build_test.go
+++ b/estargz/build_test.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -671,4 +672,83 @@ func TestCountReader(t *testing.T) {
 		})
 	}
 
+}
+
+func sampleTar(t *testing.T, n, size int) (tarBytes []byte, want map[string]string) {
+	t.Helper()
+	want = make(map[string]string, n)
+	var ents []tarEntry
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("file%04d", i)
+		content := randomContents(size)
+		want[name] = content
+		ents = append(ents, file(name, content))
+	}
+	sr := buildTar(t, ents, "")
+	tarBytes = make([]byte, sr.Size())
+	if _, err := sr.ReadAt(tarBytes, 0); err != nil && err != io.EOF {
+		t.Fatalf("read tar: %v", err)
+	}
+	return tarBytes, want
+}
+
+func buildBlobBytes(t *testing.T, tarBytes []byte, opts ...Option) []byte {
+	t.Helper()
+	blob, err := Build(io.NewSectionReader(bytes.NewReader(tarBytes), 0, int64(len(tarBytes))), opts...)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	data, err := io.ReadAll(blob)
+	if err != nil {
+		t.Fatalf("read blob: %v", err)
+	}
+	if err := blob.Close(); err != nil {
+		t.Fatalf("close blob: %v", err)
+	}
+	return data
+}
+
+func assertRoundTrip(t *testing.T, blob []byte, want map[string]string) {
+	t.Helper()
+	r, err := Open(io.NewSectionReader(bytes.NewReader(blob), 0, int64(len(blob))))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	for name, content := range want {
+		e, ok := r.Lookup(name)
+		if !ok {
+			t.Fatalf("missing entry %q", name)
+		}
+		sr, err := r.OpenFile(name)
+		if err != nil {
+			t.Fatalf("OpenFile %q: %v", name, err)
+		}
+		got := make([]byte, e.Size)
+		if _, err := sr.ReadAt(got, 0); err != nil && err != io.EOF {
+			t.Fatalf("ReadAt %q: %v", name, err)
+		}
+		if string(got) != content {
+			t.Fatalf("content mismatch for %q", name)
+		}
+	}
+}
+
+// TestBuildParallelismReproducible ensures an explicit worker count produces the
+// same blob regardless of GOMAXPROCS, which is what makes parallel builds
+// reproducible across machines with different core counts.
+func TestBuildParallelismReproducible(t *testing.T) {
+	tarBytes, want := sampleTar(t, 128, 1500)
+
+	prev := runtime.GOMAXPROCS(2)
+	defer runtime.GOMAXPROCS(prev)
+
+	withTwoCores := buildBlobBytes(t, tarBytes, WithChunkSize(512), WithParallelism(6))
+
+	runtime.GOMAXPROCS(8)
+	withEightCores := buildBlobBytes(t, tarBytes, WithChunkSize(512), WithParallelism(6))
+
+	if !bytes.Equal(withTwoCores, withEightCores) {
+		t.Fatalf("blob differs with GOMAXPROCS: parallelism must be honored verbatim")
+	}
+	assertRoundTrip(t, withTwoCores, want)
 }


### PR DESCRIPTION
eStargz builds fan out across runtime.GOMAXPROCS(0) workers, and the worker count fixes the chunk boundaries. The same image built on machines with different core counts therefore produces different layer digests.

Add `WithParallelism` / `--estargz-parallelism` to pin the worker count, so a build is reproducible regardless of the host's CPU count. `0` (default) keeps GOMAXPROCS; `1` forces a sequential build. It has no effect with `--estargz-min-chunk-size`, which still builds with a single worker.

Note: #2340 parallelizes MinChunkSize builds and touches the same worker-count code in `Build`; whichever lands second will be rebased on the other.