### PR TITLE
snapshot: restore remote mounts on demand after restart

### DIFF
--- a/cmd/containerd-stargz-grpc/main.go
+++ b/cmd/containerd-stargz-grpc/main.go
@@ -190,6 +190,9 @@ func main() {
 			log.G(ctx).WithError(err).Fatalf("failed to configure fusemanager")
 		}
 		flags := []snbase.Opt{snbase.AsynchronousRemove}
+		if config.LazyRestoreOnRestart {
+			flags = append(flags, snbase.LazyRestoreOnRestart)
+		}
 		// "managerNewlyStarted" being true indicates that the FUSE manager is newly started. To
 		// fully recover the snapshotter and the FUSE manager's state, we need to restore
 		// all snapshot mounts. If managerNewlyStarted is false, the existing FUSE manager maintains

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -128,6 +128,9 @@ When you stop Stargz Sanpshotter on the node, it takes the following behaviour d
 
 killing containerd-stargz-grpc will result in unmounting all snapshot mounts managed by Stargz Snapshotter.
 When containerd-stargz-grpc is restarted, all those snapshots are mounted again by lazy pulling all layers.
+If `lazy_restore_on_restart = true`, containerd-stargz-grpc restores the local snapshot directories but doesn't resolve remote blobs or create FUSE mounts at startup. The first `Prepare`, `View`, or `Mounts` request that uses a remote snapshot mounts it on demand. If the registry is still unavailable, that request fails with an unavailable error while the snapshotter keeps running; a later request retries the mount. Metadata-only operations such as `Stat`, `Usage`, and `Walk` don't trigger an on-demand mount.
+When `lazy_restore_on_restart` and `allow_invalid_mounts_on_restart` are both enabled, lazy restoration takes precedence during startup, so `allow_invalid_mounts_on_restart` isn't consulted unless lazy restoration is disabled.
+
 If the snapshotter fails to mount one of the snapshots (e.g. because of lazy pulling failure) during this step, the behaviour differs depending on `allow_invalid_mounts_on_restart` flag in the config TOML.
 
 - `allow_invalid_mounts_on_restart = true`: containerd-stargz-grpc leaves the failed snapshots as empty directories. The user needs to manually remove those snapshot via containerd (e.g. using `ctr snapshot rm` command). The name of those snapshots can be seen in the log with `failed to restore remote snapshot` message.
@@ -147,6 +150,8 @@ When stopping FUSE manager for upgrading the binary or restarting the node, you 
 3. Kill the FUSE manager process (`stargz-fuse-manager`)
 4. Restart the containerd-stargz-grpc process. This restores all snapshot mounts by lazy pulling them. `allow_invalid_mounts_on_restart` (described in the above) can still be used for controlling the behaviour of the error cases.
 5. Restart the containers.
