### PR TITLE
fs/metrics: count failed blob reads by errno

### DIFF
--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -18,7 +18,9 @@ package commonmetrics
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/containerd/log"
@@ -38,6 +40,9 @@ const (
 
 	// BytesServedKey is the key for any metric related to counting bytes served as the part of specific operation.
 	BytesServedKey = "bytes_served"
+
+	// BlobFetchErrorsKey is the key for the count of failed blob reads.
+	BlobFetchErrorsKey = "blob_fetch_errors_total"
 
 	// Keep namespace as stargz and subsystem as fs.
 	namespace = "stargz"
@@ -126,7 +131,43 @@ var (
 		},
 		[]string{"operation_type", "layer"},
 	)
+
+	// blobFetchErrors counts blob reads that failed, broken down by the
+	// errno the failure carried. The label is drawn from a fixed set so
+	// that a storm of failures cannot blow up metric cardinality.
+	blobFetchErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      BlobFetchErrorsKey,
+			Help:      "The number of failed blob reads. Broken down by the errno the failure carried.",
+		},
+		[]string{"errno"},
+	)
 )
+
+// errnoNames is the set of errnos reported under their own label value.
+// Anything else is reported as "other", and an error carrying no errno at all
+// as "none".
+var errnoNames = map[syscall.Errno]string{
+	syscall.EACCES:       "EACCES",
+	syscall.EAGAIN:       "EAGAIN",
+	syscall.EBADF:        "EBADF",
+	syscall.ECONNREFUSED: "ECONNREFUSED",
+	syscall.ECONNRESET:   "ECONNRESET",
+	syscall.EDQUOT:       "EDQUOT",
+	syscall.EHOSTUNREACH: "EHOSTUNREACH",
+	syscall.EIO:          "EIO",
+	syscall.EMFILE:       "EMFILE",
+	syscall.ENETUNREACH:  "ENETUNREACH",
+	syscall.ENFILE:       "ENFILE",
+	syscall.ENOENT:       "ENOENT",
+	syscall.ENOSPC:       "ENOSPC",
+	syscall.EPIPE:        "EPIPE",
+	syscall.EROFS:        "EROFS",
+	syscall.ESTALE:       "ESTALE",
+	syscall.ETIMEDOUT:    "ETIMEDOUT",
+}
 
 var register sync.Once
 var logLevel = log.DebugLevel
@@ -153,6 +194,7 @@ func Register(l log.Level) {
 		prometheus.MustRegister(operationLatencyMicroseconds)
 		prometheus.MustRegister(operationCount)
 		prometheus.MustRegister(bytesCount)
+		prometheus.MustRegister(blobFetchErrors)
 	})
 }
 
@@ -182,6 +224,27 @@ func IncOperationCount(operation string, layer digest.Digest) {
 // AddBytesCount wraps the labels attachment as well as calling Add into a single method.
 func AddBytesCount(operation string, layer digest.Digest, bytes int64) {
 	bytesCount.WithLabelValues(operation, layer.String()).Add(float64(bytes))
+}
+
+// IncBlobFetchError records a failed blob read. Calling it before Register is
+// harmless; the counter simply is not exported yet.
+func IncBlobFetchError(err error) {
+	if err == nil {
+		return
+	}
+	blobFetchErrors.WithLabelValues(ErrnoLabel(err)).Inc()
+}
+
+// ErrnoLabel returns the errno label value used for the given error.
+func ErrnoLabel(err error) string {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return "none"
+	}
+	if name, ok := errnoNames[errno]; ok {
+		return name
+	}
+	return "other"
 }
 
 // WriteLatencyLogValue wraps writing the log info record for latency in milliseconds. The log record breaks down by operation and layer digest.

