### PR TITLE
Reset instead of dropping registry traffic in integration tests

### DIFF
--- a/script/integration/containerd/entrypoint.sh
+++ b/script/integration/containerd/entrypoint.sh
@@ -372,19 +372,19 @@ REGISTRY_HOST_IP=$(getent hosts "${REGISTRY_HOST}" | awk '{ print $1 }')
 REGISTRY_ALT_HOST_IP=$(getent hosts "${REGISTRY_ALT_HOST}" | awk '{ print $1 }')
 
 echo "Disabling source registry and check if mirroring is working for stargz snapshotter..."
-iptables -A OUTPUT -d "${REGISTRY_HOST_IP}" -j DROP
+iptables -A OUTPUT -p tcp -d "${REGISTRY_HOST_IP}" -j REJECT --reject-with tcp-reset
 iptables -L
 copy_out_dir "${REGISTRY_HOST}/alpine:esgz" "/usr" "${USR_MIRROR}" "stargz"
-iptables -D OUTPUT -d "${REGISTRY_HOST_IP}" -j DROP
+iptables -D OUTPUT -p tcp -d "${REGISTRY_HOST_IP}" -j REJECT --reject-with tcp-reset
 
 echo "Disabling mirror registry and check if refreshing works for stargz snapshotter..."
-iptables -A OUTPUT -d "${REGISTRY_ALT_HOST_IP}" -j DROP
+iptables -A OUTPUT -p tcp -d "${REGISTRY_ALT_HOST_IP}" -j REJECT --reject-with tcp-reset
 iptables -L
 copy_out_dir "${REGISTRY_HOST}/alpine:esgz" "/usr" "${USR_REFRESH}" "stargz"
-iptables -D OUTPUT -d "${REGISTRY_ALT_HOST_IP}" -j DROP
+iptables -D OUTPUT -p tcp -d "${REGISTRY_ALT_HOST_IP}" -j REJECT --reject-with tcp-reset
 
 echo "Disabling all registries and running container should fail"
-iptables -A OUTPUT -d "${REGISTRY_HOST_IP}","${REGISTRY_ALT_HOST_IP}" -j DROP
+iptables -A OUTPUT -p tcp -d "${REGISTRY_HOST_IP}","${REGISTRY_ALT_HOST_IP}" -j REJECT --reject-with tcp-reset
 iptables -L
 if ctr-remote run --rm --snapshotter=stargz "${REGISTRY_HOST}/alpine:esgz" test tar -c /usr > /usr_dummy_fail.tar ; then
     echo "All registries are disabled so this must be failed"
@@ -392,7 +392,7 @@ if ctr-remote run --rm --snapshotter=stargz "${REGISTRY_HOST}/alpine:esgz" test 
 else
     echo "Failed to run the container as expected"
 fi
-iptables -D OUTPUT -d "${REGISTRY_HOST_IP}","${REGISTRY_ALT_HOST_IP}" -j DROP
+iptables -D OUTPUT -p tcp -d "${REGISTRY_HOST_IP}","${REGISTRY_ALT_HOST_IP}" -j REJECT --reject-with tcp-reset
 
 echo "Diffing root filesystems for mirroring"
 diff --no-dereference -qr "${USR_ORG}/" "${USR_MIRROR}/"


### PR DESCRIPTION
The integration test blocks registries with `iptables -j DROP`. That black-holes connections that are already established, so the client gets neither RST nor ICMP and waits out the kernel's TCP retransmission limit.

The builtin snapshotter has no request timeout to cut that short: `service/resolver/registry.go` sets `HTTPClient.Timeout` (30s by default), but `service/resolver/cri.go` leaves it unset, and `fs/remote/resolver.go` only applies a deadline when the timeout is non-zero. So the blocked phases cost minutes each.

That makes `Integration (--build-arg=CONTAINERD_VERSION=main, true, memory, ...)` take ~52m while every other job in `Tests` finishes in 9-13m, so it alone sets the workflow's wall clock. Most recently [53m on main](https://github.com/containerd/stargz-snapshotter/actions/runs/27085443933/job/79938914324).

This is long-standing rather than a recent change in GitHub Actions. The [oldest run GitHub still retains](https://github.com/containerd/stargz-snapshotter/actions/runs/15795359162/job/44526677651) (2025-06-21) already took 52m, back when the matrix had only four Integration variants, and every run sampled between then and now took 52-53m. A cost dominated by kernel retransmission timers would not track runner hardware anyway.

Plain `REJECT` does not help, because it answers with ICMP unreachable, which is a soft error for an established connection. Tried locally: the refresh phase still hung for 9+ minutes with the socket in `ESTABLISHED` and the zero-window probe count climbing, exactly as under `DROP`.

`--reject-with tcp-reset` sends RST, so the client fails immediately. Locally the three blocked phases take 8s in total, and the job [finishes in 6m](https://github.com/containerd/stargz-snapshotter/actions/runs/31078454193/job/92541546328) here, in line with the other Integration jobs.

Mirroring, refreshing and the all-registries-down case are all still exercised, and a registry that answers with RST is a closer model of one being down than a silent black hole is.

The missing timeout on the CRI path looks unintentional, but it is a separate change.