+
+If `lazy_restore_on_restart` is enabled, step 4 restores only the local snapshot directories. Remote FUSE mounts are deferred until the snapshots are first used.
 
 ### Unexpected restart handling
 

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -377,7 +377,7 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[s
 	fs.layerMu.Unlock()
 	if l == nil {
 		log.G(ctx).Debug("layer not registered")
-		return fmt.Errorf("layer not registered")
+		return snapshot.ErrLayerNotRegistered
 	}
 
 	if l.Info().FetchedSize < l.Info().Size {

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -24,6 +24,7 @@ package fs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -33,6 +34,7 @@ import (
 	"github.com/containerd/stargz-snapshotter/fs/layer"
 	"github.com/containerd/stargz-snapshotter/fs/remote"
 	"github.com/containerd/stargz-snapshotter/fs/source"
+	"github.com/containerd/stargz-snapshotter/snapshot"
 	"github.com/containerd/stargz-snapshotter/task"
 	fusefs "github.com/hanwen/go-fuse/v2/fs"
 	digest "github.com/opencontainers/go-digest"
@@ -58,6 +60,10 @@ func TestCheck(t *testing.T) {
 	bl.success = false
 	if err := fs.Check(context.TODO(), "test", nil); err == nil {
 		t.Errorf("connection succeeded; wanted to fail")
+	}
+
+	if err := fs.Check(context.TODO(), "missing", nil); !errors.Is(err, snapshot.ErrLayerNotRegistered) {
+		t.Fatalf("missing layer error = %v; want ErrLayerNotRegistered", err)
 	}
 }
 

--- a/fusemanager/client.go
+++ b/fusemanager/client.go
@@ -26,7 +26,9 @@ import (
 	"github.com/containerd/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	pb "github.com/containerd/stargz-snapshotter/fusemanager/api"
 	"github.com/containerd/stargz-snapshotter/snapshot"
@@ -120,6 +122,9 @@ func (cli *Client) Check(ctx context.Context, mountpoint string, labels map[stri
 	_, err := cli.client.Check(ctx, req)
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("failed to call Check")
+		if status.Code(err) == codes.NotFound {
+			return fmt.Errorf("%w: %v", snapshot.ErrLayerNotRegistered, err)
+		}
 		return err
 	}
 

--- a/fusemanager/fusemanager_test.go
+++ b/fusemanager/fusemanager_test.go
@@ -19,6 +19,7 @@ package fusemanager
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -27,6 +28,7 @@ import (
 
 	pb "github.com/containerd/stargz-snapshotter/fusemanager/api"
 	"github.com/containerd/stargz-snapshotter/service"
+	"github.com/containerd/stargz-snapshotter/snapshot"
 	"google.golang.org/grpc"
 )
 
@@ -229,7 +231,49 @@ func TestFuseManager(t *testing.T) {
 				if !mockFs.unmountCalled {
 					t.Error("Unmount() was not called on filesystem")
 				}
+
+				err = client.Check(context.Background(), tc.mountpoint, tc.labels)
+				if !errors.Is(err, snapshot.ErrLayerNotRegistered) {
+					t.Errorf("Check() after unmount error = %v; want ErrLayerNotRegistered", err)
+				}
 			}
 		})
+	}
+}
+
+func TestRestoreFuseInfoRespectsRestartMode(t *testing.T) {
+	ctx := context.Background()
+	fuseStorePath := filepath.Join(t.TempDir(), "fusestore.db")
+	fm, err := NewFuseManager(ctx, nil, grpc.NewServer(), fuseStorePath, "")
+	if err != nil {
+		t.Fatalf("failed to create fuse manager: %v", err)
+	}
+	defer fm.Close(ctx)
+
+	mockFs := newMockFileSystem(t)
+	fm.curFs = mockFs
+	fm.config = &Config{Config: service.Config{
+		SnapshotterConfig: service.SnapshotterConfig{LazyRestoreOnRestart: true},
+	}}
+	if err := fm.storeFuseInfo(&fuseInfo{
+		Mountpoint: "/snapshot/1/fs",
+		Labels:     map[string]string{"test": "label"},
+	}); err != nil {
+		t.Fatalf("failed to store fuse info: %v", err)
+	}
+
+	if err := fm.restoreFuseInfo(ctx); err != nil {
+		t.Fatalf("lazy fuse restore failed: %v", err)
+	}
+	if mockFs.mountCalled {
+		t.Fatal("lazy fuse restore mounted a remote layer")
+	}
+
+	fm.config.Config.LazyRestoreOnRestart = false
+	if err := fm.restoreFuseInfo(ctx); err != nil {
+		t.Fatalf("eager fuse restore failed: %v", err)
+	}
+	if !mockFs.mountCalled {
+		t.Fatal("eager fuse restore didn't mount the remote layer")
 	}
 }

--- a/fusemanager/fusestore.go
+++ b/fusemanager/fusestore.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/containerd/log"
 	bolt "go.etcd.io/bbolt"
 
 	"github.com/containerd/stargz-snapshotter/service"
@@ -80,6 +81,11 @@ func (fm *Server) removeFuseInfo(fuseInfo *fuseInfo) error {
 // restoreFuseInfo restores fuseInfo when Init is called, it will skip mounted
 // layers whose mountpoint can be found in fsMap
 func (fm *Server) restoreFuseInfo(ctx context.Context) error {
+	if fm.config.Config.LazyRestoreOnRestart {
+		log.G(ctx).Debug("deferred fuse-manager mount restoration until first use")
+		return nil
+	}
+
 	return fm.ms.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(fuseInfoBucket)
 		if bucket == nil {

--- a/fusemanager/service.go
+++ b/fusemanager/service.go
@@ -19,6 +19,7 @@ package fusemanager
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -30,6 +31,8 @@ import (
 	"github.com/moby/sys/mountinfo"
 	bolt "go.etcd.io/bbolt"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	pb "github.com/containerd/stargz-snapshotter/fusemanager/api"
 	"github.com/containerd/stargz-snapshotter/service"
@@ -261,15 +264,18 @@ func (fm *Server) Check(ctx context.Context, req *pb.CheckRequest) (*pb.Response
 
 	obj, found := fm.fsMap.Load(req.Mountpoint)
 	if !found {
-		err := fmt.Errorf("failed to find filesystem of mountpoint %s", req.Mountpoint)
+		err := fmt.Errorf("%w: failed to find filesystem of mountpoint %s", snapshot.ErrLayerNotRegistered, req.Mountpoint)
 		log.G(ctx).WithError(err).Errorf("failed to check filesystem")
-		return &pb.Response{}, err
+		return &pb.Response{}, status.Error(codes.NotFound, err.Error())
 	}
 
 	fs := obj.(snapshot.FileSystem)
 	err := fs.Check(ctx, req.Mountpoint, req.Labels)
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("failed to check filesystem")
+		if errors.Is(err, snapshot.ErrLayerNotRegistered) {
+			return &pb.Response{}, status.Error(codes.NotFound, err.Error())
+		}
 		return &pb.Response{}, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/xid v1.6.0
 	github.com/sirupsen/logrus v1.9.4
@@ -79,7 +80,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/selinux v1.13.1 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/script/demo/config.stargz.toml
+++ b/script/demo/config.stargz.toml
@@ -9,3 +9,5 @@ insecure = true
 direct = true
 [snapshotter]
 allow_invalid_mounts_on_restart = true
+# Set to true to avoid registry access while restoring snapshots at startup.
+# lazy_restore_on_restart = true

--- a/service/config.go
+++ b/service/config.go
@@ -70,4 +70,8 @@ type SnapshotterConfig struct {
 	// NOTE: User needs to manually remove the snapshots from containerd's metadata store using
 	//       ctr (e.g. `ctr snapshot rm`).
 	AllowInvalidMountsOnRestart bool `toml:"allow_invalid_mounts_on_restart" json:"allow_invalid_mounts_on_restart"`
+
+	// LazyRestoreOnRestart restores remote snapshot directories at startup but
+	// defers remote resolution and FUSE mounting until a snapshot is first used.
+	LazyRestoreOnRestart bool `toml:"lazy_restore_on_restart" json:"lazy_restore_on_restart"`
 }

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -1,0 +1,41 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package service
+
+import (
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestLazyRestoreOnRestartConfig(t *testing.T) {
+	data := []byte(`
+[snapshotter]
+lazy_restore_on_restart = true
+allow_invalid_mounts_on_restart = false
+`)
+	var config Config
+	if err := toml.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	if !config.LazyRestoreOnRestart {
+		t.Fatal("lazy_restore_on_restart wasn't decoded")
+	}
+	if config.AllowInvalidMountsOnRestart {
+		t.Fatal("lazy_restore_on_restart unexpectedly enabled allow_invalid_mounts_on_restart")
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -78,6 +78,9 @@ func NewStargzSnapshotterService(ctx context.Context, root string, config *Confi
 	if config.AllowInvalidMountsOnRestart {
 		snOpts = append(snOpts, snapshot.AllowInvalidMountsOnRestart)
 	}
+	if config.LazyRestoreOnRestart {
+		snOpts = append(snOpts, snapshot.LazyRestoreOnRestart)
+	}
 
 	snapshotter, err = snapshot.NewSnapshotter(ctx, snapshotterRoot(root), fs, snOpts...)
 	if err != nil {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -18,6 +18,7 @@ package snapshot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,6 +34,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/sys/mountinfo"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -52,6 +54,11 @@ const (
 	prepareSucceeded     = "true"
 	prepareFailed        = "false"
 )
+
+// ErrLayerNotRegistered indicates that a remote layer has no live filesystem
+// registration. This can happen after snapshotter or node restart when remote
+// snapshot restoration was skipped or failed.
+var ErrLayerNotRegistered = errors.New("layer not registered")
 
 // FileSystem is a backing filesystem abstraction.
 //
@@ -73,6 +80,7 @@ type SnapshotterConfig struct {
 	asyncRemove                 bool
 	noRestore                   bool
 	allowInvalidMountsOnRestart bool
+	lazyRestoreOnRestart        bool
 }
 
 // Opt is an option to configure the remote snapshotter
@@ -97,6 +105,13 @@ func AllowInvalidMountsOnRestart(config *SnapshotterConfig) error {
 	return nil
 }
 
+// LazyRestoreOnRestart restores remote snapshot directories at startup but
+// defers creating their FUSE mounts until the snapshots are used.
+func LazyRestoreOnRestart(config *SnapshotterConfig) error {
+	config.lazyRestoreOnRestart = true
+	return nil
+}
+
 type snapshotter struct {
 	root        string
 	ms          *storage.MetaStore
@@ -107,6 +122,9 @@ type snapshotter struct {
 	userxattr                   bool // whether to enable "userxattr" mount option
 	noRestore                   bool
 	allowInvalidMountsOnRestart bool
+	lazyRestoreOnRestart        bool
+
+	remountGroup singleflight.Group
 }
 
 // NewSnapshotter returns a Snapshotter which can use unpacked remote layers
@@ -157,6 +175,7 @@ func NewSnapshotter(ctx context.Context, root string, targetFs FileSystem, opts 
 		userxattr:                   userxattr,
 		noRestore:                   config.noRestore,
 		allowInvalidMountsOnRestart: config.allowInvalidMountsOnRestart,
+		lazyRestoreOnRestart:        config.lazyRestoreOnRestart,
 	}
 
 	if err := o.restoreRemoteSnapshot(ctx); err != nil {
@@ -602,8 +621,10 @@ func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 
 func (o *snapshotter) mounts(ctx context.Context, s storage.Snapshot, checkKey string) ([]mount.Mount, error) {
 	// Make sure that all layers lower than the target layer are available
-	if checkKey != "" && !o.checkAvailability(ctx, checkKey) {
-		return nil, fmt.Errorf("layer %q unavailable: %w", s.ID, errdefs.ErrUnavailable)
+	if checkKey != "" {
+		if err := o.checkAvailability(ctx, checkKey); err != nil {
+			return nil, errdefs.ErrUnavailable.WithMessage(fmt.Sprintf("layer %q unavailable: %v", s.ID, err))
+		}
 	}
 
 	if len(s.ParentIDs) == 0 {
@@ -703,45 +724,114 @@ func (o *snapshotter) prepareRemoteSnapshot(ctx context.Context, key string, lab
 	return o.fs.Mount(ctx, mountpoint, labels)
 }
 
-// checkAvailability checks avaiability of the specified layer and all lower
+// checkAvailability checks availability of the specified layer and all lower
 // layers using filesystem's checking functionality.
-func (o *snapshotter) checkAvailability(ctx context.Context, key string) bool {
+func (o *snapshotter) checkAvailability(ctx context.Context, key string) error {
 	log.G(ctx).WithField("key", key).Debug("checking layer availability")
 
+	layers, err := o.remoteLayers(ctx, key)
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("failed to collect remote layers")
+		return err
+	}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	for _, layer := range layers {
+		layer := layer
+		eg.Go(func() error {
+			lCtx := log.WithLogger(egCtx, log.G(egCtx).WithField("mount-point", layer.mountpoint))
+			log.G(lCtx).Debug("checking mount point")
+			if err := o.ensureLayerAvailable(lCtx, layer.mountpoint, layer.labels); err != nil {
+				log.G(lCtx).WithError(err).Warn("layer is unavailable")
+				return err
+			}
+			return nil
+		})
+	}
+	return eg.Wait()
+}
+
+type remoteLayer struct {
+	mountpoint string
+	labels     map[string]string
+}
+
+// remoteLayers copies all information needed for availability checks out of
+// the metadata transaction so checks and remounts never hold it during network
+// operations.
+func (o *snapshotter) remoteLayers(ctx context.Context, key string) ([]remoteLayer, error) {
 	ctx, t, err := o.ms.TransactionContext(ctx, false)
 	if err != nil {
-		log.G(ctx).WithError(err).Warn("failed to get transaction")
-		return false
+		return nil, err
 	}
 	defer t.Rollback()
 
-	eg, egCtx := errgroup.WithContext(ctx)
+	var layers []remoteLayer
 	for cKey := key; cKey != ""; {
 		id, info, _, err := storage.GetInfo(ctx, cKey)
 		if err != nil {
-			log.G(ctx).WithError(err).Warnf("failed to get info of %q", cKey)
-			return false
+			return nil, fmt.Errorf("failed to get info of %q: %w", cKey, err)
 		}
-		mp := o.upperPath(id)
-		lCtx := log.WithLogger(ctx, log.G(ctx).WithField("mount-point", mp))
 		if _, ok := info.Labels[remoteLabel]; ok {
-			eg.Go(func() error {
-				log.G(lCtx).Debug("checking mount point")
-				if err := o.fs.Check(egCtx, mp, info.Labels); err != nil {
-					log.G(lCtx).WithError(err).Warn("layer is unavailable")
-					return err
-				}
-				return nil
+			layers = append(layers, remoteLayer{
+				mountpoint: o.upperPath(id),
+				labels:     cloneLabels(info.Labels),
 			})
-		} else {
-			log.G(lCtx).Debug("layer is normal snapshot(overlayfs)")
 		}
 		cKey = info.Parent
 	}
-	if err := eg.Wait(); err != nil {
-		return false
+	return layers, nil
+}
+
+func cloneLabels(labels map[string]string) map[string]string {
+	cloned := make(map[string]string, len(labels))
+	for key, value := range labels {
+		cloned[key] = value
 	}
-	return true
+	return cloned
+}
+
+func (o *snapshotter) ensureLayerAvailable(ctx context.Context, mountpoint string, labels map[string]string) error {
+	err := o.fs.Check(ctx, mountpoint, labels)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, ErrLayerNotRegistered) || !o.lazyRestoreOnRestart {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	// A remount is shared by all callers for this mountpoint, so it must not be
+	// canceled when one caller goes away. Each caller still observes its own
+	// cancellation while waiting for the shared result below.
+	remountCtx := context.WithoutCancel(ctx)
+	resultCh := o.remountGroup.DoChan(mountpoint, func() (any, error) {
+		// Another caller may have completed the mount while this caller waited.
+		if err := o.fs.Check(remountCtx, mountpoint, labels); err == nil {
+			return nil, nil
+		} else if !errors.Is(err, ErrLayerNotRegistered) {
+			return nil, err
+		}
+
+		log.G(remountCtx).Info("remounting remote layer on demand")
+		if err := o.fs.Mount(remountCtx, mountpoint, labels); err != nil {
+			return nil, fmt.Errorf("failed to remount remote layer: %w", err)
+		}
+
+		return nil, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case result := <-resultCh:
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return result.Err
+	}
 }
 
 func (o *snapshotter) restoreRemoteSnapshot(ctx context.Context) error {
@@ -791,6 +881,10 @@ func (o *snapshotter) restoreRemoteSnapshot(ctx context.Context) error {
 			return nil
 		}(); err != nil {
 			return fmt.Errorf("failed to create remote snapshot directory: %s: %w", info.Name, err)
+		}
+		if o.lazyRestoreOnRestart {
+			log.G(ctx).WithField("snapshot", info.Name).Debug("deferred remote snapshot mount until first use")
+			continue
 		}
 		if err := o.prepareRemoteSnapshot(ctx, info.Name, info.Labels); err != nil {
 			if o.allowInvalidMountsOnRestart {

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -22,8 +22,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -371,6 +374,333 @@ func TestFailureDetection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLazyRestoreOnRestart(t *testing.T) {
+	tests := []struct {
+		name          string
+		prepareActive bool
+		use           func(context.Context, snapshots.Snapshotter, string, string) error
+	}{
+		{
+			name: "prepare",
+			use: func(ctx context.Context, sn snapshots.Snapshotter, target, _ string) error {
+				_, err := sn.Prepare(ctx, "active-after-restart", target)
+				return err
+			},
+		},
+		{
+			name: "view",
+			use: func(ctx context.Context, sn snapshots.Snapshotter, target, _ string) error {
+				_, err := sn.View(ctx, "view-after-restart", target)
+				return err
+			},
+		},
+		{
+			name:          "mounts",
+			prepareActive: true,
+			use: func(ctx context.Context, sn snapshots.Snapshotter, _, active string) error {
+				_, err := sn.Mounts(ctx, active)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			root, fs, target, active := prepareRemoteSnapshotForRestart(t, tt.prepareActive)
+			fs.setMountFailure(true) // Simulate a registry that isn't reachable during startup.
+
+			sn, err := NewSnapshotter(ctx, root, fs, LazyRestoreOnRestart)
+			if err != nil {
+				t.Fatalf("failed to restart snapshotter lazily: %v", err)
+			}
+			defer sn.Close()
+
+			if got := fs.mountCallCount(); got != 0 {
+				t.Fatalf("startup mounted %d remote layers; want zero", got)
+			}
+			layers, err := sn.(*snapshotter).remoteLayers(ctx, target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(layers) != 1 {
+				t.Fatalf("got %d remote layers; want one", len(layers))
+			}
+			if _, err := os.Stat(layers[0].mountpoint); err != nil {
+				t.Fatalf("remote snapshot directory wasn't restored: %v", err)
+			}
+
+			// Metadata-only APIs must not cause remote mounts.
+			if _, err := sn.Stat(ctx, target); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := sn.Usage(ctx, target); err != nil {
+				t.Fatal(err)
+			}
+			if err := sn.Walk(ctx, func(context.Context, snapshots.Info) error { return nil }); err != nil {
+				t.Fatal(err)
+			}
+			if got := fs.mountCallCount(); got != 0 {
+				t.Fatalf("metadata-only APIs mounted %d remote layers; want zero", got)
+			}
+
+			fs.setMountFailure(false) // Registry/network becomes available after startup.
+			if err := tt.use(ctx, sn, target, active); err != nil {
+				t.Fatalf("first use failed: %v", err)
+			}
+			if got := fs.mountCallCount(); got != 1 {
+				t.Fatalf("first use mounted remote layer %d times; want one", got)
+			}
+		})
+	}
+}
+
+func TestOnDemandRemountFailureIsRetried(t *testing.T) {
+	fs := newRestartFileSystem()
+	fs.setMountFailure(true)
+	o := &snapshotter{
+		fs:                   fs,
+		lazyRestoreOnRestart: true,
+	}
+	mountpoint := "/snapshot/1/fs"
+
+	if err := o.ensureLayerAvailable(context.Background(), mountpoint, nil); err == nil {
+		t.Fatal("first remount succeeded; want failure")
+	}
+	if err := o.ensureLayerAvailable(context.Background(), mountpoint, nil); err == nil {
+		t.Fatal("second remount succeeded; want failure")
+	}
+	if got := fs.mountCallCount(); got != 2 {
+		t.Fatalf("two requests made %d mount attempts; want two", got)
+	}
+}
+
+func TestOnDemandRemountErrorIsReported(t *testing.T) {
+	ctx := context.Background()
+	root, fs, _, active := prepareRemoteSnapshotForRestart(t, true)
+	fs.setMountFailure(true)
+
+	sn, err := NewSnapshotter(ctx, root, fs, LazyRestoreOnRestart)
+	if err != nil {
+		t.Fatalf("failed to restart snapshotter lazily: %v", err)
+	}
+	defer sn.Close()
+
+	_, err = sn.Mounts(ctx, active)
+	if !errdefs.IsUnavailable(err) {
+		t.Fatalf("Mounts() error = %v; want unavailable", err)
+	}
+	if !strings.Contains(err.Error(), "registry unavailable") {
+		t.Fatalf("Mounts() error = %v; want registry failure details", err)
+	}
+}
+
+func TestOnDemandRemountSingleflight(t *testing.T) {
+	const callers = 16
+	fs := newRestartFileSystem()
+	fs.mountStarted = make(chan struct{}, 1)
+	fs.mountRelease = make(chan struct{})
+	fs.checkObserved = make(chan struct{}, callers+1)
+	o := &snapshotter{
+		fs:                   fs,
+		lazyRestoreOnRestart: true,
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	for range callers {
+		go func() {
+			<-start
+			errs <- o.ensureLayerAvailable(context.Background(), "/snapshot/1/fs", nil)
+		}()
+	}
+	close(start)
+
+	select {
+	case <-fs.mountStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for remount")
+	}
+	// Every caller performs an initial Check and the singleflight leader checks
+	// once more before mounting.
+	for range callers + 1 {
+		select {
+		case <-fs.checkObserved:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for concurrent availability checks")
+		}
+	}
+	close(fs.mountRelease)
+
+	for range callers {
+		if err := <-errs; err != nil {
+			t.Errorf("concurrent remount failed: %v", err)
+		}
+	}
+	if got := fs.mountCallCount(); got != 1 {
+		t.Fatalf("concurrent callers made %d mount attempts; want one", got)
+	}
+}
+
+func TestOnDemandRemountSurvivesLeaderCancellation(t *testing.T) {
+	fs := newRestartFileSystem()
+	fs.mountStarted = make(chan struct{}, 1)
+	fs.mountRelease = make(chan struct{})
+	o := &snapshotter{
+		fs:                   fs,
+		lazyRestoreOnRestart: true,
+	}
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderErr := make(chan error, 1)
+	go func() {
+		leaderErr <- o.ensureLayerAvailable(leaderCtx, "/snapshot/1/fs", nil)
+	}()
+
+	select {
+	case <-fs.mountStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for leader remount")
+	}
+
+	followerErr := make(chan error, 1)
+	go func() {
+		followerErr <- o.ensureLayerAvailable(context.Background(), "/snapshot/1/fs", nil)
+	}()
+
+	cancelLeader()
+	select {
+	case err := <-leaderErr:
+		if err != context.Canceled {
+			t.Fatalf("leader error = %v; want context canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("canceled leader remained blocked on shared remount")
+	}
+
+	close(fs.mountRelease)
+	select {
+	case err := <-followerErr:
+		if err != nil {
+			t.Fatalf("follower failed after leader cancellation: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for follower")
+	}
+
+	if got := fs.mountCallCount(); got != 1 {
+		t.Fatalf("concurrent callers made %d mount attempts; want one", got)
+	}
+}
+
+func prepareRemoteSnapshotForRestart(t *testing.T, prepareActive bool) (root string, fs *restartFileSystem, target, active string) {
+	t.Helper()
+	ctx := context.Background()
+	root = t.TempDir()
+	fs = newRestartFileSystem()
+	sn, err := NewSnapshotter(ctx, root, fs)
+	if err != nil {
+		t.Fatalf("failed to create initial snapshotter: %v", err)
+	}
+	target = prepareWithTarget(t, sn, "remote-target", "remote-prepare", "", nil)
+	if prepareActive {
+		active = "active-before-restart"
+		if _, err := sn.Prepare(ctx, active, target); err != nil {
+			t.Fatalf("failed to prepare active snapshot: %v", err)
+		}
+	}
+	if err := sn.Close(); err != nil {
+		t.Fatalf("failed to close initial snapshotter: %v", err)
+	}
+	fs.reset()
+	return root, fs, target, active
+}
+
+type restartFileSystem struct {
+	mu            sync.Mutex
+	mounted       map[string]bool
+	mountCalls    int
+	failMount     bool
+	mountStarted  chan struct{}
+	mountRelease  chan struct{}
+	checkObserved chan struct{}
+}
+
+func newRestartFileSystem() *restartFileSystem {
+	return &restartFileSystem{mounted: make(map[string]bool)}
+}
+
+func (fs *restartFileSystem) Mount(ctx context.Context, mountpoint string, labels map[string]string) error {
+	fs.mu.Lock()
+	fs.mountCalls++
+	fail := fs.failMount
+	release := fs.mountRelease
+	started := fs.mountStarted
+	fs.mu.Unlock()
+	if started != nil {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	}
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if fail {
+		return fmt.Errorf("registry unavailable")
+	}
+	fs.mu.Lock()
+	fs.mounted[mountpoint] = true
+	fs.mu.Unlock()
+	return nil
+}
+
+func (fs *restartFileSystem) Check(ctx context.Context, mountpoint string, labels map[string]string) error {
+	if fs.checkObserved != nil {
+		select {
+		case fs.checkObserved <- struct{}{}:
+		default:
+		}
+	}
+	fs.mu.Lock()
+	mounted := fs.mounted[mountpoint]
+	fs.mu.Unlock()
+	if !mounted {
+		return ErrLayerNotRegistered
+	}
+	return nil
+}
+
+func (fs *restartFileSystem) Unmount(ctx context.Context, mountpoint string) error {
+	fs.mu.Lock()
+	delete(fs.mounted, mountpoint)
+	fs.mu.Unlock()
+	return nil
+}
+
+func (fs *restartFileSystem) setMountFailure(fail bool) {
+	fs.mu.Lock()
+	fs.failMount = fail
+	fs.mu.Unlock()
+}
+
+func (fs *restartFileSystem) mountCallCount() int {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	return fs.mountCalls
+}
+
+func (fs *restartFileSystem) reset() {
+	fs.mu.Lock()
+	fs.mountCalls = 0
+	fs.mounted = make(map[string]bool)
+	fs.mu.Unlock()
 }
 
 func bindFileSystem(t *testing.T) FileSystem {


### PR DESCRIPTION
Add lazy_restore_on_restart to skip remote resolution and FUSE mount restoration during snapshotter startup.

When an unregistered remote layer is first used, restore its mount from the snapshot labels. Coalesce concurrent requests for the same mountpoint and support both in-process and fuse-manager modes.

This allows the snapshotter to start while the registry is unavailable.