--- a/fs/metrics/common/metrics_test.go
+++ b/fs/metrics/common/metrics_test.go
@@ -1,0 +1,105 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commonmetrics
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestErrnoLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "a full cache volume is reported as such",
+			err:  fmt.Errorf("failed to commit cache: %w", syscall.ENOSPC),
+			want: "ENOSPC",
+		},
+		{
+			name: "an unwrapped errno",
+			err:  syscall.EIO,
+			want: "EIO",
+		},
+		{
+			name: "an errno outside the reported set stays low cardinality",
+			err:  syscall.Errno(0x7fff),
+			want: "other",
+		},
+		{
+			name: "an error carrying no errno",
+			err:  fmt.Errorf("unexpected status code 503"),
+			want: "none",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ErrnoLabel(tt.err); got != tt.want {
+				t.Errorf("got %q; want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIncBlobFetchError(t *testing.T) {
+	// A collector may be registered with more than one registry, so this
+	// gathers from a private one rather than the default.
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(blobFetchErrors); err != nil {
+		t.Fatalf("failed to register: %v", err)
+	}
+
+	IncBlobFetchError(nil) // must not be counted
+	IncBlobFetchError(fmt.Errorf("writing to cache: %w", syscall.ENOSPC))
+	IncBlobFetchError(syscall.ENOSPC)
+	IncBlobFetchError(fmt.Errorf("unexpected status code 503"))
+
+	want := map[string]float64{"ENOSPC": 2, "none": 1}
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather: %v", err)
+	}
+	got := map[string]float64{}
+	for _, f := range families {
+		if f.GetName() != "stargz_fs_blob_fetch_errors_total" {
+			t.Errorf("unexpected metric %q", f.GetName())
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			labels := m.GetLabel()
+			if len(labels) != 1 || labels[0].GetName() != "errno" {
+				t.Fatalf("got labels %v; want a single errno label", labels)
+			}
+			got[labels[0].GetValue()] = m.GetCounter().GetValue()
+		}
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %v; want %v", got, want)
+	}
+	for errno, n := range want {
+		if got[errno] != n {
+			t.Errorf("errno=%s: got %v; want %v", errno, got[errno], n)
+		}
+	}
+}

--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/containerd/containerd/v2/pkg/reference"
 	"github.com/containerd/stargz-snapshotter/cache"
+	commonmetrics "github.com/containerd/stargz-snapshotter/fs/metrics/common"
 	"github.com/containerd/stargz-snapshotter/fs/source"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
@@ -262,11 +263,13 @@ func (b *blob) ReadAt(p []byte, offset int64, opts ...Option) (int, error) {
 	fr := b.getFetcher()
 
 	if err := b.prepareChunksForRead(allRegion, offset, p, fr, allData, &readAtOpts); err != nil {
+		commonmetrics.IncBlobFetchError(err)
 		return 0, err
 	}
 
 	// Read required data
 	if err := b.fetchRange(allData, &readAtOpts); err != nil {
+		commonmetrics.IncBlobFetchError(err)
 		return 0, err
 	}
 


### PR DESCRIPTION
### Motivation

When a blob read fails on the data path, the failure surfaces only as an error returned up the FUSE stack. Nothing watching the snapshotter can tell one cause from another: a cache volume that has filled up and is failing writes with `ENOSPC` looks exactly like a registry refusing requests, and neither is visible at all unless someone is reading logs at the time.

### What this adds

A counter over the two error paths of `blob.ReadAt`:

```
stargz_fs_blob_fetch_errors_total{errno}
```

The label carries the errno the failure arrived with, extracted with `errors.As` so that it survives wrapping. It is drawn from a fixed set of 17 errnos; anything outside that set is reported as `other`, and an error carrying no errno as `none`, so a storm of failures cannot blow up metric cardinality.

The counter is registered alongside the existing filesystem metrics, so it follows the same `no_prometheus` setting and needs no new configuration. Incrementing it before registration is harmless, and it only happens on a path that is already returning an error, so there is no cost on a healthy read.

No new dependencies.

### How this was verified

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test -race ./fs/... ./cache/...` passes.
- New unit tests cover the errno mapping (wrapped errno, bare errno, an errno outside the reported set, an error with no errno) and the counter itself, including the exported metric name and label.
