### PR TITLE
fs: add ns query parameter to mirror requests per OCI distribution spec

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -34,6 +34,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"path"
 	"strconv"
 	"strings"
@@ -247,6 +248,11 @@ func newHTTPFetcher(ctx context.Context, fc *fetcherConfig) (*httpFetcher, int64
 			path.Join(host.Host, host.Path),
 			strings.TrimPrefix(fc.refspec.Locator, fc.refspec.Hostname()+"/"),
 			digest)
+		if isProxy(host, fc.refspec.Hostname()) {
+			// Qualify requests to mirror hosts with the upstream registry
+			// namespace, following the same convention as containerd.
+			blobURL += "?ns=" + url.QueryEscape(fc.refspec.Hostname())
+		}
 		url, header, err := redirect(ctx, blobURL, tr, timeout, host.Header)
 		if err != nil {
 			rErr = fmt.Errorf("failed to redirect (host %q, ref:%q, digest:%q): %v: %w", host.Host, fc.refspec, digest, err, rErr)
@@ -276,6 +282,22 @@ func newHTTPFetcher(ctx context.Context, fc *fetcherConfig) (*httpFetcher, int64
 	}
 
 	return nil, 0, fmt.Errorf("cannot resolve layer: %w", rErr)
+}
+
+// isProxy returns true when the host serves contents of other registries
+// (i.e. the host is configured as a mirror), following the same rule as
+// containerd's resolver. registry-1.docker.io is the canonical host of
+// "docker.io" references so it isn't a proxy for them.
+//
+// Ported from containerd's unexported RegistryHost.isProxy:
+// https://github.com/containerd/containerd/blob/77c84241c7cbdd9b4eca2591793e3d4f4317c590/core/remotes/docker/registry.go#L85-L92
+func isProxy(host docker.RegistryHost, refHost string) bool {
+	if refHost != host.Host {
+		if refHost != "docker.io" || host.Host != "registry-1.docker.io" {
+			return true
+		}
+	}
+	return false
 }
 
 type transport struct {

--- a/fs/remote/resolver_test.go
+++ b/fs/remote/resolver_test.go
@@ -294,6 +294,74 @@ func TestMirror(t *testing.T) {
 	}
 }
 
+// TestNamespaceQuery tests that requests to mirror hosts are qualified with
+// the "ns" query parameter pointing to the upstream registry, following the
+// same convention as containerd, and that requests to the upstream registry
+// itself aren't.
+func TestNamespaceQuery(t *testing.T) {
+	tests := []struct {
+		name   string
+		ref    string
+		mirror string
+		wantNS string
+	}{
+		{
+			name:   "mirror",
+			ref:    "dummyexample.com/library/test",
+			mirror: "mirrorexample.com",
+			wantNS: "dummyexample.com",
+		},
+		{
+			name: "no-mirror",
+			ref:  "dummyexample.com/library/test",
+		},
+		{
+			name:   "docker-mirror",
+			ref:    "docker.io/library/test",
+			mirror: "mirrorexample.com",
+			wantNS: "docker.io",
+		},
+		{
+			name:   "docker-canonical-host",
+			ref:    "docker.io/library/test",
+			mirror: "registry-1.docker.io",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refspec, err := reference.Parse(tt.ref)
+			if err != nil {
+				t.Fatalf("failed to prepare dummy reference: %v", err)
+			}
+			wantHost := refspec.Hostname()
+			tr := &sampleRoundTripper{okURLs: []string{regexp.QuoteMeta(wantHost)}}
+			var mirrors []hostFactory
+			if tt.mirror != "" {
+				wantHost = tt.mirror
+				tr.okURLs = []string{regexp.QuoteMeta(tt.mirror)}
+				mirrors = append(mirrors, hostSimple(tt.mirror))
+			}
+			fetcher, _, err := newHTTPFetcher(context.Background(), &fetcherConfig{
+				hosts:   hostsConfig(tr, mirrors...)(t),
+				refspec: refspec,
+				desc:    ocispec.Descriptor{Digest: digest.FromString("dummy")},
+			})
+			if err != nil {
+				t.Fatalf("failed to resolve reference: %v", err)
+			}
+			checkFetcherURL(t, fetcher, wantHost)
+			nurl, err := url.Parse(fetcher.url)
+			if err != nil {
+				t.Fatalf("failed to parse url %q: %v", fetcher.url, err)
+			}
+			if gotNS := nurl.Query().Get("ns"); gotNS != tt.wantNS {
+				t.Errorf("invalid ns query parameter %q(%q); want %q", gotNS, nurl.String(), tt.wantNS)
+			}
+		})
+	}
+}
+
 func checkFetcherURL(t *testing.T, f *httpFetcher, wantHost string) {
 	nurl, err := url.Parse(f.url)
 	if err != nil {


### PR DESCRIPTION
The `ns` query parameter on pull requests to a mirror identifies the upstream registry the request is for. It is part of the OCI distribution spec ([Registry Proxying](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#registry-proxying)), and containerd adds it to every request it sends to a mirror per its [registry host namespace convention](https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-host-namespace). The stargz snapshotter doesn't send it when fetching layer chunks, so mirrors that depend on it can't serve us. Spegel for example rejects requests without `ns`, making it unusable as a mirror with this snapshotter (spegel-org/spegel#510, and see [this comment](https://github.com/spegel-org/spegel/pull/1387#issuecomment-4711974654) suggesting the fix belongs here).

Append `ns=<refspec.Hostname()>` to the blob URL when the host is a mirror, like containerd does. The check is copied from containerd's unexported [`RegistryHost.isProxy`](https://github.com/containerd/containerd/blob/v2.2.3/core/remotes/docker/registry.go#L85-L92), including the special case for `registry-1.docker.io`.

Requests to the ref's own registry are unchanged. Note that chunk cache keys are derived from the blob URL, so mirror users will refetch cached chunks once after upgrading.
