### PR TITLE
fusemanager: Add a dedicated metrics endpoint

### DIFF
--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -98,6 +98,9 @@ type FuseManagerConfig struct {
 
 	// Path is path to the fusemanager's executable (default: looking for a binary "stargz-fuse-manager")
 	Path string `toml:"path" json:"path"`
+
+	// MetricsAddress is address for the fusemanager's metrics API
+	MetricsAddress string `toml:"metrics_address" json:"metrics_address"`
 }
 
 func main() {
@@ -173,7 +176,11 @@ func main() {
 		if !filepath.IsAbs(fmAddr) {
 			log.G(ctx).WithError(err).Fatalf("fuse manager address must be an absolute path: %s", fmAddr)
 		}
-		managerNewlyStarted, err := fusemanager.StartFuseManager(ctx, fmPath, fmAddr, filepath.Join(*rootDir, "fusestore.db"), *logLevel, filepath.Join(*rootDir, "stargz-fuse-manager.log"))
+		fmMetricsAddr := ""
+		if !config.NoPrometheus {
+			fmMetricsAddr = fuseManagerConfig.MetricsAddress
+		}
+		managerNewlyStarted, err := fusemanager.StartFuseManager(ctx, fmPath, fmAddr, filepath.Join(*rootDir, "fusestore.db"), *logLevel, filepath.Join(*rootDir, "stargz-fuse-manager.log"), fmMetricsAddr)
 		if err != nil {
 			log.G(ctx).WithError(err).Fatalf("failed to start fusemanager")
 		}

--- a/fusemanager/fusemanager.go
+++ b/fusemanager/fusemanager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	golog "log"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -29,6 +30,7 @@ import (
 	"syscall"
 
 	"github.com/containerd/log"
+	metrics "github.com/docker/go-metrics"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
@@ -38,12 +40,13 @@ import (
 )
 
 var (
-	versionFlag   bool
-	fuseStoreAddr string
-	address       string
-	logLevel      string
-	logPath       string
-	action        string
+	versionFlag    bool
+	fuseStoreAddr  string
+	address        string
+	metricsAddress string
+	logLevel       string
+	logPath        string
+	action         string
 )
 
 func parseFlags() {
@@ -51,6 +54,7 @@ func parseFlags() {
 	flag.StringVar(&action, "action", "", "action of fusemanager")
 	flag.StringVar(&fuseStoreAddr, "fusestore-path", "/var/lib/containerd-stargz-grpc/fusestore.db", "address for the fusemanager's store")
 	flag.StringVar(&address, "address", "/run/containerd-stargz-grpc/fuse-manager.sock", "address for the fusemanager's gRPC socket")
+	flag.StringVar(&metricsAddress, "metrics-address", "", "address for the fusemanager's metrics API")
 	flag.StringVar(&logLevel, "log-level", logrus.InfoLevel.String(), "set the logging level [trace, debug, info, warn, error, fatal, panic]")
 	flag.StringVar(&logPath, "log-path", "", "path to fusemanager's logs, logs to stderr by default, pass --log-level=panic to disable logging")
 
@@ -82,13 +86,13 @@ func run() error {
 
 	switch action {
 	case "start":
-		return startNew(ctx, logPath, address, fuseStoreAddr, logLevel)
+		return startNew(ctx, logPath, address, fuseStoreAddr, logLevel, metricsAddress)
 	default:
 		return runFuseManager(ctx)
 	}
 }
 
-func startNew(ctx context.Context, logPath, address, fusestore, logLevel string) error {
+func startNew(ctx context.Context, logPath, address, fusestore, logLevel, metricsAddr string) error {
 	self, err := os.Executable()
 	if err != nil {
 		return err
@@ -103,6 +107,9 @@ func startNew(ctx context.Context, logPath, address, fusestore, logLevel string)
 		"-address", address,
 		"-fusestore-path", fusestore,
 		"-log-level", logLevel,
+	}
+	if metricsAddr != "" {
+		args = append(args, "-metrics-address", metricsAddr)
 	}
 
 	// we use shim-like approach to start new fusemanager process by self-invoking in the background
@@ -189,6 +196,23 @@ func runFuseManager(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to listen socket: %w", err)
 	}
+	defer l.Close()
+
+	errCh := make(chan error, 2)
+	if metricsAddress != "" {
+		ml, err := net.Listen("tcp", metricsAddress)
+		if err != nil {
+			return fmt.Errorf("failed to get listener for metrics endpoint: %w", err)
+		}
+		defer ml.Close()
+		m := http.NewServeMux()
+		m.Handle("/metrics", metrics.Handler())
+		go func() {
+			if err := http.Serve(ml, m); err != nil {
+				errCh <- fmt.Errorf("error on serving metrics via %q: %w", metricsAddress, err)
+			}
+		}()
+	}
 
 	server := grpc.NewServer()
 	fm, err := NewFuseManager(ctx, l, server, fuseStoreAddr, address)
@@ -198,7 +222,6 @@ func runFuseManager(ctx context.Context) error {
 
 	pb.RegisterStargzFuseManagerServiceServer(server, fm)
 
-	errCh := make(chan error, 1)
 	go func() {
 		if err := server.Serve(l); err != nil {
 			errCh <- fmt.Errorf("error on serving via socket %q: %w", address, err)
@@ -223,7 +246,7 @@ func runFuseManager(ctx context.Context) error {
 	return nil
 }
 
-func StartFuseManager(ctx context.Context, executable, address, fusestore, logLevel, logPath string) (newlyStarted bool, err error) {
+func StartFuseManager(ctx context.Context, executable, address, fusestore, logLevel, logPath, metricsAddr string) (newlyStarted bool, err error) {
 	// if socket exists, do not start it
 	if _, err := os.Stat(address); err == nil {
 		return false, nil
@@ -241,6 +264,9 @@ func StartFuseManager(ctx context.Context, executable, address, fusestore, logLe
 		"-fusestore-path", fusestore,
 		"-log-level", logLevel,
 		"-log-path", logPath,
+	}
+	if metricsAddr != "" {
+		args = append(args, "-metrics-address", metricsAddr)
 	}
 
 	cmd := exec.Command(executable, args...)


### PR DESCRIPTION
In FUSE manager mode, the manager runs in a separate process from the gRPC server. The existing `metrics_address` setting only starts a metrics server in the gRPC server process, so it does not expose metrics produced by the FUSE manager. This makes it difficult to observe production behaviour of the snapshotter.

This change adds a new optional `fusemanager.metrics_address` setting to configure a separate metrics listener for the FUSE manager.

---

Test procedure:

1. Enable the following fuse manager configuration:
```
[fuse_manager]
  enable = true
  metrics_address = "127.0.0.1:6783"
```

2. Restart both gRPC server *and* FUSE manager if it is running
3. Confirm that fuse manager exposes `/metrics` endpoint:
```
$ curl 127.0.0.1:6783/metrics
...
stargz_fs_operation_duration_milliseconds_bucket{layer="sha256:XXX",operation_type="stargz_toc_json_deserialize",le="256"} 1
stargz_fs_operation_duration_milliseconds_bucket{layer="sha256:XXX",operation_type="stargz_toc_json_deserialize",le="512"} 1
...
```