### PR TITLE
Build the k3s node image with make image

### DIFF
--- a/script/k3s-argo-workflow/run.sh
+++ b/script/k3s-argo-workflow/run.sh
@@ -173,7 +173,7 @@ K3S_NODE_IMAGE="${K3S_NODE_REPO}/${K3S_NODE_IMAGE_NAME}:${REQUIRED_VERSION_NAME}
         make deps && \
         git add . && \
         git commit -m tmp && \
-        SKIP_AIRGAP=1 REPO="${K3S_NODE_REPO}" IMAGE_NAME="${K3S_NODE_IMAGE_NAME}" TAG="${REQUIRED_VERSION_NAME}" SKIP_VALIDATE=1 make local-image
+        REPO="${K3S_NODE_REPO}" IMAGE_NAME="${K3S_NODE_IMAGE_NAME}" TAG="${REQUIRED_VERSION_NAME}" make image
 )
 
 #1

--- a/script/k3s/run-k3s.sh
+++ b/script/k3s/run-k3s.sh
@@ -73,7 +73,7 @@ K3S_NODE_IMAGE="${K3S_NODE_REPO}/${K3S_NODE_IMAGE_NAME}:${REQUIRED_VERSION_NAME}
         make deps && \
         git add . && \
         git commit -m tmp && \
-        SKIP_AIRGAP=1 REPO="${K3S_NODE_REPO}" IMAGE_NAME="${K3S_NODE_IMAGE_NAME}" TAG="${REQUIRED_VERSION_NAME}" SKIP_VALIDATE=1 make local-image
+        REPO="${K3S_NODE_REPO}" IMAGE_NAME="${K3S_NODE_IMAGE_NAME}" TAG="${REQUIRED_VERSION_NAME}" make image
 )
 
 cat <<EOF > "${TMP_BUILTIN_CONF}"


### PR DESCRIPTION
k3s removed its local-* Makefile targets in k3s-io/k3s#14204, so `make local-image` no longer exists on main and both k3s jobs fail with "No rule to make target 'local-image'".

Drop SKIP_AIRGAP and SKIP_VALIDATE along with it. `image` only runs `binary` and scripts/package-image, neither of which reads them; validation is a separate Dockerfile stage now.