### PR TITLE
Set max_retries=1 in the builtin snapshotter's integration config

### DIFF
--- a/script/integration/containerd/config.containerd.toml
+++ b/script/integration/containerd/config.containerd.toml
@@ -7,6 +7,7 @@ metadata_store = "memory"
 
 [plugins."io.containerd.snapshotter.v1.stargz".blob]
 check_always = true
+max_retries = 1
 
 [plugins."io.containerd.snapshotter.v1.stargz".registry.mirrors."registry-integration.test"]
 endpoint = ["http://registry-alt.test:5000"]


### PR DESCRIPTION
`config.stargz.toml` sets `max_retries = 1`, but `config.containerd.toml` does not, so the builtin snapshotter falls back to the default of 5 retries with up to 5 minutes of backoff (`fs/remote/resolver.go`).

The integration test blocks registries with `iptables -j DROP`, so requests hang rather than fail fast and each retry costs the full timeout. Comparing the two phases in a recent run of `Integration (--build-arg=CONTAINERD_VERSION=main, ...)`:

| phase | builtin=true | builtin=false |
| --- | --- | --- |
| "Disabling mirror registry and check if refreshing works" | 22 min | 1.0 min |
| "Disabling all registries and running container should fail" | 24 min | 1.5 min |

That one job takes ~53 min while every other job in `Tests` finishes in 9–13 min, so it alone sets the workflow's wall clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)